### PR TITLE
Fix a leaking space.

### DIFF
--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -709,7 +709,7 @@
                 \let\pgfmathresult=\pgfutil@empty
             \else
                 % xb := rb / bb (the modified rb and modified bb!)
-                \edef\pgf@marshal{
+                \edef\pgf@marshal{%
                     \noexpand\pgfmathfloatdivide@
                         {\csname r\Pb\endcsname}
                         {\csname m\Pb b\endcsname}%


### PR DESCRIPTION
This is the ultimate cause of leaking spaces in Forest, see [Easy border for tikz and forest](https://tex.stackexchange.com/q/501270/16819) on TeX.SE
