### PR TITLE
Fix typo 'arrow.meta' -> 'arrows.meta'

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
@@ -1681,7 +1681,7 @@ done using the following handler:
 
     By default, |>| is a shorthand for |To| and |To| is a shorthand for |to|
     (an arrow from the old libraries) when |arrows.meta| is not loaded library.
-    When |arrow.meta| is loaded, |To| is redefined to mean the same as
+    When |arrows.meta| is loaded, |To| is redefined to mean the same as
     |Computer Modern Rightarrow|.
 \end{handler}
 
@@ -2115,7 +2115,7 @@ classified in different groups:
     like \texttt{\string\rightarrow} ($\to$) of the Computer Modern math fonts.
     However, it is not a ``perfect'' match: the line caps and joins of the
     ``real'' $\to$ are rounded differently from this arrow tip; but it takes a
-    keen eye to notice the difference. When the |arrow.meta| library is loaded,
+    keen eye to notice the difference. When the |arrows.meta| library is loaded,
     this arrow tip becomes the default of |To| and, thus, is used whenever |>|
     is used (unless, of course, you redefined |>|).
 }%
@@ -2161,7 +2161,7 @@ classified in different groups:
 \end{arrowtipsimple}
 
 \begin{arrowtipsimple}{To}
-    This is a shorthand for  |Computer Modern Rightarrow| when the |arrow.meta|
+    This is a shorthand for  |Computer Modern Rightarrow| when the |arrows.meta|
     library is loaded. Otherwise, it is a shorthand for the classical
     \tikzname\ rightarrow.
 \end{arrowtipsimple}


### PR DESCRIPTION
Fix typo in the name of the 'arrows.meta' library.