### PR TITLE
Support pattern objects with dvipdfmx

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
@@ -377,7 +377,7 @@
 
 % hook for xdvipdfmx:
 \def\pgfsys@dvipdfmx@patternobj#1{%
-    #1%
+    \pgfutil@insertatbegincurrentpagefrombox{#1}%
 }%
 
 % hook for xdvipdfmx:


### PR DESCRIPTION
`pgfsys-dvipdfmx.def` seems not to support `patterns` library fully. Patterns are sometimes lost with the following error:

```
dvipdfmx:warning: Object @pgfpatternobject3 used, but not defined. Replaced by null.
```

# Test code

```tex
%#!latex + dvipdfmx
\documentclass[dvipdfmx]{article}
\usepackage{tikz}
\usetikzlibrary{patterns}

\def\test{\tikz\filldraw[pattern=north east lines] (0,0) ellipse (2 and 1);}

\begin{document}
%%% Uncomment only one of the following choices.
%[1] \test %%% works correctly
[2] \setbox0\hbox{\test}\test %%% FAILS: patterns are lost
%[3] $\mathchoice{\test}{\test}{}{}$ %%% FAILS: patterns are lost
%[4] \test\setbox0\hbox{\test}\test %%% works correctly
%[5] \test$\mathchoice{\test}{\test}{}{}$ %%% works correctly
\end{document}
```

# Result

When you uncomment [2] or [3] and compile it with LaTeX (DVI mode) + dvipdfmx, you will get an unfilled ellipse like this:
 
![image](https://user-images.githubusercontent.com/6186180/67647661-6952c500-f976-11e9-82f8-024ad4a05f58.png)

# Solution

This problem does not occur when compiled with XeTeX (xdvipdfmx). So I tried replacing the definition of `\pgfsys@dvipdfmx@patternobj` in `pgfsys-dvipdfmx.def` with the one in `pgfsys-xetex.def`. This workaround seems to work well.
