### PR TITLE
Removing tab visible in documentation

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-animations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-animations.tex
@@ -544,8 +544,8 @@ Let us start with creating a snapshot:
     snapshots:
     %
     \begin{itemize}
-        \item The |begin| and |begin on| keys have no effect (but |begin
-            snapshot| has one.
+        \item The |begin| and |begin on| keys have no effect (but 
+            |begin snapshot| has one.
         \item The |end| and |end on| keys have no effect.
         \item The |current value| may not be used in a timeline (since
             \pgfname\ cannot really determine this value).
@@ -880,8 +880,8 @@ You can animate the appearance of a path in the following ways:
     path consists of appropriate Bézier curves.
 
     Unlike the dash pattern, the to-be-animated object is, indeed, the path
-    itself and not some special scope. This means that you can use the |current
-    value| for the start path. However, this also means that you really must
+    itself and not some special scope. This means that you can use the 
+    |current value| for the start path. However, this also means that you really must
     pick \emph{the path object} as the target of the animation. In conjunction
     with \tikzname, this will be an object of type |path| as in the above
     example.

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-decorations.tex
@@ -333,8 +333,8 @@ command describes the decoration automaton.
         \begin{key}{/pgf/decoration automaton/width=\meta{dimension}}
             First, this option causes an immediate switch to the state |final|
             if the remaining distance on the input path is less than
-            \meta{dimension}. The effect is the same as if you had said |switch
-            if less than=|\meta{dimension}| to final| just before the |width|
+            \meta{dimension}. The effect is the same as if you had said 
+            |switch if less than=|\meta{dimension}| to final| just before the |width|
             option.
 
             If no switch occurs, this option tells \pgfname\ the width of the

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-external.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-external.tex
@@ -257,8 +257,8 @@ there is a better way: You input the file |pgfexternal.tex|.
     Since |\beginpgfgraphicnamed| does not do macro expansion as it searches
     for |\endpgfgraphicnamed|, it is not necessary to actually include the
     packages necessary for \emph{creating} the graphics. So the idea is that
-    you comment out things like |\usepackage{tikz}| and instead say |\input
-    pgfexternal.tex|.
+    you comment out things like |\usepackage{tikz}| and instead say 
+    |\input pgfexternal.tex|.
 
     Indeed, the contents of this file is simply the following line:
     %

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-matrices.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-matrices.tex
@@ -235,8 +235,8 @@ spacing.
             processed, in this order. If the \meta{additional sep list}
             argument is missing, only the default separation list is processed.
         \item Both lists may contain dimensions, separated by commas, as well
-            as occurrences of the keywords |between origins| and |between
-            borders|.
+            as occurrences of the keywords |between origins| and 
+            |between borders|.
         \item All dimensions occurring in either list are added together to
             arrive at a dimension $d$.
         \item The last occurrence of either of the keywords is located. If

--- a/doc/generic/pgf/text-en/pgfmanual-en-drivers.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-drivers.tex
@@ -399,8 +399,8 @@ dvisvgm example
 
     \begin{key}{/pgf/tex4ht node/css=\meta{filename} (default |\string\jobname|)}
         This option allows you to tell the browser what \textsc{css} file it
-        should  use to style the display of the node (only with |tex4ht
-        node/escape=true|).
+        should  use to style the display of the node (only with 
+        |tex4ht node/escape=true|).
     \end{key}
 
     \begin{key}{/pgf/tex4ht node/class=\meta{class name} (default foreignobject)}

--- a/doc/generic/pgf/text-en/pgfmanual-en-math-numberprinting.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-math-numberprinting.tex
@@ -290,8 +290,8 @@ precision.
     |fixed relative| ``rounds from the left'': it takes the \emph{first}
     non-zero digit, temporarily places the period after this digit, and rounds
     that number. The rounding style |fixed| leaves the period where it is, and
-    rounds everything behind that digit. The |sci| style is similar to |fixed
-    relative|.
+    rounds everything behind that digit. The |sci| style is similar to 
+    |fixed relative|.
 \end{keylist}
 
 \begin{key}{/pgf/number format/int detect}

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-scopes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-scopes.tex
@@ -106,8 +106,8 @@ are local to the |{tikzpicture}| to which they apply.
     approximation of the bounding box, but will not always be accurate. First,
     the line thickness of diagonal lines is not taken into account correctly.
     Second, control points of a curve often lie far ``outside'' the curve and
-    make the bounding box too large. In this case, you should use the |[use as
-    bounding box]| option.
+    make the bounding box too large. In this case, you should use the 
+    |[use as bounding box]| option.
 
     The following key influences the baseline of the resulting picture:
     %


### PR DESCRIPTION
The tab from the code indention within the verbatim `|[use as bounding box]|` was visible in the output. Moving the line break a bit solves the problem

![Screen Shot 2019-11-12 at 22 09 33](https://user-images.githubusercontent.com/43832342/68750149-b6ce6380-05ff-11ea-9849-b28419e2af23.png)
