### PR TITLE
missing markup around |to| to distinguish it from the word "to"

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
@@ -918,8 +918,8 @@ path to be used instead of the straight line.
     To do so, you specify the nodes between the |to| keyword and the coordinate
     (if there are options to the |to| operation, these come first). The effect
     of |(a) to node {x} (b)| (typically) is the same as if you had written
-    |(a) -- node {x} (b)|, namely that the node is placed on the to. This can
-    be used to add labels to tos:
+    |(a) -- node {x} (b)|, namely that the node is placed on the |to|. This can
+    be used to add labels to |to|s:
     %
 \begin{codeexample}[]
 \begin{tikzpicture}


### PR DESCRIPTION
Maybe it would make sense to write |to| instead of to?

I read the paragraph a couple of times and without this differentiation I found it very confusing to understand which tos are code and which are part of the sentance. 