### PR TITLE
docu: simplified markup

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-scopes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-scopes.tex
@@ -333,7 +333,7 @@ Rectangles \begin{pgfpicture}
     impossible to draw lines between nodes in different pictures automatically.
 
     In order to make \pgfname\ ``remember'' a picture, the \TeX-if
-    |\||ifpgfrememberpicturepositiononpage| should be set to |true|. It is only
+    |\ifpgfrememberpicturepositiononpage| should be set to |true|. It is only
     important that this \TeX-if is |true| at the end of the
     |{pgfpicture}|-en\-vi\-ron\-ment, so you can switch it on inside the
     environment. However, you can also just switch it on globally, then the

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -1592,7 +1592,7 @@ Key 4:& \pgfkeys{/key4}
     will ``try'' to use the key, but no further action is taken when the key is
     not defined.
 
-    The \TeX-if |\||ifpgfkeyssuccess| will be set according to whether the
+    The \TeX-if |\ifpgfkeyssuccess| will be set according to whether the
     \meta{key} was successfully executed or not.
     %
 \begin{codeexample}[]
@@ -1605,7 +1605,7 @@ Key 4:& \pgfkeys{/key4}
 
 \begin{handler}{{.retry}|=|\meta{value}}
     This handler works just like |/.try|, only it will not do anything if
-    |\||ifpgfkeyssuccess| is false. Thus, this handler will only retry to set a
+    |\ifpgfkeyssuccess| is false. Thus, this handler will only retry to set a
     key if ``the last attempt failed''.
     %
 \begin{codeexample}[]
@@ -1618,7 +1618,7 @@ Key 4:& \pgfkeys{/key4}
 
 \begin{handler}{{.lastretry}|=|\meta{value}}
     This handler works like |/.retry|, only it will invoke the usual handlers
-    for unknowns keys if |\||ifpgfkeyssuccess| is false. Thus, this handler
+    for unknowns keys if |\ifpgfkeyssuccess| is false. Thus, this handler
     will only try to set a key if ``the last attempt failed''. Furthermore,
     this here is the last such attempt.
 \end{handler}


### PR DESCRIPTION
Is there any deeper reason for writing `|\||ifpgfrememberpicturepositiononpage|` instead of `|\ifpgfrememberpicturepositiononpage|`?

Simplifying the markup would also enable linking to the documentation of the macro.