### PR TITLE
typo

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
@@ -471,10 +471,10 @@ use another color.
 \end{tikzpicture}
 \end{codeexample}
 
- In this example, the definition of the style |Karl's grid| is given as an 
+ In this example, the definition of the style |Karl's grid| is given as an
  optional argument to the |{tikzpicture}| environment. Additional styles for other
  elements would follow after a comma. With many styles in effect, the optional
- argument of the environment may easily happen to be longer than the actual 
+ argument of the environment may easily happen to be longer than the actual
  contents.
 
 \subsection{Drawing Options}
@@ -1046,7 +1046,7 @@ All of these can be used together with \tikzname, so if you are familiar with
 them, feel free to use them. \tikzname\ introduces yet another command, called
 |\foreach|, which I introduced since I could never remember the syntax of the
 other packages. |\foreach| is defined in the package |pgffor| and can be used
-independently \tikzname, but \tikzname\ includes it automatically.
+independently by \tikzname, but \tikzname\ includes it automatically.
 
 In its basic form, the |\foreach| command is easy to use:
 %


### PR DESCRIPTION
I think there was a "by" missing in the following sentence on pg.43 of the manual

    ...can be used independently by \tikzname, but...

Also, I usually delete trailing white spaces and got two lines with a space at the end.
I don't know if you have any style rule about that and apologize if you preferred to keep them :)