### PR TITLE
Fix some spacing issues in manual

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
@@ -681,7 +681,7 @@ with the most general and most useful of these libraries.
     The |mark| decoration option is used to specify a marking. It comes in two
     versions:
     %
-    \begin{key}{/pgf/decoration/mark=\texttt{at position} \meta{pos}| with |\meta{code}}
+    \begin{key}{/pgf/decoration/mark=\texttt{at position }\meta{pos}\texttt{ with }\meta{code}}
         The options specifies that when a |marking| decoration is applied,
         there should be a marking at position \meta{pos} on the path whose code
         is given by \meta{code}.
@@ -774,10 +774,7 @@ with the most general and most useful of these libraries.
 
     A second way to use the |mark| key is the following:
     %
-    \begin{key}{/pgf/decoration/mark=|between positions|
-            \meta{start pos} |and| \meta{end pos} |step|
-            \meta{stepping} |with| \meta{code}%
-    }
+    \begin{key}{/pgf/decoration/mark=\texttt{between positions}\meta{start pos}\texttt{ and }\meta{end pos}\texttt{ step }\meta{stepping}\texttt{ with }\meta{code}}
         This works similarly to the |at position| version of this option, only
         multiple marks are placed, starting at \meta{start pos} and then spaced
         apart by \meta{stepping}. The \meta{start pos}, the \meta{end pos}, and

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
@@ -774,7 +774,7 @@ with the most general and most useful of these libraries.
 
     A second way to use the |mark| key is the following:
     %
-    \begin{key}{/pgf/decoration/mark=\texttt{between positions}\meta{start pos}\texttt{ and }\meta{end pos}\texttt{ step }\meta{stepping}\texttt{ with }\meta{code}}
+    \begin{key}{/pgf/decoration/mark=\texttt{between positions }\meta{start pos}\texttt{ and }\meta{end pos}\texttt{ step }\meta{stepping}\texttt{ with }\meta{code}}
         This works similarly to the |at position| version of this option, only
         multiple marks are placed, starting at \meta{start pos} and then spaced
         apart by \meta{stepping}. The \meta{start pos}, the \meta{end pos}, and


### PR DESCRIPTION
In pages 647 and 648, the following two lines do not have good spacing between words, especially the latter one.

![image](https://user-images.githubusercontent.com/44609036/68964260-7cd1ad00-080b-11ea-905f-c40f040163aa.png)

![image](https://user-images.githubusercontent.com/44609036/68964278-86f3ab80-080b-11ea-9d8f-8bb8bb654400.png)

This will probably fix this.