### PR TITLE
issue #775 and #776

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-patterns.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-patterns.tex
@@ -26,9 +26,9 @@
     \pattern [path fading=west,pattern=checkerboard light gray]
       (0,0) rectangle (5cm,2em);
 
-    \pattern [pattern=#1,pattern color=black] (0,0) rectangle +(1.5cm,2em);
-    \pattern [pattern=#1,pattern color=blue] (1.75,0) rectangle +(1.5cm,2em);
-    \pattern [pattern=#1,pattern color=red] (3.5,0) rectangle +(1.5cm,2em);
+    \pattern [pattern=#1,pattern color=black] (0,0)    rectangle +(1.5cm,2em);
+    \pattern [pattern=#1,pattern color=blue]  (1.75,0) rectangle +(1.5cm,2em);
+    \pattern [pattern=#1,pattern color=red]   (3.5,0)  rectangle +(1.5cm,2em);
   \end{tikzpicture} \\[1ex]
 }
 
@@ -219,33 +219,32 @@ There are a couple of predefined \pgfname\ patterns which are similar
 to their normal counterparts.
 
 \begin{pattern}{Lines}
-    %
-    The |Lines| pattern replaces the |horizontal lines|,
-    |vertical lines|, |north east lines|, and |north west lines|
-    patterns.  Unfortunately, due to the way the old patterns are
-    constructed, namely that they are not simply related to each other by
-    rotation, the |Lines| pattern cannot be used a drop-in replacement.
+    The |Lines| pattern replaces the |horizontal lines|, |vertical lines|,
+    |north east lines|, and |north west lines| patterns. Unfortunately, due to
+    the way the old patterns are constructed, namely that they are not simply
+    related to each other by rotation, the |Lines| pattern cannot be used as a
+    drop-in replacement.
 
-    However, the pattern options can be tuned to resemble the other
-    versions closely.  The available parameters are:
+    However, the pattern options can be tuned to resemble the other versions
+    closely. The available parameters are:
     %
     \begin{key}{/pgf/pattern keys/distance (initially 3pt)}
         Distance between lines.
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/angle (initially 0)}
-        By default the lines are horizontal.  The whole pattern is
-        rotated by this angle.  The rotation angle is measured in the
-        mathematically positive sense.
+        By default the lines are horizontal. The whole pattern is rotated by
+        this angle. The rotation angle is measured in the mathematically
+        positive sense.
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/xshift (initially 0pt)}
-        Shifts the whole pattern in $x$ direction (before applying the
+        Shifts the whole pattern in $x$-direction (before applying the
         rotation).
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/yshift (initially 0pt)}
-        Shifts the whole pattern in $y$ direction (before applying the
+        Shifts the whole pattern in $y$-direction (before applying the
         rotation).
     \end{key}
     %
@@ -253,7 +252,7 @@ to their normal counterparts.
         Thickness of the lines.
     \end{key}
     %
-    The following settings can be used to reproduce the other |lines|
+    The following settings can be used to reproduce the other |... lines|
     patterns.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{patterns.meta}}]
@@ -283,7 +282,6 @@ to their normal counterparts.
 \end{pattern}
 
 \begin{pattern}{Hatch}
-    %
     The |Hatch| pattern replaces the |grid| and |crosshatch| patterns.
     The |Hatch| pattern without options is a drop-in replacement for the
     |grid| pattern.
@@ -293,18 +291,18 @@ to their normal counterparts.
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/angle (initially 0)}
-        By default the lines are horizontal and vertical.  The whole
-        pattern is rotated by this angle.  The rotation angle is
-        measured in the mathematically positive sense.
+        By default the lines are horizontal and vertical. The whole pattern is
+        rotated by this angle. The rotation angle is measured in the
+        mathematically positive sense.
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/xshift (initially 0pt)}
-        Shifts the whole pattern in $x$ direction (before applying the
+        Shifts the whole pattern in $x$-direction (before applying the
         rotation).
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/yshift (initially 0pt)}
-        Shifts the whole pattern in $y$ direction (before applying the
+        Shifts the whole pattern in $y$-direction (before applying the
         rotation).
     \end{key}
     %
@@ -332,28 +330,27 @@ to their normal counterparts.
 \end{pattern}
 
 \begin{pattern}{Dots}
-    %
-    The |Dots| pattern replaces the |dots| and |crosshatch dots|
-    patterns.  The |Dots| pattern without options is a drop-in replacement
-    for the |dots| pattern.
+    The |Dots| pattern replaces the |dots| and |crosshatch dots| patterns. The
+    |Dots| pattern without options is a drop-in replacement for the |dots|
+    pattern.
     %
     \begin{key}{/pgf/pattern keys/distance (initially 3pt)}
         Distance between dots.
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/angle (initially 0)}
-        By default the lines are arranged on a regular grid.  The
-        whole pattern is rotated by this angle.  The rotation angle is
-        measured in the mathematically positive sense.
+        By default the lines are arranged on a regular grid. The whole pattern
+        is rotated by this angle. The rotation angle is measured in the
+        mathematically positive sense.
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/xshift (initially 0pt)}
-        Shifts the whole pattern in $x$ direction (before applying the
+        Shifts the whole pattern in $x$-direction (before applying the
         rotation).
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/yshift (initially 0pt)}
-        Shifts the whole pattern in $y$ direction (before applying the
+        Shifts the whole pattern in $y$-direction (before applying the
         rotation).
     \end{key}
     %
@@ -381,29 +378,28 @@ to their normal counterparts.
 \end{pattern}
 
 \begin{pattern}{Stars}
-    %
-    The |Stars| pattern replaces the |fivepoints stars| and
-    |sixpointed stars| patterns.  However, the stars of the |Stars|
-    pattern are constructed in a fundamentally different fashion, so
-    it can't be used as a drop-in replacement.
+    The |Stars| pattern replaces the |fivepointed stars| and |sixpointed stars|
+    patterns. However, the stars of the |Stars| pattern are constructed in a
+    fundamentally different fashion, so it can't be used as a drop-in
+    replacement.
     %
     \begin{key}{/pgf/pattern keys/distance (initially 3mm)}
         Distance between stars.
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/angle (initially 0)}
-        By default the stars are arranged on a regular grid.  The
-        whole pattern is rotated by this angle.  The rotation angle is
-        measured in the mathematically positive sense.
+        By default the stars are arranged on a regular grid. The whole pattern
+        is rotated by this angle. The rotation angle is measured in the
+        mathematically positive sense.
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/xshift (initially 0pt)}
-        Shifts the whole pattern in $x$ direction (before applying the
+        Shifts the whole pattern in $x$-direction (before applying the
         rotation).
     \end{key}
     %
     \begin{key}{/pgf/pattern keys/yshift (initially 0pt)}
-        Shifts the whole pattern in $y$ direction (before applying the
+        Shifts the whole pattern in $y$-direction (before applying the
         rotation).
     \end{key}
     %
@@ -519,10 +515,10 @@ to their normal counterparts.
 }
 
 \begin{tikzpicture}
-  \draw[pattern=mystars,pattern color=blue]               (0,0) rectangle ++(2,2);
-  \draw[pattern={mystars[points=7,tile size=15pt]}]       (2,0) rectangle ++(2,2);
-  \draw[pattern={mystars[rotate=45]},pattern color=red]   (0,2) rectangle ++(2,2);
-  \draw[pattern={mystars[rotate=30,points=4,radius=5pt]}] (2,2) rectangle ++(2,2);
+ \draw[pattern=mystars,pattern color=blue]               (0,0) rectangle +(2,2);
+ \draw[pattern={mystars[points=7,tile size=15pt]}]       (2,0) rectangle +(2,2);
+ \draw[pattern={mystars[rotate=45]},pattern color=red]   (0,2) rectangle +(2,2);
+ \draw[pattern={mystars[rotate=30,points=4,radius=5pt]}] (2,2) rectangle +(2,2);
 \end{tikzpicture}
 \end{codeexample}
 
@@ -531,7 +527,7 @@ what you prefer.
 %
 \begin{codeexample}[preamble={\usetikzlibrary{patterns.meta}}]
 \tikzdeclarepattern{
-  name=lines,
+  name=mylines,
   parameters={
       \pgfkeysvalueof{/pgf/pattern keys/size},
       \pgfkeysvalueof{/pgf/pattern keys/angle},
@@ -556,13 +552,13 @@ what you prefer.
 }
 
 \begin{tikzpicture}
-  \draw[pattern={lines[size=10pt,line width=.8pt,angle=10]},
+  \draw[pattern={mylines[size=10pt,line width=.8pt,angle=10]},
         pattern color=red]    (0,0) rectangle ++(2,2);
-  \draw[pattern={lines[size= 5pt,line width=.8pt,angle=40]},
+  \draw[pattern={mylines[size= 5pt,line width=.8pt,angle=40]},
         pattern color=blue]   (2,0) rectangle ++(2,2);
-  \draw[pattern={lines[size=10pt,line width=.4pt,angle=90]},
+  \draw[pattern={mylines[size=10pt,line width=.4pt,angle=90]},
         pattern color=green]  (0,2) rectangle ++(2,2);
-  \draw[pattern={lines[size= 2pt,line width= 1pt,angle=70]},
+  \draw[pattern={mylines[size= 2pt,line width= 1pt,angle=70]},
         pattern color=orange] (2,2) rectangle ++(2,2);
 \end{tikzpicture}
 \end{codeexample}

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
@@ -1711,6 +1711,7 @@ done using the following handler:
     Shorten the path by \meta{length} in the direction of the end point.
 \end{key}
 
+
 \subsubsection{Scoping of Arrow Keys}
 \label{section-arrow-scopes}
 
@@ -2168,7 +2169,7 @@ classified in different groups:
 \end{arrowtipsimple}
 
 \begin{arrowtipsimple}{To}
-    This is a shorthand for  |Computer Modern Rightarrow| when the |arrows.meta|
+    This is a shorthand for |Computer Modern Rightarrow| when the |arrows.meta|
     library is loaded. Otherwise, it is a shorthand for the classical
     \tikzname\ rightarrow.
 \end{arrowtipsimple}


### PR DESCRIPTION
- corrected some spellings (missing word and `fivepoints` --> `fivepointed`)
- harmonized e.g. "$x$ direction" --> "$x$-direction" with the rest of the manual
- adjusted "mystars" example so it fits to the "blue code box"
- renamed `lines` to `mylines` in last `codeexample` to match the previous `mystars` example

- minor stuff