### PR TITLE
`arrows` library replaced by `arrows.meta`

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial-nodes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial-nodes.tex
@@ -141,7 +141,7 @@ When using \LaTeX\ use:
 \documentclass{article} % say
 
 \usepackage{tikz}
-\usetikzlibrary{arrows,decorations.pathmorphing,backgrounds,positioning,fit,petri}
+\usetikzlibrary{arrows.meta,decorations.pathmorphing,backgrounds,positioning,fit,petri}
 
 \begin{document}
 \begin{tikzpicture}
@@ -158,7 +158,7 @@ When using plain \TeX\ use:
 \begin{codeexample}[code only]
 %% Plain TeX file
 \input tikz.tex
-\usetikzlibrary{arrows,decorations.pathmorphing,backgrounds,positioning,fit,petri}
+\usetikzlibrary{arrows.meta,decorations.pathmorphing,backgrounds,positioning,fit,petri}
 \baselineskip=12pt
 \hsize=6.3truein
 \vsize=8.7truein
@@ -176,7 +176,7 @@ When using Con\TeX t, use:
 \begin{codeexample}[code only]
 %% ConTeXt file
 \usemodule[tikz]
-\usetikzlibrary[arrows,decorations.pathmorphing,backgrounds,positioning,fit,petri]
+\usetikzlibrary[arrows.meta,decorations.pathmorphing,backgrounds,positioning,fit,petri]
 
 \starttext
   \starttikzpicture


### PR DESCRIPTION
Since tutorial stated that `arrows` library is deprecated (chapter 16), I replaced all it appearance in tutorial code that I found in chapter "3 Tutorial: A Petri-Net for Hagen" by `arrows.meta`.