### PR TITLE
pgfmathparser.code.tex: add pdfTeX/LuaTeX/pTeX units

### DIFF
--- a/tex/generic/pgf/math/pgfmathparser.code.tex
+++ b/tex/generic/pgf/math/pgfmathparser.code.tex
@@ -235,6 +235,16 @@
   \pgfmath@tokens@make{dimexpr}{\dimexpr\glueexpr}
 \fi
 \pgfmath@tokens@make{unit}{{bp}{cc}{cm}{dd}{em}{ex}{in}{mm}{pc}{pt}{sp}}
+\ifx\pdftexversion\@undefined\else % for pdfTeX
+  \pgfmath@tokens@make{unit}{{nc}{nd}}
+\fi
+\ifx\directlua\@undefined\else % for LuaTeX
+  \pgfmath@tokens@make{unit}{{nc}{nd}}
+\fi
+\ifx\kanjiskip\@undefined\else % for pTeX, upTeX
+  \pgfmath@tokens@make{unit}{{H}{Q}{zh}{zw}}
+\fi
+%
 \pgfmath@tokens@make{mathunit}{{mu}}
 \pgfmath@tokens@make{numeric}{.0123456789}
 \pgfmath@tokens@make{number}{0123456789}
@@ -460,7 +470,10 @@
     \else%
       \expandafter\ifx\csname pgfmath@token@numeric@\expandafter\string\pgfmath@token\endcsname\relax%
         % It isn't numeric (i.e., 012345679.), so it might be units...
+        % first double-character units...
         \expandafter\ifx\csname pgfmath@token@unit@\pgfmath@token\expandafter\string\pgfmath@token@next\endcsname\relax%
+        % then single-character units...
+        \expandafter\ifx\csname pgfmath@token@unit@\pgfmath@token\endcsname\relax%
           % ...or the exponent characters...
           \expandafter\ifx\csname pgfmath@token@exponent@\pgfmath@token\endcsname\relax%
             % ...or a base prefix...
@@ -498,7 +511,14 @@
           \else% ... and here, it is the exponent characters.
             \let\pgfmath@parse@next=\pgfmath@parse@exponent%
           \fi%
-        \else% ...but here it is units.
+        \else% ...but here it is single-character units.
+          \global\pgfmathunitsdeclaredtrue%
+          \pgfmath@dimen=\pgfmath@number\pgfmath@token\relax%
+          \edef\pgfmathresult{\pgfmath@tonumber{\pgfmath@dimen}}%
+          \expandafter\pgfmath@stack@push@operand\expandafter{\pgfmathresult}%
+          \let\pgfmath@parse@next=\pgfmath@parse@@operator%
+        \fi%
+        \else% ...but here it is double-character units.
           \global\pgfmathunitsdeclaredtrue%
           \pgfmath@dimen=\pgfmath@number\pgfmath@token\pgfmath@token@next\relax%
           \edef\pgfmathresult{\pgfmath@tonumber{\pgfmath@dimen}}%


### PR DESCRIPTION
Attempt to add engine-specific dimension units.

* pdfTeX and LuaTeX: `nd` and `nc` are available.
* pTeX and upTeX: `zw`, `zh`, `Q` and `H` are available.