### PR TITLE
fix missing trailing "]" and italic opening brackets in doc

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-external.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-external.tex
@@ -305,7 +305,7 @@ is shown below). It is slightly longer, but it can be used in the same way as
     to manually provide the |viewport| option as shown above.
 
     A possible value for |viewport| can be found in the |.pdf| image, search
-    for |/MediaBox = [ ... ]|.
+    for |/MediaBox = ||[ ... ]|.
 \end{key}
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-gd-usage-pgf.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-gd-usage-pgf.tex
@@ -522,7 +522,7 @@ of layout keys inside a picture will only open sublayouts.
     layout scopes) and the \meta{end code} at the end of the same \TeX\ scope.
 
     The need for this slightly strange macro arises from the fact that in
-    \tikzname\ we often write things like |[spring layout,node sep=2cm]|. The
+    \tikzname\ we often write things like |[spring layout,node sep=2cm||]|. The
     point is that when the |spring layout| key is executed, we do \emph{not}
     wish to open a layout scope immediately. Rather, this should happen only
     after the option |nodes sep=2cm| has been executed. For this reason,

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-calendar.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-calendar.tex
@@ -44,7 +44,7 @@ say, the |\draw| command).
         \item |[|\meta{options}|]|
 
             You provide \meta{options} in square brackets as in
-            |[red,draw=none]|. These \meta{options} can be any \tikzname\
+            |[red,draw=none||]|. These \meta{options} can be any \tikzname\
             option and they apply to the whole calendar. You can provide this
             element multiple times, the effect accumulates.
         \item |(|\meta{name}|)|

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-chains.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-chains.tex
@@ -320,7 +320,7 @@ process.
     This command is just a shortcut for
     %
     \begin{quote}
-        |\path (|\meta{existing name}|) [late options={on chain,every chain in,|\meta{options}|}]|
+        |\path (|\meta{existing name}|) [late options=||{on chain,every chain in,|\meta{options}|}]|
     \end{quote}
     %
     In particular, it is possible to continue to path after a |\chainin|

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-circuits.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-circuits.tex
@@ -89,8 +89,8 @@ circuit can be configured in general ways and that the labels are placed
 automatically by default. Here is the graphic once more, generated from
 \emph{exactly the same source code}, with only the options of the
 |{tikzpicture}| environment replaced by
-|[rotate=-90,circuit ee IEC,x=3.25cm,y=2.25cm]|:
-%
+|[rotate=-90,circuit ee IEC,x=3.25cm,y=2.25cm||]|:
+
 \begin{tikzpicture}[rotate=-90,circuit ee IEC,x=3cm,y=2.25cm]
   % Let us start with some contacts:
   \foreach \contact/\y in {1/1,2/2,3/3.5,4/4.5,5/5.5}
@@ -147,7 +147,7 @@ whose shape is a symbol shape.
 
 \subsubsection{Symbol Graphics}
 
-Symbols can be created by |\node[shape=some symbol shape]|. However, in order
+Symbols can be created by |\node[shape=some symbol shape||]|. However, in order
 to represent some symbols correctly, just using standard \pgfname\ shapes is
 not sufficient. For instance, most symbols have a visually appealing ``default
 size'', but the size of a symbol shape depends only on the current values of

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex
@@ -221,7 +221,7 @@ such a file to environments where \pgfname\ is not available.
 \begin{key}{/tikz/external/shell escape=\marg{command-line arg} (initially -shell-escape)}
     Contains the command line option for |latex| which enables the |\write18|
     feature. For \TeX-Live, this is |-shell-escape|. For MiK\TeX, you should
-    use |\tikzexternalize[shell escape=-enable-write18]|.
+    use |\tikzexternalize[shell escape=-enable-write18||]|.
 \end{key}
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-spy.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-spy.tex
@@ -267,7 +267,7 @@ automatically.
             %
             \begin{key}{/tikz/magnification=\meta{number}}
                 This has the same effect as saying
-                |lens={scale=|\meta{number}|}|.
+                |lens=||{scale=|\meta{number}|}|.
             \end{key}
             %
             Now, usually the size of a node is determined in such a way that it

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgffor.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgffor.tex
@@ -298,7 +298,7 @@ This section describes the package |pgffor|, which is loaded automatically by
 
     \begin{key}{/pgf/foreach/var=\meta{variable}}
         This key provides an alternative way to specify variables:
-        |\foreach [var=\x,var=\y]| is the same as |\foreach \x/\y|. If used,
+        |\foreach [var=\x,var=\y||]| is the same as |\foreach \x/\y|. If used,
         this key should be used before the other keys.
     \end{key}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -115,7 +115,7 @@ require that no value \emph{may} be specified using |/.value forbidden|.
 
 All keys for a package like, say, \tikzname\ start with the path |/tikz|. We
 obviously do not like to write this path down every time we use a key (so we do
-not have to write things like |\draw[/tikz/line width=1cm]|). What we need is
+not have to write things like |\draw[/tikz/line width=1cm||]|). What we need is
 to somehow ``change the default path to a specific location''. This is done
 using the handler |/.cd| (for ``change directory''). Once this handler has been
 used on a key, all subsequent keys {\itshape in the current call of |\pgfkeys|

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-animations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-animations.tex
@@ -836,13 +836,13 @@ whose use is detected by the presence of a colon inside a key:
 \begin{quote}
   \normalfont
   \opt{\meta{object name(s)}}|:|\opt{\meta{attribute(s)}}
-  |={|\meta{options}|}|
+  |=||{|\meta{options}|}|
 
   or
 
   \opt{\meta{object
       name(s)}}|:|\opt{\meta{attribute(s)}}|_|\opt{\meta{id}}
-  |={|\meta{options}|}|
+  |=||{|\meta{options}|}|
 \end{quote}
 %
 In the place to the left of an equal sign, where you would normally use a key,
@@ -857,7 +857,7 @@ The effect of the above code is the same as:
 %
 \begin{quote}
   \normalfont
-  |sync = { object = |\meta{objects}|, attribute = |\meta{attribute}|, id = |\meta{id}|, |\meta{options}|, entry }|
+  |sync = ||{ object = |\meta{objects}|, attribute = |\meta{attribute}|, id = |\meta{id}|, |\meta{options}|, entry }|
 \end{quote}
 %
 although when the object, the attribute, or the id is left empty in the colon
@@ -960,13 +960,13 @@ allows you to use a special syntax with nodes and scopes:
         curly braces), you can write
         %
         \begin{quote}
-            |:some attribute = {|\meta{options}|}|
+            |:some attribute = ||{|\meta{options}|}|
         \end{quote}
         %
         and this will have the same effect as if you had written
         %
         \begin{quote}
-            |[animate = { myself: = { :some attribute = {|\meta{options}|}}}]|
+            |[animate = ||{ myself: = ||{ :some attribute = ||{|\meta{options}|}}}]|
         \end{quote}
         %
         Note that you can use this syntax repeatedly, but each use creates a
@@ -976,13 +976,13 @@ allows you to use a special syntax with nodes and scopes:
         |{tikzpicture}| and |{scope}|, when they are followed immediately by
         %
         \begin{quote}
-            |:some attribute = {|\meta{options}|}|
+            |:some attribute = ||{|\meta{options}|}|
         \end{quote}
         %
         then
         %
         \begin{quote}
-            |animate = { myself: = { :some attribute = {|\meta{options}|}}}|
+            |animate = ||{ myself: = ||{ :some attribute = ||{|\meta{options}|}}}|
         \end{quote}
         %
         is added to the options of the command or scope. Again, you can use the
@@ -1085,7 +1085,7 @@ following call:
 %
 \begin{quote}
     \normalfont
-    |sync = {time = |\meta{time}|, |\meta{options}|, entry}|
+    |sync = ||{time = |\meta{time}|, |\meta{options}|, entry}|
 \end{quote}
 
 
@@ -1108,7 +1108,7 @@ is executed:
 %
 \begin{quote}
     \normalfont
-    |sync = {value = |\meta{value}|, |\meta{options}|, entry}|
+    |sync = ||{value = |\meta{value}|, |\meta{options}|, entry}|
 \end{quote}
 
 This means that when you write |1s = "red"|, what actually happens is that
@@ -1128,7 +1128,7 @@ following gets executed before the above |sync|:
 %
 \begin{quote}
     \normalfont
-    |base = {value = |\meta{value}|}|
+    |base = ||{value = |\meta{value}|}|
 \end{quote}
 
 This makes it easy to specify base values for timelines.

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
@@ -263,7 +263,7 @@ configuration of an arrow tip should be used. You use \emph{arrow keys}, where
 a certain parameter like the |length| of an arrow is set to a given value using
 the standard key--value syntax. You can provide several arrow keys following an
 arrow tip kind in  an arrow tip specification as in
-|Stealth[length=4pt,width=2pt]|.
+|Stealth[length=4pt,width=2pt||]|.
 
 While selecting a font may be easy, \emph{designing} a new font is a highly
 creative and difficult process and more often than not, not all faces of a font
@@ -1012,7 +1012,7 @@ ends in its middle.
 \end{codeexample}
 
 Now we wish to add a blue open arrow tip the red line like, say,
-|Stealth[length=1cm,open,blue]|:
+|Stealth[length=1cm,open,blue||]|:
 %
 \begin{codeexample}[setup code,hidden]
 \usetikzlibrary{patterns}
@@ -1442,7 +1442,7 @@ names. Here are some examples:
     \item |-Stealth[] >| is legal and does what was presumably meant in the
         previous item.
     \item |< Stealth-| is legal and is the counterpart to |-Stealth[] >|.
-    \item |-Stealth[length=5pt] Stealth[length=6pt]| selects two stealth
+    \item |-Stealth[length=5pt] Stealth[length=6pt||]| selects two stealth
         arrow tips, but at slightly different sizes for the end of lines.
 \end{itemize}
 
@@ -1672,7 +1672,7 @@ done using the following handler:
     definition internally:
     %
     \begin{quote}
-        |>-< /.tip = >[reversed]|
+        |>-< /.tip = ||>[reversed]|
     \end{quote}
     %
     Translation: ``When |<| is used in an end specification, please replace it

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex
@@ -15,7 +15,7 @@
 A \emph{coordinate} is a position on the canvas on which your picture is drawn.
 \tikzname\ uses a special syntax for specifying coordinates. Coordinates are
 always put in round brackets. The general syntax is
-\declare{|(|\opt{|[|\meta{options}|]|}\meta{coordinate  specification}|)|}.
+\declare{|(|\opt{|[|\meta{options}|]|}\meta{coordinate specification}|)|}.
 
 The \meta{coordinate specification} specifies coordinates using one of many
 different possible \emph{coordinate systems}. Examples are the Cartesian

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
@@ -2408,7 +2408,7 @@ the |complete bipartite| key is |{target'}{source'}|. Thus, if you just write
 |->[complete bipartite]|, the same happens as if you had written
 %
 \begin{quote}
-    |->[complete bipartite={target'}{source'}]|
+    |->[complete bipartite=||{target'}{source'}]|
 \end{quote}
 %
 This is exactly what we want to happen. The same default values are also set

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
@@ -137,7 +137,7 @@ The following style influences scopes:
 \end{codeexample}
     %
      The effect is the same as of
-    |(0,0) -- (1,1) circle[radius=2pt] -- (3,2) circle[radius=2pt]|.
+    |(0,0) -- (1,1) circle[radius=2pt] -- (3,2) circle[radius=2pt||]|.
 \end{key}
 
 The following options are for experts only:
@@ -500,7 +500,7 @@ operation.
 \tikzset{r/.style={radius=#1},rx/.style={x radius=#1},ry/.style={y radius=#1}}
 \end{codeexample}
     %
-    You can then say |circle [r=1cm]| or |circle [rx=1,ry=1.5]|. The reason
+    You can then say |circle [r=1cm||]| or |circle [rx=1,ry=1.5||]|. The reason
     \tikzname\ uses the longer names by default is that it encourages people to
     write more readable code.
 
@@ -756,7 +756,7 @@ and looks like this: \tikz \draw (-1ex,1.5ex) parabola[parabola height=-1.5ex]
         %
         \begin{key}{/tikz/parabola height=\meta{dimension}}
             This option has the same effect as
-            |[bend pos=0.5,bend={+(0pt,|\meta{dimension}|)}]|.
+            |[bend pos=0.5,bend=||{+(0pt,|\meta{dimension}|)}]|.
             %
 \begin{codeexample}[]
 \begin{tikzpicture}
@@ -845,7 +845,7 @@ specification for details.
     An \textsc{svg} coordinate like |10 20| is always interpreted as
     |(10pt,20pt)|, so the basic unit is always points (|pt|). The
     $xy$-coordinate system is not used. However, you can use scaling to
-    (locally) change the basic unit. For instance, |svg[scale=1cm]| (yes, this
+    (locally) change the basic unit. For instance, |svg[scale=1cm||]| (yes, this
     works, although some rather evil magic is involved) will cause 1cm to be
     the basic unit.
 
@@ -1148,7 +1148,7 @@ not actually extend that path, but have different, mostly local, effects.
     The first kind of permissible \meta{assignment}s have the following form:
     %
     \begin{quote}
-        |\n|\meta{number register}|={|\meta{formula}|}|
+        |\n|\meta{number register}|=||{|\meta{formula}|}|
     \end{quote}
     %
     When an assignment has this form, the \meta{formula} is evaluated using the
@@ -1178,7 +1178,7 @@ not actually extend that path, but have different, mostly local, effects.
     The second kind of \meta{assignments} have the following form:
     %
     \begin{quote}
-        |\p|\meta{point register}|={|\meta{formula}|}|
+        |\p|\meta{point register}|=||{|\meta{formula}|}|
     \end{quote}
     %
     Point position registers store a single point, consisting of an $x$-part
@@ -1288,7 +1288,7 @@ not actually extend that path, but have different, mostly local, effects.
 When \tikzname\ encounters and opening or a closing brace (|{| or~|}|) at some
 point where a path operation should come, it will open or close a scope. All
 options that can be applied ``locally'' will be scoped inside the scope. For
-example, if you apply a transformation like |[xshift=1cm]| inside the scoped
+example, if you apply a transformation like |[xshift=1cm||]| inside the scoped
 area, the shifting only applies to the scope. On the other hand, an option like
 |color=red| does not have any effect inside a scope since it can only be
 applied to the path as a whole.
@@ -1331,7 +1331,7 @@ to the |node| operation and discussed in detail in Section~\ref{section-pics}.
     This path operation has the same effect as if you had said:
     %
     \begin{quote}
-        |[animate = { myself:|\meta{animate attribute}|=|\marg{options}|} ]|
+        |[animate = ||{myself:|\meta{animate attribute}|=|\marg{options}|} ]|
     \end{quote}
     %
     This causes an animation of \meta{animate attribute} to be added to the

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-plots.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-plots.tex
@@ -170,7 +170,7 @@ plot [x=0:10] sin(x)
 \end{codeexample}
 
 The \meta{local options} of the |plot| operation are local to each plot and do
-not affect other plots ``on the same path''. For example, |plot[yshift=1cm]|
+not affect other plots ``on the same path''. For example, |plot[yshift=1cm||]|
 will locally shift the plot 1cm upward. Remember, however, that most options
 can only be applied to paths as a whole. For example, |plot[red]| does not have
 the effect of making the plot red. After all, you are trying to ``locally''

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-scopes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-scopes.tex
@@ -375,7 +375,7 @@ provided the single brace is followed by options in square brackets:
 \end{tikzpicture}
 \end{codeexample}
 
-In the above example, |{ [thick]| actually causes a |\begin{scope}[thick]| to
+In the above example, |{ [ultra thick]| actually causes a |\begin{scope}[ultra thick]| to
 be inserted, and the corresponding closing |}| causes an |\end{scope}| to be
 inserted.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -415,7 +415,7 @@ There is a special syntax for specifying ``light-weight'' nodes:
 \begin{pathoperation}{coordinate}{\opt{|[|\meta{options}|]|}|(|\meta{name}|)|\opt{|at(|\meta{coordinate}|)|}}
     This has the same effect as
 
-    |\node[shape=coordinate]|\verb|[|\meta{options}|](|\meta{name}|)at(|\meta{coordinate}|){}|,
+    |\node[shape=coordinate][|\meta{options}|](|\meta{name}|)at(|\meta{coordinate}|){}|,
 
     where the |at| part may be omitted.
 \end{pathoperation}
@@ -1785,7 +1785,7 @@ ways to achieve this:
         %
         \begin{key}{/tikz/transform shape}
             Causes the current ``external'' transformation matrix to be applied
-            to the shape. For example, if you said |\tikz[scale=3]| and then
+            to the shape. For example, if you said |\tikz[scale=3||]| and then
             say |node[transform shape] {X}|, you will get a ``huge'' X in your
             graphic.
         \end{key}
@@ -2006,7 +2006,7 @@ explicitly by using the |pos| option or implicitly by placing the node
     This option causes the node to be rotated such that a horizontal line
     becomes a tangent to the curve. The rotation is normally done in such a way
     that text is never ``upside down''. To get upside-down text, use can use
-    |[rotate=180]| or |[allow upside down]|, see below.
+    |[rotate=180||]| or |[allow upside down]|, see below.
     %
 \begin{codeexample}[]
 \tikz \draw (0,0) .. controls +(up:2cm) and +(left:2cm) .. (1,3)
@@ -2465,7 +2465,7 @@ provides:
     had written
     %
     \begin{quote}
-        |label={[|\meta{options}|]|\meta{text}|}|
+        |label=||{[|\meta{options}|]|\meta{text}|}|
     \end{quote}
     %
     instead. The ``almost'' refers to the following additional feature: In

--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial-map.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial-map.tex
@@ -433,7 +433,7 @@ complexity'' and ``computational models'' get more neutral colors; Johannes
 picks orange and blue.
 
 To set the colors, Johannes must use the |concept color| option, rather than
-just, say, |node [fill=red]|. Setting just the fill color to |red| would,
+just, say, |node [fill=red||]|. Setting just the fill color to |red| would,
 indeed, make the node red, but it would \emph{just} make the node red and not
 the bar connecting the concept to its parent and also not its children. By
 comparison, the special |concept color| option will not only set the color of

--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
@@ -530,7 +530,7 @@ current position. So, we first have to ``get there''.
 \end{codeexample}
 
 Karl thinks this is really a bit small and he cannot continue unless he learns
-how to do scaling. For this, he can add the |[scale=3]| option. He could add
+how to do scaling. For this, he can add the |[scale=3||]| option. He could add
 this option to each |\draw| command, but that would be awkward. Instead, he
 adds it to the whole environment, which causes this option to apply to
 everything within.
@@ -1226,7 +1226,7 @@ Karl is quite pleased with the result, but his son points out that this is
 still not perfectly satisfactory: The grid and the circle interfere with the
 numbers and decrease their legibility. Karl is not very concerned by this (his
 students do not even notice), but his son insists that there is an easy
-solution: Karl can add the |[fill=white]| option to fill out the background of
+solution: Karl can add the |[fill=white||]| option to fill out the background of
 the text shape with a white color.
 
 The next thing Karl wants to do is to add the labels like $\sin \alpha$. For


### PR DESCRIPTION
Inside shortverb,
1. If it contains "=" and ends with "]", this "]" is missing from output.
   E.g., "|[key=val]|" produces "[key=val".
   Change the input to "|[key=val||]|".

2. If it contains "=<opening bracket>", this bracket is typeset in italic.
   E.g., "|a={...}|" produces "a=<italic {>...}".
   Change the input to "|a=||{...}|".

The first kind of change is rather complete, but for the  second kind, 
I only checked contents of every `quote` environment.

There is already a case of second kind in the source code:
https://github.com/pgf-tikz/pgf/blob/357bc05926a057f7c1fcbc95877fc508723ac105/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex#L2404-L2408


---
Locally on my computer, I use a simplified `pgfmanual.tex` to test and compare:
```tex
\documentclass[a4paper]{ltxdoc}

\input{../pgfmanual-luatex.cfg}
\input{../../text-en/pgfmanual-en-main-preamble.tex}

\begin{document}
\parindent=0pt
\subsubsection*{First kind}
Before: |plot[yshift=3cm]| \par
After: |plot[yshift=3cm||]| 

\subsubsection*{Second kind}
Before
\begin{quote}
    |>-< /.tip = >[reversed]|
\end{quote}

After
\begin{quote}
    |>-< /.tip = ||>[reversed]|
\end{quote}

% pgfmanual-en-tikz-shapes.tex:2404
% (the double vertical bar after = is needed to avoid the two opening brackets
%  being typeset in italics)
Before
\begin{quote}
    |:some attribute = {|\meta{options}|}|
\end{quote}

After
\begin{quote}
    |:some attribute = ||{|\meta{options}|}|
\end{quote}
\end{document}
```
![image](https://user-images.githubusercontent.com/6376638/76956564-3de56c80-694f-11ea-9481-04808f1c82f1.png)
