### PR TITLE
SVG-driver code for invisibility (nulldevice PS operator)

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-common-svg.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-common-svg.def
@@ -321,10 +321,15 @@
 \def\pgfsys@beveljoin{\pgf@sys@svg@gs{stroke-linejoin="bevel"}}
 
 % Invisibility
-\def\pgfsys@begininvisible{\pgfsysprotocol@literal{<g visibility="hidden">\pgfsys@svg@newline }}
-\def\pgfsys@endinvisible{\pgfsysprotocol@literal{</g>}}
-\def\pgfsys@begininvisiblescope{\pgfsys@beginscope@{ visibility="hidden"}}
-\def\pgfsys@endinvisiblescope{\pgfsys@endscope}
+\def\pgfsys@begininvisible{%
+  \special{ps::[begin]}%
+  \special{ps:: gsave nulldevice}%
+  \special{ps::[end]}}
+\def\pgfsys@endinvisible{%
+  \special{ps::[begin]}%
+  \special{ps:: grestore}%
+  \special{ps::[end]}%
+}
 
 
 %


### PR DESCRIPTION
As of commit commit https://github.com/mgieseki/dvisvgm/commit/67bf043bf77205557370d2e29e29067938925f9a, `dvisvgm` supports the PostScript `nulldevice` operator. This invalidates / makes redundant the current low-level implementation of the beamer-pause code in the dvisvgm driver of PGF. The proposed pull-request replaces the current implementation and is based on `dvips` driver code which also works with `dvisvgm` now. It also fixes https://github.com/josephwright/beamer/issues/591 .