### PR TITLE
DOC:matrix: Add example for matrix row/col keys

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
@@ -475,6 +475,53 @@ different columns.
 \end{tikzpicture}
 \end{codeexample}
 
+In some cases, it is desirable to include some automation in each column/row
+separately. A typical example is to apply stripe-pattern to almost all columns
+and treat only a few of them differently. Then, nesting these keys can open up
+a lot of possibilities; in the following example a "feature comparison" table
+is demonstrated. It is intentionally made rather verbose to show how the column
+and row settings can be progressively overwritten to create certain effects.
+
+\begin{codeexample}[preamble={\usetikzlibrary{matrix,shapes.misc}}]
+\begin{tikzpicture}
+  [mycol/.style={column #1/.append style={
+     every even row/.style={nodes={fill=gray!10}}}
+   }]
+
+\matrix [matrix of nodes, nodes in empty cells,
+   nodes={text width=2cm, align=center,
+          minimum height=1.5em, anchor=center},
+   mycol/.list={1,...,5}, % add mycol style to all cols
+   column 1/.style={
+     row 1 column 1/.style={nodes={fill=none, draw=none}},
+     nodes={fill=yellow, chamfered rectangle, inner sep=0,
+            chamfered rectangle corners={north west, south east}},
+   },
+   row 1/.style={nodes={text depth=0.2ex, text width=2cm, text=white}},
+   column 2/.append style={row 1/.append style={nodes={fill=green}}},
+   column 3/.append style={every even row/.style={nodes={fill=red!10}},
+                           row 1 column 3/.append style={nodes={fill=red}}
+                          },
+   column 4/.append style={row 1/.append style={nodes={fill=blue!40}}},
+   column 5/.append style={row 1/.append style={nodes={fill=blue!90!black}}},
+  ] (m)
+  {
+            & Basic     & Standard   & Professional & Enterprise \\
+  Feature A & $\bullet$ & $\bullet$  & $\bullet$    & $\bullet$  \\
+  Feature B & $\bullet$ & $\bullet$  & $\bullet$    & $\bullet$  \\
+  Feature C &           &            &              & $\bullet$  \\
+  Feature D &           & $\bullet$  & $\bullet$    & $\bullet$  \\
+  Feature E &           &            & $\bullet$    & $\bullet$  \\
+  };
+
+\draw[ultra thick, rounded corners=1mm, red] (m-1-3.north west)
+                          rectangle (m-6-3.south east);
+\node[anchor=north,
+   align=center, text=red] at (m-6-3.south) {Popular\\Choice!};
+\end{tikzpicture}
+\end{codeexample}
+
+
 The order in which these styles are applied is configurable.  You can also
 install your own styles.  The following styles (in fact, internally they are
 |/.code| keys) wrap the styles introduced in the previous paragraph passing the

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
@@ -478,7 +478,7 @@ different columns.
 In some cases, it is desirable to include some automation in each column/row
 separately. A typical example is to apply stripe-pattern to almost all columns
 and treat only a few of them differently. Then, nesting these keys can open up
-a lot of possibilities; in the following example a "feature comparison" table
+a lot of possibilities; in the following example a ``feature comparison'' table
 is demonstrated. It is intentionally made rather verbose to show how the column
 and row settings can be progressively overwritten to create certain effects.
 


### PR DESCRIPTION
Cross-ref : #867 

A verbose example is added to demonstrate the key possibilities 