### PR TITLE
DOC:matrix: Streamlined "every XX row/col" example

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
@@ -477,33 +477,33 @@ different columns.
 
 In some cases, it is desirable to include some automation in each column/row
 separately. A typical example is to apply stripe-pattern to almost all columns
-and treat only a few of them differently. Then, nesting these keys can open up
+with exceptions. For these type of use-cases, nesting these keys can open up
 a lot of possibilities; in the following example a ``feature comparison'' table
-is demonstrated. It is intentionally made rather verbose to show how the column
-and row settings can be progressively overwritten to create certain effects.
+is demonstrated. It is intentionally made rather verbose and a bit redundant
+to show how the column and row settings can be progressively overwritten to
+create certain effects.
 
-\begin{codeexample}[preamble={\usetikzlibrary{matrix,shapes.misc}}]
-\begin{tikzpicture}
-  [mycol/.style={column #1/.append style={
-     every even row/.style={nodes={fill=gray!20}}}
-   }]
+\begin{codeexample}[preamble={\usetikzlibrary{matrix,fit}}]
+\begin{tikzpicture}[
+  font=\sffamily,
+  striped col/.style={column #1/.append style={
+        every even row/.style={nodes={fill=lime!50}}}},
+  head color/.style args={#1/#2}{column #1/.append style={
+        row 1/.append style={nodes={fill=#2}}}}
+]
 
-\matrix [matrix of nodes, nodes in empty cells,
+\matrix [
+   matrix of nodes, nodes in empty cells,
    nodes={text width=2cm, align=center,
           minimum height=1.5em, anchor=center},
-   mycol/.list={1,...,5}, % add mycol style to all cols
-   column 1/.style={
+   striped col/.list={1,...,5}, % add striped col style to all cols
+   column 1/.style={ % Override stripes and modify the feature column
      row 1 column 1/.style={nodes={fill=none, draw=none}},
-     nodes={fill=yellow!75!black, chamfered rectangle, inner sep=0,
-            chamfered rectangle corners={north west, south east}},
+     nodes={fill={rgb,255:red,230;green,230;blue,150}, inner ysep=0},
    },
+   % modify headers first via common styles and then specific colors
    row 1/.style={nodes={text depth=0.2ex, text width=2cm, text=white}},
-   column 2/.append style={row 1/.append style={nodes={fill=green!75!black}}},
-   column 3/.append style={every even row/.style={nodes={fill=red!10}},
-                           row 1 column 3/.append style={nodes={fill=red}}
-                          },
-   column 4/.append style={row 1/.append style={nodes={fill=blue!40}}},
-   column 5/.append style={row 1/.append style={nodes={fill=blue!90!black}}},
+   head color/.list={2/orange,3/olive,4/cyan,5/teal}
   ] (m)
   {
             & Basic     & Standard   & Professional & Enterprise \\
@@ -513,11 +513,10 @@ and row settings can be progressively overwritten to create certain effects.
   Feature D &           & $\bullet$  & $\bullet$    & $\bullet$  \\
   Feature E &           &            & $\bullet$    & $\bullet$  \\
   };
-
-\draw[ultra thick, rounded corners=1mm, red] (m-1-3.north west)
-                          rectangle (m-6-3.south east);
-\node[anchor=north,
-   align=center, text=red] at (m-6-3.south) {Popular\\Choice!};
+% Add emphasis on selection by the use of "fit" library
+\node[fit={(m-1-4.north west) (m-6-4.south east)},
+      ultra thick, inner sep=0, rounded corners=1mm,
+      draw=cyan, label={[cyan,align=center]270:Popular\\Choice!}]{};
 \end{tikzpicture}
 \end{codeexample}
 
@@ -525,7 +524,7 @@ The order in which these styles are applied is configurable.  You can also
 install your own styles.  The following styles (in fact, internally they are
 |/.code| keys) wrap the styles introduced in the previous paragraph passing the
 correct argument and ensuring that they are only called for even or odd rows.
-It's not recommended to override these.
+However, it is not recommended to override these.
 
 \begin{stylekey}{/tikz/matrix/inner style/every cell}
     Wraps |/tikz/every cell|.

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
@@ -499,7 +499,7 @@ create certain effects.
    striped col/.list={1,...,5}, % add striped col style to all cols
    column 1/.style={ % Override stripes and modify the feature column
      row 1 column 1/.style={nodes={fill=none, draw=none}},
-     nodes={fill={rgb,255:red,230;green,230;blue,150}, inner ysep=0},
+     nodes={fill={rgb,256:red,184;green,184;blue,120}, inner ysep=0},
    },
    % modify headers first via common styles and then specific colors
    row 1/.style={nodes={text depth=0.2ex, text width=2cm, text=white}},

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-matrices.tex
@@ -487,7 +487,7 @@ create certain effects.
 \begin{tikzpicture}[
   font=\sffamily,
   striped col/.style={column #1/.append style={
-        every even row/.style={nodes={fill=lime!50}}}},
+        every even row/.style={nodes={fill=olive!50}}}},
   head color/.style args={#1/#2}{column #1/.append style={
         row 1/.append style={nodes={fill=#2}}}}
 ]
@@ -499,11 +499,11 @@ create certain effects.
    striped col/.list={1,...,5}, % add striped col style to all cols
    column 1/.style={ % Override stripes and modify the feature column
      row 1 column 1/.style={nodes={fill=none, draw=none}},
-     nodes={fill={rgb,256:red,184;green,184;blue,120}, inner ysep=0},
+     nodes={fill=olive, inner ysep=0},
    },
    % modify headers first via common styles and then specific colors
    row 1/.style={nodes={text depth=0.2ex, text width=2cm, text=white}},
-   head color/.list={2/orange,3/olive,4/cyan,5/teal}
+   head color/.list={2/orange,3/teal,4/cyan,5/magenta}
   ] (m)
   {
             & Basic     & Standard   & Professional & Enterprise \\


### PR DESCRIPTION
Continuation of #871 

A bit better example via `./list` handlers and better colorization thanks to @Mo-Gul's suggestion.