### PR TITLE
[doc] external lib, change "uncomment tikz pkg" to "comment"

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex
@@ -987,8 +987,9 @@ external graphics. It can be found at
 latex/pgf/utilities/tikzexternal.sty
 \end{codeexample}
 %
-\noindent and needs to be used instead of |\usepackage{tikz}|. So, we uncomment
-|\usepackage{tikz}| and our example from the beginning becomes
+\noindent and needs to be used instead of |\usepackage{tikz}|. So, we comment
+|\usepackage{tikz}| and |\usetikzlibrary{external}|, load packages |graphicx|
+and |tikzexternal|, and finally our example from the beginning becomes
 %
 \begin{codeexample}[code only]
 \documentclass{article}


### PR DESCRIPTION
In sec. 53.5, _Using External Graphics Without `pgf` Installed_, the manual says
https://github.com/pgf-tikz/pgf/blob/d96c3f2f547eca014288331871c4d5a9d74d9fc1/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex#L980-L991
On lines 990--991, it should say "comment \usepackage{tikz}" instead of "uncomment".

This was introduced in https://github.com/pgf-tikz/pgf/commit/a8f414ec4dd0f6a77c5f3bb3caad6a45954d11a2#diff-b9f3e5fa757bdafb882b21ec86acec2dR500.