### PR TITLE
manual typos and formatting inconsistencies

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-actions.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-actions.tex
@@ -174,7 +174,7 @@ count on this.
 \end{command}
 %
 \begin{command}{\pgfsetmiterlimit\marg{miter limit factor}}
-    Sets the miter limit to  \meta{miter limit factor}. See again
+    Sets the miter limit to \meta{miter limit factor}. See again
     Section~\ref{section-cap-joins}.
 \end{command}
 
@@ -432,7 +432,7 @@ tips are added are explained in Section~\ref{section-arrow-tips-where}.
 \label{section-fill}
 
 Filling a path means coloring every interior point of the path with the current
-fill color. It is not always obvious whether a point is ``inside'' a  path when
+fill color. It is not always obvious whether a point is ``inside'' a path when
 the path is self-intersecting and/or consists or multiple parts. In this case
 either the nonzero winding number rule or the even-odd crossing number rule is
 used to decide which points lie ``inside''. These rules are explained in

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-animations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-animations.tex
@@ -504,7 +504,7 @@ Let us start with creating a snapshot:
 
 
     \medskip\textbf{Timing and Events.}
-    The timeline of an animation normally starts at a ```moment |0s|'' and the
+    The timeline of an animation normally starts at a ``moment |0s|'' and the
     \meta{time} is considered relative to this time. For instance, if a
     timeline contains, say, the settings |entry={2s}{0}| and |entry={3s}{10}|
     and \marg{time} is set to |2.5s|, then the value the attribute will get is

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-animations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-animations.tex
@@ -485,7 +485,7 @@ for an object when it is \emph{not} being animated.
 Let us start with creating a snapshot:
 
 \begin{command}{\pgfsnapshot\marg{time}}
-    When this command is used inside a \TeX\ scope, the behaviour of
+    When this command is used inside a \TeX\ scope, the behavior of
     |\pgfanimateattribute| changes: Instead of adding an animation to the
     object and the attribute, the object's attribute is set to value it would
     have during the animation at time \meta{time}. Note that when this command

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-arrows.tex
@@ -205,7 +205,7 @@ arrows.
         |foo[length=5pt,open]| once more later anywhere in the document, the
         setup code will not be executed again.
     \item The next thing that happens is that we have a look at the
-        \emph{drawin code} stored in the |code| field of the arrow. In our
+        \emph{drawing code} stored in the |code| field of the arrow. In our
         example, the drawing code would consist of creating a filled path with
         four straight segments.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-arrows.tex
@@ -432,9 +432,9 @@ fast arrow tip management.
             well as to the line width.
 
             The \meta{code} should draw the arrow tip ``going right along the
-            $x$-axis''. \pgfname\ will take care of setting up a  canvas
+            $x$-axis''. \pgfname\ will take care of setting up a canvas
             transformation beforehand to a rotation such that when the drawing
-            is rendered, the arrow tip that is  actually drawn points in the
+            is rendered, the arrow tip that is actually drawn points in the
             direction of the line. Alternatively, when bending is switched on,
             even more complicated low-level transformations will be done
             automatically.
@@ -647,7 +647,7 @@ fast arrow tip management.
             This sets up things so that whenever \meta{name} is now used in an
             arrow specification, it will be replaced by the \meta{end arrow
             specification} (the problems resulting form the \meta{name} begin
-            used in a start arrow  specification are taken care of
+            used in a start arrow specification are taken care of
             automatically). See also Section~\ref{section-arrow-tip-macro} for
             details on the order in which options get executed in such cases.
 
@@ -719,9 +719,9 @@ setup a \TeX-if that you can access in the setup code:
     \item |\ifpgfarrowharpoon| is setup by |harpoon| and also |left| and
         |right|.
     \item |\ifpgfarrowroundcap| is set to true by |line cap=round| and set to
-        false by |line cap=butt|. It also gets (re)set by  |round| and |sharp|.
+        false by |line cap=butt|. It also gets (re)set by |round| and |sharp|.
     \item |\ifpgfarrowroundjoin| is set to true by |line join=round| and set to
-        false by |line join=miter|. It also gets (re)set by  |round| and
+        false by |line join=miter|. It also gets (re)set by |round| and
         |sharp|.
     \item |\ifpgfarrowopen| is set to true by |fill=none| and by |open| (which
         is a shorthand for |fill=none|) and set to false by |color| and all

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-decorations.tex
@@ -208,7 +208,7 @@ command describes the decoration automaton.
     certain position on the input path. This current point will ``travel along
     the path'', each time being moved along by a certain distance. This will
     also work if the path is not a straight line. That is, it is permissible
-    that the path curves are veers at a sharp angle.  It is also permissible
+    that the path curves are veers at a sharp angle. It is also permissible
     that while traveling along the input path, the current input segment ends
     and a new input segment starts. In this case, the remaining distance on the
     first input segment is subtracted from the \meta{dimension} and then we
@@ -431,7 +431,7 @@ command describes the decoration automaton.
 
         \begin{command}{\pgfdecoratedinputsegmentlength}
             The length of the current input segment of the input path.
-            ``Current input segment''  refers to the input segment on which the
+            ``Current input segment'' refers to the input segment on which the
             current point lies.
         \end{command}
 
@@ -553,7 +553,7 @@ Once a decoration has been declared, it can be used.
             The \meta{before code} and the \meta{after code} are optional. The
             input path is divided into input paths as follows: The first input
             path consists of the first lines of the path specified in the
-            \meta{environment contents} until the \meta{length}  of the first
+            \meta{environment contents} until the \meta{length} of the first
             element of the \meta{decoration list} is reached. If this length is
             reached in the middle of a line, the line is broken up at this
             exact position. Then the second input path has the \meta{length} of
@@ -563,12 +563,12 @@ Once a decoration has been declared, it can be used.
 
             If the lengths in the \meta{decoration list} do not add up to the
             total length of the path in the \meta{environment contents}, either
-            some  decorations are dropped (if their lengths add up to more than
+            some decorations are dropped (if their lengths add up to more than
             the length of the \meta{environment contents}) or the input path is
-            not fully used (if their lengths  add up to less).
+            not fully used (if their lengths add up to less).
         \item The preexisting path is reinstalled.
         \item The decoration automata move along the input paths, thus creating
-            (and  possibly using) the output paths. These output paths extend
+            (and possibly using) the output paths. These output paths extend
             the current path (unless they are used).
     \end{enumerate}
 
@@ -835,7 +835,7 @@ decorations, a meta-decoration must be declared before it can be used.
 
             Otherwise, this option tells \pgfname\ the width of the
             ``meta-segment'', that is, the length of the sub-input-path which
-            the decoration automaton specified  in \meta{code} will decorate.
+            the decoration automaton specified in \meta{code} will decorate.
         \end{key}
 
         \begin{key}{/pgf/meta-decoration automaton/next state=\meta{new state}}

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-decorations.tex
@@ -334,8 +334,8 @@ command describes the decoration automaton.
             First, this option causes an immediate switch to the state |final|
             if the remaining distance on the input path is less than
             \meta{dimension}. The effect is the same as if you had said 
-            |switch if less than=|\meta{dimension}| to final| just before the |width|
-            option.
+            |switch if less than=|\meta{dimension}| to final| just before the 
+            |width| option.
 
             If no switch occurs, this option tells \pgfname\ the width of the
             segment. The current point will travel along the input path (as
@@ -599,7 +599,7 @@ Once a decoration has been declared, it can be used.
             point.
     \end{itemize}
 
-    Before the automata start to "work on" their respective inputs paths,
+    Before the automata start to ``work on'' their respective inputs paths,
     \meta{before code} is executed. After the decoration automaton has
     finished, \meta{after code} is executed.
     %

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-external.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-external.tex
@@ -132,10 +132,10 @@ As we see in Figure~\ref{fig1}, the world is flat.
             away without any macro expansion. This means, in particular, that
             (a) you cannot put |\endpgfgraphicnamed| inside a macro and (b) the
             macros used in the graphics need not be defined at all when the
-            graphic file is included. \item The most complex behaviour arises
+            graphic file is included. \item The most complex behavior arises
             when current the |\jobname| equals the \meta{file name prefix} and,
             furthermore, the \emph{real job name} has been declared. The
-            behaviour for this case is explained later.
+            behavior for this case is explained later.
     \end{enumerate}
 
     Note that the |\beginpgfgraphicnamed| does not really have any effect until
@@ -257,7 +257,7 @@ there is a better way: You input the file |pgfexternal.tex|.
     Since |\beginpgfgraphicnamed| does not do macro expansion as it searches
     for |\endpgfgraphicnamed|, it is not necessary to actually include the
     packages necessary for \emph{creating} the graphics. So the idea is that
-    you comment out things like |\usepackage{tikz}| and instead say 
+    you comment out things like |\usepackage{tikz}| and instead say
     |\input pgfexternal.tex|.
 
     Indeed, the contents of this file is simply the following line:

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-external.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-external.tex
@@ -110,13 +110,13 @@ As we see in Figure~\ref{fig1}, the world is flat.
     %
     \begin{enumerate}
         \item The easiest situation arises if there does not yet exist a
-            graphic file called \meta{file name  prefix}|.|\meta{suffix}, where
+            graphic file called \meta{file name prefix}|.|\meta{suffix}, where
             the \meta{suffix} is one of the suffixes understood by your current
             backend driver (so |pdf| or |jpg| if you use |pdftex|, |eps| if you
             use |dvips|, and so on). In this case, both this command and the
             |\endpgfgraphicnamed| command simply have no effect.
         \item A more complex situation arises when a graphic file named
-            \meta{file name  prefix}|.|\meta{suffix} \emph{does} exist. In this
+            \meta{file name prefix}|.|\meta{suffix} \emph{does} exist. In this
             case, this graphic file is included using the |\includegraphics|
             command%
             %

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-images.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-images.tex
@@ -66,7 +66,7 @@ To speedup the compilation, you may wish to use the following class option:
 \begin{command}{\pgfdeclareimage\oarg{options}\marg{image name}\marg{filename}}
     Declares an image, but does not paint anything. To draw the image, use
     |\pgfuseimage{|\meta{image name}|}|. The \meta{filename} may not have an
-    extension. For \textsc{pdf}, the extensions |.pdf|, |.jpg|, and |.png|
+    extension.  For \textsc{pdf}, the extensions |.pdf|, |.jpg|, and |.png|
     will automatically tried. For PostScript, the extensions |.eps|, |.epsi|,
     and |.ps| will be tried.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-images.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-images.tex
@@ -66,7 +66,7 @@ To speedup the compilation, you may wish to use the following class option:
 \begin{command}{\pgfdeclareimage\oarg{options}\marg{image name}\marg{filename}}
     Declares an image, but does not paint anything. To draw the image, use
     |\pgfuseimage{|\meta{image name}|}|. The \meta{filename} may not have an
-    extension.  For \textsc{pdf}, the extensions |.pdf|, |.jpg|, and |.png|
+    extension. For \textsc{pdf}, the extensions |.pdf|, |.jpg|, and |.png|
     will automatically tried. For PostScript, the extensions |.eps|, |.epsi|,
     and |.ps| will be tried.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-internalregisters.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-internalregisters.tex
@@ -25,7 +25,7 @@ temporaries than |\pgf@x| and |\pgf@y|.
 \begin{internallist}[dimen register]{\pgf@x,\pgf@y}
     These registers are used to process point coordinates in the basic layer of
     \pgfname, see Section~\ref{section-internal-pointcmds}. After a
-    |\pgfpoint|$\dotsc$ command, they contain the final $x$ and $y$ coordinate,
+    |\pgfpoint|$\dotsc$ command, they contain the final $x$- and $y$-coordinate,
     respectively.
 
     The values of |\pgf@x| and |\pgf@y| are set \emph{globally} in contrast to

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-internalregisters.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-internalregisters.tex
@@ -19,12 +19,12 @@ registers. This section describes how to use a set of pre-allocated temporary
 registers of the basic layer without needing to allocate more of them.
 
 A part of these internals are already mentioned in
-section~\ref{section-internal-pointcmds}, but the basic layer provides more
+Section~\ref{section-internal-pointcmds}, but the basic layer provides more
 temporaries than |\pgf@x| and |\pgf@y|.
 
 \begin{internallist}[dimen register]{\pgf@x,\pgf@y}
     These registers are used to process point coordinates in the basic layer of
-    \pgfname, see section~\ref{section-internal-pointcmds}. After a
+    \pgfname, see Section~\ref{section-internal-pointcmds}. After a
     |\pgfpoint|$\dotsc$ command, they contain the final $x$ and $y$ coordinate,
     respectively.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-matrices.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-matrices.tex
@@ -193,7 +193,7 @@ All matrices are typeset using the following command:
     \begin{itemize}
         \item It is not necessary to actually mention |\pgfmatrixnextcell| or
             |\pgfmatrixendrow| inside the \meta{matrix cells}. It suffices that
-            the  macros inside \meta{matrix cells} expand to these macros
+            the macros inside \meta{matrix cells} expand to these macros
             sooner or later.
         \item In particular, you can define clever macros that insert columns
             and rows as needed for special effects.

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
@@ -421,7 +421,7 @@ create a node whose position is determined only at some later time.
 
     Once a late node has been created, you can add arbitrary code in the same
     picture. Then, at some later point, you call |\pgfpositionnodenow| to
-    finally position the node at a given position. At this point, the above
+    finally position the node at a given position.  At this point, the above
     macros must have the exact same values they had when \meta{macro name} was
     called. Note that the above macros are local to a scope that ends right
     after the call to \meta{macro name}, so it is your job to copy the values
@@ -1103,7 +1103,7 @@ The following command declares a new shape:
         in the shape's coordinate system, and relative to the anchor |center|.
         Note that |\pgfpointshapeborder| will produce an error if the shape does
         not contain the |center| anchor.
-        
+
         It is now the job of the \meta{code} to set up |\pgf@x| and |\pgf@y|
         such that they specify the point on the shape's border that lies on a
         straight line from the shape's center to the point $p$. Usually, this is

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
@@ -220,14 +220,14 @@ must set up the box |\pgfnodepartXYZbox|. The box will be placed at the anchor
 \end{pgfpicture}
 \end{codeexample}
 
-    \emph{Note:\/} Be careful when using the |\setbox| command inside a
+    \emph{Note:} Be careful when using the |\setbox| command inside a
     |{pgfpicture}| command. You will have to use |\pgfinterruptpath| at the
     beginning of the box and |\endpgfinterruptpath| at the end of the box to
     make sure that the box is typeset correctly. In the above example this
     problem was sidestepped by moving the box construction outside the
     environment.
 
-    \emph{Note:\/} It is not necessary to use |\newbox| for every node part
+    \emph{Note:} It is not necessary to use |\newbox| for every node part
     name. Although you need a different box for each part of a single shape,
     two different shapes may very well use the same box even when the names of
     the parts are different. Suppose you have a |circle split| shape that has a

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
@@ -17,7 +17,7 @@ This section describes the |shapes| module.
 \begin{pgfmodule}{shapes}
     This module defines commands both for creating nodes and for creating
     shapes. The package is loaded automatically by |pgf|, but you can load it
-    manually if you have  only included |pgfcore|.
+    manually if you have only included |pgfcore|.
 \end{pgfmodule}
 
 
@@ -379,7 +379,7 @@ create a node whose position is determined only at some later time.
 \begin{command}{\pgfpositionnodelater\marg{macro name}}
     This command is not a replacement for |\pgfnode|. Rather, when this command
     is used in a scope, all subsequent node creations in this scope will be
-    affected in the following way:  When a node is created, it is not inserted
+    affected in the following way: When a node is created, it is not inserted
     into the current picture. Instead, it is stored in the box
     |\pgfpositionnodelaterbox|. Furthermore, the node is not relevant for the
     picture's bounding box, but a bounding box for the node is computed and
@@ -421,7 +421,7 @@ create a node whose position is determined only at some later time.
 
     Once a late node has been created, you can add arbitrary code in the same
     picture. Then, at some later point, you call |\pgfpositionnodenow| to
-    finally position the node at a given position.  At this point, the above
+    finally position the node at a given position. At this point, the above
     macros must have the exact same values they had when \meta{macro name} was
     called. Note that the above macros are local to a scope that ends right
     after the call to \meta{macro name}, so it is your job to copy the values
@@ -759,7 +759,7 @@ In order to define a new shape, you must provide:
 %
 \begin{itemize}
     \item a \emph{shape name},
-    \item code for computing the  \emph{saved anchors} and \emph{saved
+    \item code for computing the \emph{saved anchors} and \emph{saved
     dimensions},
     \item code for computing \emph{anchor} positions in terms of the saved
         anchors,
@@ -773,7 +773,7 @@ In order to define a new shape, you must provide:
 
 \subsubsection{Normal Anchors Versus Saved Anchors}
 
-Anchors  are special places in a shape. For example, the |north east| anchor,
+Anchors are special places in a shape. For example, the |north east| anchor,
 which is a normal anchor, lies at the upper right corner of the |rectangle|
 shape, as does |\northeast|, which is a saved anchor. The difference is the
 following: \emph{saved anchors are computed and stored for each node, anchors
@@ -798,9 +798,9 @@ knowing where the locations of the saved anchors are.
 As an example, consider the |rectangle| shape. For this shape two anchors are
 saved: The |\northeast| corner and the |\southwest| corner. A normal anchor
 like |north west| can now easily be expressed in terms of these coordinates:
-Take the $x$-position of the |\southwest| point  and the $y$-position of the
+Take the $x$-position of the |\southwest| point and the $y$-position of the
 |\northeast| point. The |rectangle| shape currently defines 13 normal anchors,
-but needs only two saved anchors. Adding new anchors like a  |south south east|
+but needs only two saved anchors. Adding new anchors like a |south south east|
 anchor would not increase the memory and computation requirements of pictures.
 
 All anchors (both saved and normal) are specified in a local \emph{shape
@@ -873,7 +873,7 @@ The following command declares a new shape:
         should be a \TeX\ macro name like |\centerpoint|.
 
         The \meta{code} will be executed each time |\pgfnode| (or
-        |\pgfmultipartnode|) is called to  create a node of the shape
+        |\pgfmultipartnode|) is called to create a node of the shape
         \meta{shape name}. When the \meta{code} is executed, the \TeX-boxes of
         the node parts will contain the text labels of the node. Possibly,
         these box are void. For example, if there is just a |text| part, the
@@ -1098,7 +1098,7 @@ The following command declares a new shape:
 
         When the user requests a point on the border of the shape using the
         |\pgfpointshapeborder| command, the \meta{code} will be executed to
-        discern this point. When the execution of  the \meta{code} starts, the
+        discern this point. When the execution of the \meta{code} starts, the
         dimensions |\pgf@x| and |\pgf@y| will have been set to a location $p$
         in the shape's coordinate system, and relative to the anchor |center|.
         Note that |\pgfpointshapeborder| will produce an error if the shape does

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-paths.tex
@@ -141,7 +141,7 @@ be used to start a new part of a path.
 
 \begin{command}{\pgfpathcurveto\marg{support 1}\marg{support 2}\marg{coordinate}}
     This command extends the current path with a Bézier curve from the last
-    point of the path to  \meta{coordinate}. The \meta{support 1} and
+    point of the path to \meta{coordinate}. The \meta{support 1} and
     \meta{support 2} are the first and second support point of the Bézier
     curve. For more information on Bézier curves, please consult a standard
     textbook on computer graphics.
@@ -601,7 +601,7 @@ the path.
 \subsection{The Parabola Path Operation}
 
 \begin{command}{\pgfpathparabola\marg{bend vector}\marg{end vector}}
-    This command appends two half-parabolas to the  current path. The first
+    This command appends two half-parabolas to the current path. The first
     starts at the current point and ends at the current point plus \meta{bend
     vector}. At this point, it has its bend. The second half parabola starts at
     that bend point and ends at point that is given by the bend plus \meta{end

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-patterns.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-patterns.tex
@@ -83,7 +83,7 @@ used for this:
     complete tile.
 
     The size of a tile is given by \meta{tile size}, that is, a tile is a
-    rectangle whose lower left   corner is the origin and whose upper right
+    rectangle whose lower left corner is the origin and whose upper right
     corner is given by \meta{tile size}. This might make you wonder why the
     second and third parameters are needed. First, the bounding box might be
     smaller than the tile size if the tile is larger than the picture on the

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-plots.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-plots.tex
@@ -313,7 +313,7 @@ reader'' that parses coordinate files a bit more intelligently.
     the coordinates of the \meta{function}. In detail, the following happens:
 
     This command works with two files: \meta{prefix}|.gnuplot| and
-    \meta{prefix}|.table|.  If the optional argument \meta{prefix} is not
+    \meta{prefix}|.table|. If the optional argument \meta{prefix} is not
     given, it is set to |\jobname|.
 
     Let us start with the situation where none of these files exists. Then
@@ -378,7 +378,7 @@ set terminal table; set output "#1.table"; set format "%.5f"
 \subsection{Plot Handlers}
 \label{section-plot-handlers}
 
-A \emph{plot handler}  determines what ``should be done'' with a plot stream.
+A \emph{plot handler} determines what ``should be done'' with a plot stream.
 You must set the plot handler before the stream starts. The following commands
 install the most basic plot handlers; more plot handlers are defined in the
 file |pgflibraryplothandlers|, which is documented in
@@ -416,7 +416,7 @@ All plot handlers work by setting or redefining the following three macros:
 \end{command}
 
 \begin{command}{\pgfsetlinetofirstplotpoint}
-    Specifies that  plot handlers should issue a line-to command for the first
+    Specifies that plot handlers should issue a line-to command for the first
     point of the plot.
     %
 \begin{codeexample}[]

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-plots.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-plots.tex
@@ -132,8 +132,7 @@ groups.
 
                 The net effect of this setting is that at outlier points plots
                 get interrupted and ``restarted'' when the points are no longer
-                outliers. This is usually the behaviour you will be looking
-                for.
+                outliers. This is usually the behavior you will be looking for.
         \end{itemize}
     \end{key}
 \end{command}
@@ -491,7 +490,7 @@ You can define new plot handlers using the following command:
 \pgfplotstreamend
 \end{codeexample}
 
-    The \meta{configuration} is used to define the behaviour of the handler. It
+    The \meta{configuration} is used to define the behavior of the handler. It
     is a list of key--value pairs, where the following keys are allowed:
     %
     \begin{itemize}

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-plots.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-plots.tex
@@ -313,7 +313,7 @@ reader'' that parses coordinate files a bit more intelligently.
     the coordinates of the \meta{function}. In detail, the following happens:
 
     This command works with two files: \meta{prefix}|.gnuplot| and
-    \meta{prefix}|.table|. If the optional argument \meta{prefix} is not
+    \meta{prefix}|.table|.  If the optional argument \meta{prefix} is not
     given, it is set to |\jobname|.
 
     Let us start with the situation where none of these files exists. Then

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-points.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-points.tex
@@ -628,7 +628,7 @@ relevant only if you need to understand how the point commands work internally.
 When a command like |\pgfpoint{1cm}{2pt}| is called, all that happens is that
 the two \TeX-dimension variables |\pgf@x| and |\pgf@y| are set to |1cm| and
 |2pt|, respectively. These variables belong to the set of internal \pgfname\
-registers, see section~\ref{section-internal-registers} for details. A command
+registers, see Section~\ref{section-internal-registers} for details. A command
 like |\pgfpathmoveto| that takes a coordinate as parameter will just execute
 this parameter and then use the values of |\pgf@x| and |\pgf@y| as the
 coordinates to which it will move the pen on the current path.

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-points.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-points.tex
@@ -22,7 +22,7 @@ specify a coordinate you can use commands that start with |\pgfpoint|.
 
 \subsection{Basic Coordinate Commands}
 
-The following commands are the most basic  for specifying a coordinate.
+The following commands are the most basic for specifying a coordinate.
 
 \begin{command}{\pgfpoint\marg{x coordinate}\marg{y coordinate}}
     Yields a point location. The coordinates are given as \TeX\ dimensions.
@@ -128,7 +128,7 @@ $x$- and $y$-vector do not necessarily point ``horizontally'' and
     This command is similar to the |\pgfpointpolar| command, but the
     \meta{radius} is now a factor to be interpreted in the $xy$-coordinate
     system. This means that a degree of |0| is the same as the $x$-vector of
-    the $xy$-coordinate  system times \meta{radius} and a degree of |90| is the
+    the $xy$-coordinate system times \meta{radius} and a degree of |90| is the
     $y$-vector times \meta{radius}. As for |\pgfpointpolar|, a \meta{radius}
     can also be a pair separated by a slash. In this case, the $x$- and
     $y$-vectors are multiplied by different factors.
@@ -156,7 +156,7 @@ dimensional graphics.
 
 \begin{command}{\pgfpointxyz\marg{$s_x$}\marg{$s_y$}\marg{$s_z$}}
     Yields a point that is situated at $s_x$ times the $x$-vector plus $s_y$
-    times the $y$-vector plus  $s_z$ times the $z$-vector.
+    times the $y$-vector plus $s_z$ times the $z$-vector.
     %
 \begin{codeexample}[]
 \begin{pgfpicture}
@@ -517,7 +517,7 @@ determine border points of shapes.
 
 \begin{pgflibrary}{intersections}
     This library defines the below command and allows you to calculate the
-    intersections of  two arbitrary paths. However, due to the low accuracy of
+    intersections of two arbitrary paths. However, due to the low accuracy of
     \TeX, the paths should not be ``too complicated''. In particular, you
     should not try to intersect paths consisting of lots of very small segments
     such as plots or decorated paths.
@@ -531,7 +531,7 @@ determine border points of shapes.
     so can contain transformations (which will be in addition to any existing
     transformations). The code should not use the path in any way, unless the
     path is saved first and restored afterward. \pgfname{} will regard
-    solutions as ``a bit special'', in that the points returned  will be
+    solutions as ``a bit special'', in that the points returned will be
     ``absolute'' and unaffected by any further transformations.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{intersections}}]

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-quick.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-quick.tex
@@ -84,7 +84,7 @@ All quick path construction commands start with |\pgfpathq|.
 
 \begin{command}{\pgfpathqcurveto\marg{$s^1_x$}\marg{$s^1_y$}\marg{$s^2_x$}\marg{$s^2_y$}\marg{$t_x$}\marg{$t_y$}}
     The quick version of the curve-to operation. The first support point is
-    $(s^1_x,s^1_y)$, the second support point is  $(s^2_x,s^2_y)$, and the
+    $(s^1_x,s^1_y)$, the second support point is $(s^2_x,s^2_y)$, and the
     target is $(t_x,t_y)$.
     %
 \begin{codeexample}[]

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-shadings.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-shadings.tex
@@ -29,7 +29,7 @@ shadings are included for convenience.
 Once you have declared a shading, you can insert it into the text using the
 command |\pgfuseshading|. This command cannot be used directly in a
 |{pgfpicture}|, you have to put a |\pgftext| around it. The second command for
-using shadings, |\pgfshadepath|, on the other hand, can only be used  inside
+using shadings, |\pgfshadepath|, on the other hand, can only be used inside
 |{pgfpicture}| environments. It will ``fill'' the current path with the
 shading.
 
@@ -617,7 +617,7 @@ than if you work in your intended color model.
     been used, an additional transformation is applied.
 
     After everything has been set up, the shading is inserted. Due to the
-    transformations and clippings, the effect will be that  the shading seems
+    transformations and clippings, the effect will be that the shading seems
     to ``fill'' the path.
 
     If both the path and the shadings were always rectangles and if rotations
@@ -631,7 +631,7 @@ than if you work in your intended color model.
     $(50\mathrm{bp},50\mathrm{bp})$, which is the middle of the shading, is at
     the middle of the path and such that the point
     $(25\mathrm{bp},25\mathrm{bp})$ is at the lower left corner of the path and
-    that  $(75\mathrm{bp},75\mathrm{bp})$  is at upper right corner.
+    that $(75\mathrm{bp},75\mathrm{bp})$ is at upper right corner.
 
     In other words, only the center quarter of the shading will actually
     ``survive the clipping'' if the path is a rectangle. If the path is not a

--- a/doc/generic/pgf/text-en/pgfmanual-en-drivers.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-drivers.tex
@@ -67,7 +67,7 @@ The files in the |generic/pgf| directory do the actual work.
 \subsubsection{Using the Plain \TeX\ Format}
 
 When using the plain \TeX\ format, you say |\input{pgf.tex}| or
-|\input{tikz.tex}|. Then, instead of  |\begin{pgfpicture}| and
+|\input{tikz.tex}|. Then, instead of |\begin{pgfpicture}| and
 |\end{pgfpicture}| you use |\pgfpicture| and |\endpgfpicture|.
 
 Unlike for the \LaTeX\ format, \pgfname\ is not as good at discerning the
@@ -101,7 +101,7 @@ first (the modules |pgf| and |tikz| both include |pgfmod| for you, so typically
 you can skip this). This special module is necessary since old versions of
 Con\TeX t~MkII before 2005 satanically restricted the length of module names to
 8 characters and \pgfname's long names are mapped to cryptic 6-letter-names for
-you by the module |pgfmod|.  This restriction was never in place in
+you by the module |pgfmod|. This restriction was never in place in
 Con\TeX t~MkIV and the |pgfmod| module can be safely ignored nowadays.
 
 
@@ -206,7 +206,7 @@ program: it uses a different input format, but the output is exactly the same.
 
 \begin{filedescription}{pgfsys-vtex.def}
     This is the driver file for use with the commercial \textsc{vtex} program.
-    Even though it produces  \textsc{pdf} output, it includes
+    Even though it produces \textsc{pdf} output, it includes
     |pgfsys-common-postscript.def|. Note that the \textsc{vtex} program can
     produce \emph{both} Postscript and \textsc{pdf} output, depending on the
     command line parameters. However, whether you produce Postscript or
@@ -331,7 +331,7 @@ dvisvgm example
             supported.
         \item Text inside |pgfpicture|s is not supported very well. The
             reason is that the \textsc{svg} specification currently does not
-            support text very well and, although it is  possible to ``escape
+            support text very well and, although it is possible to ``escape
             back'' to \textsc{html}, \tikzname\ has then to guess what size
             the text rendered by the browser would have.
         \item Unlike for other output formats, the bounding box of a picture
@@ -385,7 +385,7 @@ dvisvgm example
     complicated text nodes is much better since code that renders well outside
     a |{pgfpicture}|, should also render well inside a text node. Another
     advantage is that inside text nodes with fixed width, \textsc{html} will
-    produce line breaks for long  lines. On the other hand, you need a browser
+    produce line breaks for long lines. On the other hand, you need a browser
     with good \textsc{svg} support to display the picture. Also, the text will
     display differently, depending on your browsers, the fonts you have on your
     system and your settings. Finally, \pgfname\ has to guess the size of the
@@ -401,7 +401,7 @@ dvisvgm example
 
     \begin{key}{/pgf/tex4ht node/css=\meta{filename} (default |\string\jobname|)}
         This option allows you to tell the browser what \textsc{css} file it
-        should  use to style the display of the node (only with 
+        should use to style the display of the node (only with 
         |tex4ht node/escape=true|).
     \end{key}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-drivers.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-drivers.tex
@@ -101,8 +101,8 @@ first (the modules |pgf| and |tikz| both include |pgfmod| for you, so typically
 you can skip this). This special module is necessary since old versions of
 Con\TeX t~MkII before 2005 satanically restricted the length of module names to
 8 characters and \pgfname's long names are mapped to cryptic 6-letter-names for
-you by the module |pgfmod|. This restriction was never in place in
-Con\TeX t~MkIV and the |pgfmod| module can be safely ignored nowadays.
+you by the module |pgfmod|.  This restriction was never in place in Con\TeX
+t~MkIV and the |pgfmod| module can be safely ignored nowadays.
 
 
 \subsection{Supported Output Formats}
@@ -401,7 +401,7 @@ dvisvgm example
 
     \begin{key}{/pgf/tex4ht node/css=\meta{filename} (default |\string\jobname|)}
         This option allows you to tell the browser what \textsc{css} file it
-        should use to style the display of the node (only with 
+        should use to style the display of the node (only with
         |tex4ht node/escape=true|).
     \end{key}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-axes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-axes.tex
@@ -332,7 +332,7 @@ scaling = min at 0cm and max at 5cm
     %
     to map the complete range of values into an interval of length of 5cm.
 
-    The interval  $[s_1,s_2]$ need not contain all values that the
+    The interval $[s_1,s_2]$ need not contain all values that the
     \meta{attribute} may attain. It is permissible that values are less than
     $s_1$ or more than $s_2$.
 
@@ -873,7 +873,7 @@ data {
     %
     \begin{itemize}
         \item The |x|-values are surveyed and the $x$-axis is then scaled and
-            shifted so  that it has the length specified by the following key.
+            shifted so that it has the length specified by the following key.
             %
             \begin{key}{/tikz/data visualization/scientific axes/width=\meta{dimension} (initially 5cm)}
             \end{key}
@@ -3191,7 +3191,7 @@ axis system to specify how grid lines are drawn.
             really need to be a grid \emph{line}. Consider for instance a three
             dimensional axis system. A ``grid line'' for the $x$-coordinate |3|
             would actually be a ``grid plane''.
-        \item For a polar coordinate  system and a fixed radius, this set of
+        \item For a polar coordinate system and a fixed radius, this set of
             positions at a certain radius is not a straight line, but an arc.
             For more complicated coordinate systems such as the one arising
             from three-dimensional spherical projections, a grid line may well
@@ -3219,7 +3219,7 @@ axis system to specify how grid lines are drawn.
 
     By the above discussion, in order to create a grid line for attribute $a$
     having value $v$, we need to specify an axis ``along'' which the line
-    should be drawn. When there  are only two axes, this is usually ``the other
+    should be drawn. When there are only two axes, this is usually ``the other
     axis''. This ``other axis'' is specified using the following key:
     %
     \begin{key}{/tikz/data visualization/direction axis=\meta{axis name}}

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-axes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-axes.tex
@@ -1991,7 +1991,7 @@ low=min, high=max
 \end{codeexample}
     %
     This causes grid lines to span all possible values when they are
-    visualized, which is usually the desired behaviour (the |low| and |high|
+    visualized, which is usually the desired behavior (the |low| and |high|
     keys are explained in Section~\ref{section-dv-visualize-ticks}. You can
     append the |style| key to this style to configure the overall appearance of
     grid lines. It should be noted that settings to |style| inside |every grid|
@@ -2838,7 +2838,7 @@ left axis={ visualize axis={ x axis={ goto=min } }
         The key can be passed to an axis. It will set the attribute monitored
         by the axis to the given \meta{value}, which is usually some number.
         However, \meta{value} may also be one of the following, which causes a
-        special behaviour:
+        special behavior:
         %
         \begin{itemize}
             \item |min|: The attribute is set to the minimal value that the

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-axes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-axes.tex
@@ -2265,7 +2265,7 @@ The text produced by the automatic typesetting is computed as follows:
 %
 \begin{enumerate}
     \item The current contents of the key |tick prefix| is put into the node.
-    \item This is followed by a call of the key |tick typesetting| which gets
+    \item This is followed by a call of the key |tick typesetter| which gets
         the \meta{value} of the tick as its argument in scientific notation.
     \item This is followed by the contents of the key |tick suffix|.
 \end{enumerate}
@@ -2310,7 +2310,7 @@ Let us have a look at these keys in detail:
     \end{key}
 \end{key}
 
-\begin{key}{/tikz/data visualization/tick typesetting=\meta{value}}
+\begin{key}{/tikz/data visualization/tick typesetter=\meta{value}}
     The key gets called for each number that should be typeset. The argument
     \meta{value} will be in scientific notation (like |1.0e1| for $10$). By
     default, this key applies |\pgfmathprintnumber| to its argument. This
@@ -2550,14 +2550,14 @@ special ticks that you may have added using the |also at| key. When using the
     option. Then ticks are placed all positions $i\cdot s + p$ that lie in the
     interval $[a,b]$, where $i$ ranges over all integers.
 
-    The tick positions computed in the way described above are \emph{mayor}
+    The tick positions computed in the way described above are \emph{major}
     step positions. In addition to these, if the key
     |minor steps between steps| is set to some number $n$, then $n$ many minor
-    ticks are introduced between each two mayor ticks (and also before and
-    after the last mayor tick, provided the values still lie in the interval
+    ticks are introduced between each two major ticks (and also before and
+    after the last major tick, provided the values still lie in the interval
     $[a,b]$). Note that is $n$ is $1$, then one minor tick will be added in the
-    middle between any two mayor ticks. Use a value of $9$ (not $10$) to
-    partition the interval between two mayor ticks into ten equally sized minor
+    middle between any two major ticks. Use a value of $9$ (not $10$) to
+    partition the interval between two major ticks into ten equally sized minor
     intervals.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{datavisualization}}]
@@ -2585,11 +2585,11 @@ special ticks that you may have added using the |also at| key. When using the
     |logarithmic| option with an axis.
 
     In detail, the following happens: As for |linear steps| let numbers $a$,
-    $b$, $s$, and $p$ be given. Then, mayor ticks are placed at all positions
+    $b$, $s$, and $p$ be given. Then, major ticks are placed at all positions
     $10^{i\cdot s+p}$ that lie in the interval $[a,b]$ for $i \in \mathbb{Z}$.
 
     The minor steps are added in the same way as for |linear steps|. In
-    particular, they interpolate \emph{linearly} between mayor steps.
+    particular, they interpolate \emph{linearly} between major steps.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{datavisualization}}]
 \begin{tikzpicture}

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-formats.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-formats.tex
@@ -256,7 +256,7 @@ data [format=named] {
         \end{enumerate}
         %
         In the first case, if the optional |samples| part is missing, the
-        number of |samples| is taken from the value stored  in the following
+        number of |samples| is taken from the value stored in the following
         key:
         %
         \begin{key}{/pgf/data/samples=\meta{number} (initially 25)}
@@ -362,7 +362,7 @@ data [format=function] {
 \subsection{Advanced: The Data Parsing Process}
 \label{section-dv-parsing}
 
-Whenever data is fed to the data visualization system, it will be  handled by
+Whenever data is fed to the data visualization system, it will be handled by
 the |\pgfdata| command, declared in the |datavisualization| module. The command
 is both used to parse data stored in external sources (that is, in external
 files or which is produced on the fly by calling an external command) as well
@@ -397,7 +397,7 @@ Let us now have a look at how |\pgfdata| works.
         If you set the |read from file| attribute to a non-empty
         \meta{filename}, the data will be read from this file. In this case, no
         \meta{inline data} may be present, not even empty curly braces should
-        be provided. If |read from file| is empty, the  data must directly
+        be provided. If |read from file| is empty, the data must directly
         follow as \meta{inline data}.
         %
 \begin{codeexample}[code only]
@@ -459,7 +459,7 @@ Let us now have a look at how |\pgfdata| works.
     \begin{itemize}
         \item In case you have specified an external source, the data
             visualization object is told (by means of invoking the |add data|
-            method) that it should (later) read data from  the file specified
+            method) that it should (later) read data from the file specified
             by the |source| key using the format specified by the |format| key.
             The file is not read at this point, but only later during the
             actual visualization.

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-introduction.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-introduction.tex
@@ -71,7 +71,7 @@ extra data structures need to be created.
 
 The \emph{visualization pipeline} is a series of actions that are performed on
 the to-be-visualized data. The data is presented to the visualization pipeline
-in the form of a long stream of  complex data points. The visualization
+in the form of a long stream of complex data points. The visualization
 pipeline makes several passes over this stream of data points. During the first
 pass(es), called the \emph{survey phase(s)}, information is gathered about the
 data points such as minimal and maximal values, which can be useful for

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-main.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-main.tex
@@ -351,7 +351,7 @@ picture to create pictures containing multiple data visualizations.
     to-be-read data may have a different format, but the data will be
     visualized as if it have been specified inside a single |data| command.
 
-    The behaviour of the |data| command depends on whether the \meta{inline
+    The behavior of the |data| command depends on whether the \meta{inline
     data} is present. If it is not present, the \meta{options} must be used to
     specify a source file from which the data is read; if the \meta{inline
     data} is present no file will be used, instead the data should directly

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-main.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-main.tex
@@ -372,7 +372,7 @@ picture to create pictures containing multiple data visualizations.
   data [read from file=file2.csv];
 \end{codeexample}
         %
-        The other way round, if |read from file| is empty, the  data must
+        The other way round, if |read from file| is empty, the data must
         directly follow as \meta{inline data}.
         %
 \begin{codeexample}[code only]

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-main.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-main.tex
@@ -45,8 +45,8 @@ In order to visualize, you basically need to do three things:
 \end{enumerate}
 
 The syntax of the |\datavisualization| command is designed in such a way that
-if you only need to provide very few options to create plots that ``look good
-by default''.
+you only need to provide very few options to create plots that ``look good by
+default''.
 
 This section is structured as follows: First, the philosophy behind concepts
 like ``data points'', ``axes'', or ``visualizers'' is explained. Each of these

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-stylesheets.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-stylesheets.tex
@@ -3110,7 +3110,7 @@ data group {function classes};
     less space inside the data visualization than next to it. Also, the
     legend's node is filled in white by default to ensures that the legend is
     clearly legible even in the presence of, say, a grid or data points behind
-    it. This behaviour is triggered by the following style key:
+    it. This behavior is triggered by the following style key:
 
     \begin{stylekey}{/tikz/data visualization/legend options/every legend inside}
         Executed the keys |opaque| by default and sets the text size to the

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-stylesheets.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-stylesheets.tex
@@ -3113,7 +3113,7 @@ data group {function classes};
     it. This behaviour is triggered by the following style key:
 
     \begin{stylekey}{/tikz/data visualization/legend options/every legend inside}
-        Executed the keys |opaque| by default and sets the  text size to the
+        Executed the keys |opaque| by default and sets the text size to the
         size of footnotes.
     \end{stylekey}
 \end{key}

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-visualizers.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-visualizers.tex
@@ -391,7 +391,7 @@ data [format=function] {
         \item Additionally, plot marks can be drawn at the collected data
             points. Here, all of the options available to \tikzname\ for
             drawing plot marks are available. To configure them, all options
-            offered by \tikzname\ for  configuring marks are available such as
+            offered by \tikzname\ for configuring marks are available such as
             |mark repeat|:
             %
 \begin{codeexample}[

--- a/doc/generic/pgf/text-en/pgfmanual-en-gd-algorithm-layer.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-gd-algorithm-layer.tex
@@ -110,7 +110,7 @@ them, we have a look at the main parts of the algorithm layer:
 
 \subsection{Getting Started}
 
-In this section, a ``hello world'' example of a graph drawing algorithm  is
+In this section, a ``hello world'' example of a graph drawing algorithm is
 given, followed by an overview of the organization of the whole engine.
 
 
@@ -171,7 +171,7 @@ editor, the code could also be executed through the use of |require|.
 
 Executing the code ``just'' declares the algorithm, this is what the |declare|
 function does. Inside some internal tables, the algorithm layer will store the
-fact that a  |very simple demo layout| is now available. The algorithm layer
+fact that a |very simple demo layout| is now available. The algorithm layer
 will also communicate with the display layer through the binding layer to
 advertise this fact to the ``user''. In the case of \tikzname, this means that
 the option key |very simple demo layout| becomes available at this point and we

--- a/doc/generic/pgf/text-en/pgfmanual-en-gd-overview.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-gd-overview.tex
@@ -285,7 +285,7 @@ The documentation of the graph drawing engine is structured as follows:
 \subsection{Acknowledgements}
 
 Graph drawing in \tikzname\ began as a student's project under my supervision.
-Ren\'ee Ahrens, Olof-Joachim Frahm, Jens Kluttig, Matthias Schulz, and Stephan
+Renée Ahrens, Olof-Joachim Frahm, Jens Kluttig, Matthias Schulz, and Stephan
 Schuster wrote the first prototype of a graph drawing system inside \tikzname\
 that uses Lua\TeX\ for the implementation of graph drawing algorithms.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-gd-usage-pgf.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-gd-usage-pgf.tex
@@ -484,9 +484,9 @@ you say |orient=90| directly followed by |orient=0|, the result is that the
 Unfortunately, if keys like |tree layout| were ``just'' to select an algorithm,
 we would still need a key or some special syntax to actually start a
 (sub)layout. In early versions of the system this was exactly what people had
-to do and this was somewhat awkward. Because of this problem, the behaviour of
+to do and this was somewhat awkward. Because of this problem, the behavior of
 the layout keys in \pgfname\ (and only there, other display layers need to
-implement their own behaviour) is now a bit more involved. When you use a key
+implement their own behavior) is now a bit more involved. When you use a key
 like |tree layout| (more precisely, any key that was declared as an algorithm
 key on the algorithm layer of the graph drawing system) in any scope in
 \pgfname, the following happens:

--- a/doc/generic/pgf/text-en/pgfmanual-en-gd-usage-pgf.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-gd-usage-pgf.tex
@@ -317,7 +317,7 @@ drawing engine, while for edges a command has to be called explicitly:
             \meta{second node},
         \item |<-| indicates a directed edge from \meta{second node} to
             \meta{first node}, but with the ``additional hint'' that this is a
-            ``backward'' edge. A graph drawing algorithm may  or may not take
+            ``backward'' edge. A graph drawing algorithm may or may not take
             this hint into account.
         \item |<->| indicates a bi-directed edge between \meta{first node} and
             \meta{second node}.

--- a/doc/generic/pgf/text-en/pgfmanual-en-gd-usage-tikz.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-gd-usage-tikz.tex
@@ -46,7 +46,7 @@ this, you need to use the following command, which is defined by the
     \begin{enumerate}
         \item Check whether Lua\TeX\ can call |require| on the library file
             |pgf.gd.|\meta{name}|.library|. Lua\TeX's usual file search
-            mechanism  will search the texmf-trees in the usual manner and the
+            mechanism will search the texmf-trees in the usual manner and the
             dots in the file name get converted into directory slashes.
         \item If the above failed, try to |require| the string
             |pgf.gd.|\meta{name}.

--- a/doc/generic/pgf/text-en/pgfmanual-en-guidelines.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-guidelines.tex
@@ -59,7 +59,7 @@ In many publications, even in good journals, the authors and editors have
 obviously  invested a lot of time on the text, but seem to have spend about
 five minutes to create all of the graphics. Graphics often seem to have been
 added as an ``afterthought'' or look like a screen shot of whatever the
-authors's statistical software shows them. As will be argued later on, the
+authors' statistical software shows them. As will be argued later on, the
 graphics that programs like \textsc{gnuplot} produce by default are of poor
 quality.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-guidelines.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-guidelines.tex
@@ -18,7 +18,7 @@ The guidelines in this section come from different sources. Many of them are
 just what I would like to claim is ``common sense'', some reflect my personal
 experience (though, hopefully, not my personal preferences), some come from
 books (the bibliography is still missing, sorry) on graphic design and
-typography. The most influential source  are the brilliant books by Edward
+typography. The most influential source are the brilliant books by Edward
 Tufte. While I do not agree with everything written in these books, many of
 Tufte's arguments are so convincing that I decided to repeat them in the
 following guidelines.
@@ -56,7 +56,7 @@ creation of \emph{a first draft} of a half page graphic. Later on, I expect
 another one to two hours before the final graphic is finished.
 
 In many publications, even in good journals, the authors and editors have
-obviously  invested a lot of time on the text, but seem to have spend about
+obviously invested a lot of time on the text, but seem to have spend about
 five minutes to create all of the graphics. Graphics often seem to have been
 added as an ``afterthought'' or look like a screen shot of whatever the
 authors' statistical software shows them. As will be argued later on, the
@@ -240,7 +240,7 @@ parts of the graphics. When placing labels, stick to the following guidelines:
         large size, they also should not be obscured by lines or other text.
         This also applies to labels of lines and text \emph{behind} the
         labels.
-    \item Labels should be ``in  place''. Whenever there is enough space,
+    \item Labels should be ``in place''. Whenever there is enough space,
         labels should be placed next to the thing they label. Only if
         necessary, add a (subdued) line from the label to the labeled object.
         Try to avoid labels that only reference explanations in external
@@ -354,7 +354,7 @@ that went wrong with the 3D-bar diagram:
         height of the bars correctly. Consider the ``bad'' bar. It the number
         this bar stands for more than 20 or less? While the front of the bar
         is below the 20 line, the back of the bar (which counts) is above.
-    \item It is impossible to tell which  numbers are represented by the
+    \item It is impossible to tell which numbers are represented by the
         bars. Thus, the bars needlessly hide the information these bars are
         all about.
     \item What do the bar heights add up to? Is it 100\% or 60\%?
@@ -519,7 +519,7 @@ of things that went wrong:
         \emph{despite the fact that the percentage of Braunkohle is less than
         the percentage of Kernenergie}.
     \item The 3D-distortion gets worse for small areas. The area of
-        ``Regenerative'' somewhat larger  than the area of ``Erdgas''. The
+        ``Regenerative'' somewhat larger than the area of ``Erdgas''. The
         area of ``Wind'' is slightly smaller than the area of
         ``Mineral\"olprodukte'' \emph{although the percentage of Wind is
         nearly three times larger than the percentage of
@@ -589,7 +589,7 @@ The job of typography is to make reading the text, that is, ``absorbing'' its
 information content, as effortless as possible. For a novel, readers absorb the
 content by reading the text line-by-line, as if they were listening to someone
 telling the story. In this situation anything on the page that distracts the
-eye from  going quickly and evenly from line to line will make the text harder
+eye from going quickly and evenly from line to line will make the text harder
 to read.
 
 Now, pick up your favorite weekly magazine or newspaper and have a look at a
@@ -642,7 +642,7 @@ Here is a non-exhaustive list of things that can distract readers:
         plots. You lose data points this way and the eye is not particularly
         good at ``grouping things according to a dashing pattern''. The eye
         is \emph{much} better at grouping things according to colors.
-    \item Background patterns filling an area using  diagonal lines or
+    \item Background patterns filling an area using diagonal lines or
         horizontal and vertical lines or just dots are almost always
         distracting and, usually, serve no real purpose.
     \item Background images and shadings distract and only seldomly add

--- a/doc/generic/pgf/text-en/pgfmanual-en-guidelines.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-guidelines.tex
@@ -494,7 +494,7 @@ a pie chart in \emph{Die Zeit}, June 4th, 2005:
     \node[above right] at (Erdgas label) {Erdgas\ \ \footnotesize (59,2 kWh)};
 
     \draw (Mineral) -- (Mineral -| left border) coordinate (Mineral label);
-    \node[above right] at (Mineral label) {Mineral\"olprodukte\ \
+    \node[above right] at (Mineral label) {Mineralölprodukte\ \
       \footnotesize (9,2 kWh) \  \ \normalsize\textbf{1,6\%}};
 
     \draw (Sonstige) |- (Regenerative label -| left border) coordinate (Sonstige label);
@@ -519,11 +519,10 @@ of things that went wrong:
         \emph{despite the fact that the percentage of Braunkohle is less than
         the percentage of Kernenergie}.
     \item The 3D-distortion gets worse for small areas. The area of
-        ``Regenerative'' somewhat larger than the area of ``Erdgas''. The
-        area of ``Wind'' is slightly smaller than the area of
-        ``Mineral\"olprodukte'' \emph{although the percentage of Wind is
-        nearly three times larger than the percentage of
-        Mineral\"olprodukte.}
+        ``Regenerative'' somewhat larger than the area of ``Erdgas''. The area
+        of ``Wind'' is slightly smaller than the area of ``Mineralölprodukte''
+        \emph{although the percentage of Wind is nearly three times larger than
+        the percentage of Mineralölprodukte.}
 
         In the last case, the different sizes are only partly due to
         distortion. The designer(s) of the original graphic have also made

--- a/doc/generic/pgf/text-en/pgfmanual-en-installation.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-installation.tex
@@ -104,9 +104,9 @@ three different |texmf| trees:
 \begin{itemize}
     \item The root |texmf| tree, which is usually located at
         |/usr/share/texmf/| or |c:\texmf\| or somewhere similar.
-    \item The local  |texmf| tree, which is usually located at
+    \item The local |texmf| tree, which is usually located at
         |/usr/local/share/texmf/| or |c:\localtexmf\| or somewhere similar.
-    \item Your personal  |texmf| tree, which is usually located in your home
+    \item Your personal |texmf| tree, which is usually located in your home
         directory at |~/texmf/| or |~/Library/texmf/|.
 \end{itemize}
 
@@ -141,7 +141,7 @@ package easy, it is not \textsc{tds}-compliant. If you want to be
 \textsc{tds}-compliant.)
 
 The |.tar| file of the |pgf| package contains the following files and
-directories at its root: |README|, |doc|,  |generic|, |plain|, and |latex|. You
+directories at its root: |README|, |doc|, |generic|, |plain|, and |latex|. You
 should ``merge'' each of the four directories with the following directories
 |texmf/doc|, |texmf/tex/generic|, |texmf/tex/plain|, and |texmf/tex/latex|. For
 example, in the |.tar| file the |doc| directory contains just the directory

--- a/doc/generic/pgf/text-en/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-introduction.tex
@@ -217,12 +217,12 @@ can be left out.
 The bulk of the \pgfname\ system and its documentation was written by Till
 Tantau. A further member of the main team is Mark Wibrow, who is responsible,
 for example, for the \pgfname\ mathematical engine, many shapes, the decoration
-engine, and matrices. The third member is Christian Feuers\"anger who
-contributed the floating point library, image externalization, extended key
-processing, and automatic hyperlinks in the manual.
+engine, and matrices. The third member is Christian Feuersänger who contributed
+the floating point library, image externalization, extended key processing, and
+automatic hyperlinks in the manual.
 
 Furthermore, occasional contributions have been made by Christophe Jorssen,
-Jin-Hwan Cho, Olivier Binda, Matthias Schulz, Ren\'ee Ahrens, Stephan Schuster,
+Jin-Hwan Cho, Olivier Binda, Matthias Schulz, Renée Ahrens, Stephan Schuster,
 and Thomas Neumann.
 
 Additionally, numerous people have contributed to the \pgfname\ system by
@@ -253,7 +253,7 @@ When you need help with \pgfname\ and \tikzname, please do the following:
     \item \emph{As a last resort} you can try to email me (Till Tantau) or,
         if the problem concerns the mathematical engine, Mark Wibrow. I do
         not mind getting emails, I simply get way too many of them. Because
-        of this, I cannot guarantee that your emails will be answered in a 
+        of this, I cannot guarantee that your emails will be answered in a
         timely fashion or even at all. Your chances that your problem will
         be fixed are somewhat higher if you mail to the \pgfname\ mailing
         list (naturally, I read this list and answer questions when I have

--- a/doc/generic/pgf/text-en/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-introduction.tex
@@ -60,7 +60,7 @@ It turns out that there are actually \emph{two} layers below \tikzname:
         headaches to everyone who wants to create graphics in a portable way.
         \pgfname's system layer ``abstracts away'' these differences. For
         example, the system command |\pgfsys@lineto{10pt}{10pt}| extends the
-        current path  to the coordinate $(10\mathrm{pt},10\mathrm{pt})$ of
+        current path to the coordinate $(10\mathrm{pt},10\mathrm{pt})$ of
         the current |{pgfpicture}|. Depending on whether |dvips|, |dvipdfm|,
         or |pdftex| is used to process the document, the system command will
         be converted to different |\special| commands. The system layer is as
@@ -106,8 +106,8 @@ you access to all features of \pgfname, but it is intended to be easy to use.
 The syntax is a mixture of \textsc{metafont} and \textsc{pstricks} and some
 ideas of myself. There are other frontends besides \tikzname, but they are intended
 more as ``technology studies'' and less as serious alternatives to
-\tikzname. In particular, the |pgfpict2e| frontend   reimplements the standard
-\LaTeX\ |{picture}|  environment and commands like |\line| or |\vector| using
+\tikzname. In particular, the |pgfpict2e| frontend reimplements the standard
+\LaTeX\ |{picture}| environment and commands like |\line| or |\vector| using
 the \pgfname\ basic layer. This layer is not really ``necessary'' since the
 |pict2e.sty| package does at least as good a job at reimplementing the
 |{picture}| environment. Rather, the idea behind this package is to have a

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-3d.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-3d.tex
@@ -85,7 +85,7 @@
 \subsection{Coordinate Planes}
 
 Sometimes drawing with full three dimensional coordinates is not necessary and
-it suffices to draw in two dimensions but in a different coordinate plane.  The
+it suffices to draw in two dimensions but in a different coordinate plane. The
 following options help you to switch to a different plane.
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-3d.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-3d.tex
@@ -85,7 +85,7 @@
 \subsection{Coordinate Planes}
 
 Sometimes drawing with full three dimensional coordinates is not necessary and
-it suffices to draw in two dimensions but in a different coordinate plane. The
+it suffices to draw in two dimensions but in a different coordinate plane.  The
 following options help you to switch to a different plane.
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-automata.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-automata.tex
@@ -202,7 +202,7 @@ now two options: First, |accepting by arrow|, which works the same way as
 |accepting by double|, where accepting states get a double line around them.
 
 \begin{stylekey}{/tikz/accepting (initially accepting by double)}
-    This style is used to draw accepting states. You can replace this by the
+    This style is used to draw accepting states.  You can replace this by the
     style |accepting by arrow| to get accepting states with an arrow leaving
     them.
 \end{stylekey}

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-automata.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-automata.tex
@@ -202,7 +202,7 @@ now two options: First, |accepting by arrow|, which works the same way as
 |accepting by double|, where accepting states get a double line around them.
 
 \begin{stylekey}{/tikz/accepting (initially accepting by double)}
-    This style is used to draw accepting states.  You can replace this by the
+    This style is used to draw accepting states. You can replace this by the
     style |accepting by arrow| to get accepting states with an arrow leaving
     them.
 \end{stylekey}

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-calendar.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-calendar.tex
@@ -131,11 +131,11 @@ say, the |\draw| command).
     \end{key}
     %
     \begin{key}{/tikz/month xshift=\meta{dimension}}
-        Specifies an additional  horizontal shift between different months.
+        Specifies an additional horizontal shift between different months.
     \end{key}
     %
     \begin{key}{/tikz/month yshift=\meta{dimension}}
-        Specifies an additional  vertical shift between different months.
+        Specifies an additional vertical shift between different months.
         %
 \begin{codeexample}[preamble={\usetikzlibrary{calendar}}]
 \tikz \calendar[dates=2000-01-01 to 2000-02-last,week list,
@@ -727,7 +727,7 @@ labels:
 \begin{stylekey}{/tikz/month label left}
     Places the month label to the left of the first day of the month. (For
     |week list| and |month list| where a month does not start on a Monday, the
-    position is chosen ``as if'' the month had started on a Monday --  which is
+    position is chosen ``as if'' the month had started on a Monday -- which is
     usually exactly what you want.)
     %
 \begin{codeexample}[preamble={\usetikzlibrary{calendar}}]

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-circuits.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-circuits.tex
@@ -1471,9 +1471,8 @@ Let us begin with the base library that defines the handling of inputs.
 
 An \emph{electrical engineering circuit} contains symbols like resistors or
 capacitors or voltage sources and annotations like the two arrows pointing
-toward an element whose behaviour is light dependent. The electrical
-engineering libraries, abbreviated ee-libraries, provide such symbols and
-annotations.
+toward an element whose behavior is light dependent. The electrical engineering
+libraries, abbreviated ee-libraries, provide such symbols and annotations.
 
 Just as for logical gates, there are different ways of drawing ee-symbols.
 Currently, there is one main library for drawing circuits, which uses the

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-circuits.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-circuits.tex
@@ -949,7 +949,7 @@ to use one of the following libraries, instead:
 
 \begin{tikzlibrary}{circuits.logic.IEC}
     This library provides graphics based on gates recommended by the
-    International Electrotechnical Commission.  When you include this library,
+    International Electrotechnical Commission. When you include this library,
     you can use the following key to set up a scope that contains a logical
     circuit where the gates are shown in this style.
 
@@ -1028,7 +1028,7 @@ set and gate graphic = and gate US graphic
 
 \begin{tikzlibrary}{circuits.logic.CDH}
     This library provides graphics based on the logic symbols used in A. Croft,
-    R. Davidson, and M. Hargreaves (1992),  \emph{Engineering Mathematics},
+    R. Davidson, and M. Hargreaves (1992), \emph{Engineering Mathematics},
     Addison-Wesley, 82--95. They are identical to the US-style symbols, except
     for the and- and nand-gates.
 
@@ -1660,7 +1660,7 @@ Section~\ref{section-circuits-annotations}.
     \begin{enumerate}
         \item You can use keys like |red| to change the appearance of this
             annotation, locally.
-        \item You can use keys like |<-|  or |-latex| to change the direction
+        \item You can use keys like |<-| or |-latex| to change the direction
             and kinds of arrows used in the annotation.
         \item You can use info labels like |ohm=5| or |info=foo| inside the
             \meta{options}. These info labels will be added to the main node

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-circuits.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-circuits.tex
@@ -949,7 +949,7 @@ to use one of the following libraries, instead:
 
 \begin{tikzlibrary}{circuits.logic.IEC}
     This library provides graphics based on gates recommended by the
-    International Electrotechnical Commission. When you include this library,
+    International Electrotechnical Commission.  When you include this library,
     you can use the following key to set up a scope that contains a logical
     circuit where the gates are shown in this style.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
@@ -1610,7 +1610,7 @@ shapes. This library is included mostly for historical reasons, using the
     \begin{key}{/pgf/decoration/text=\marg{text}}
         Set the text this decoration will use. Braces can be used to group
         multiple characters together, or commands that should not be expanded
-        until they are typset, for example |gr{\"o}{\ss}eren|. You should
+        until they are typeset, for example |gr{\"o}{\ss}eren|. You should
         \emph{not} use the formatting delimiters or math mode characters that
         the |text along path| decoration supports.
     \end{key}

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
@@ -2048,7 +2048,7 @@ shapes. This library is included mostly for historical reasons, using the
         restarted each time the text is repeated. Secondly, the options for
         alignment, scaling or fitting the text to the path, fitting the path to
         the text, and so on, are computed using the decoration text before the
-        decoration starts. If any of these options are given the behaviour of
+        decoration starts. If any of these options are given the behavior of
         the |repeat text| key is undefined, but typically it will be ignored.
         %
 \begin{codeexample}[preamble={\usetikzlibrary{decorations.text}}]

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
@@ -1063,7 +1063,7 @@ shapes. This library is included mostly for historical reasons, using the
     decorate a path. The following options are common options used by the
     decorations in this library:
 
-    \begin{key}{/pgf/decoration/shape width=\meta{dimension}  (initially 2.5pt)}
+    \begin{key}{/pgf/decoration/shape width=\meta{dimension} (initially 2.5pt)}
         The desired width of the shapes. For decorations that support varying
         shape sizes, this key sets both the start and end width (which can be
         overwritten using options like |shape start width|).
@@ -1131,7 +1131,7 @@ shapes. This library is included mostly for historical reasons, using the
     Please note that the background path of the shapes is used, but \emph{no
     nodes are created}. This means that \emph{you cannot have text inside the
     shapes of this path, you cannot name them, or refer to them.} Finally, this
-    decoration \emph{will not work with shapes that depend  strongly on the
+    decoration \emph{will not work with shapes that depend strongly on the
     size of the text box (like the arrow shapes).} If any of these restrictions
     pose a problem, use the |markings| library instead.
     %
@@ -1182,7 +1182,7 @@ shapes. This library is included mostly for historical reasons, using the
     so that it has the desired size (which may vary as we travel along the
     to-be-decorated path). This means that settings involving angles and
     distances may not appear entirely accurate. More general options such as
-    |inner sep| and |minimum size| will be ignored,  but transformations can be
+    |inner sep| and |minimum size| will be ignored, but transformations can be
     applied to each segment as described below.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{decorations.shapes,shapes.geometric}}]
@@ -1208,7 +1208,7 @@ shapes. This library is included mostly for historical reasons, using the
         Set the spacing between the shapes on the decorations path. This can be
         just a distance on its own, but the additional keywords
         |between centers|, and |between borders| (which must be preceded by a
-        comma), specify that the distance  is between the center anchors of the
+        comma), specify that the distance is between the center anchors of the
         shapes or between the edges of the \emph{boundaries} of the shape
         borders.
         %
@@ -1395,9 +1395,9 @@ shapes. This library is included mostly for historical reasons, using the
         \item It is only possible to typeset text in math mode under
             considerable restrictions. Math mode is entered and exited using
             any character of category code 3 (e.g., in plain \TeX{} this is |$|). %$
-            Math subscripts and superscripts need to be  contained within
+            Math subscripts and superscripts need to be contained within
             braces (e.g., |{^y_i}|) as do commands like |\times| or |\cdot|.
-            However, even modestly complex mathematical  typesetting is
+            However, even modestly complex mathematical typesetting is
             unlikely to be successful along a path (or even desirable).
         \item Some inaccuracies in positioning may be particularly apparent at
             input segment boundaries. This can (unfortunately) only be solved
@@ -1455,7 +1455,7 @@ shapes. This library is included mostly for historical reasons, using the
         formatting commands. If \meta{after} is empty, then \meta{before} will
         be used for both delimiters. In general you should stick to characters
         whose category codes are |11| or |12|. As |+| is used to indicate that
-        the specified format commands are added  to any existing ones, you
+        the specified format commands are added to any existing ones, you
         should avoid using |+| as a delimiter.
         %
 \begin{codeexample}[preamble={\usetikzlibrary{decorations.text}}]
@@ -1469,7 +1469,7 @@ shapes. This library is included mostly for historical reasons, using the
     \end{key}
 }
 
-    \begin{key}{/pgf/decoration/text color=\meta{color}  (initially black)}
+    \begin{key}{/pgf/decoration/text color=\meta{color} (initially black)}
         The color of the text.
     \end{key}
 
@@ -1612,7 +1612,7 @@ shapes. This library is included mostly for historical reasons, using the
         multiple characters together, or commands that should not be expanded
         until they are typset, for example |gr{\"o}{\ss}eren|. You should
         \emph{not} use the formatting delimiters or math mode characters that
-        the |text along path| decoration  supports.
+        the |text along path| decoration supports.
     \end{key}
 
     \begin{key}{/pgf/decoration/text align=\meta{align}}

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-edges.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-edges.tex
@@ -156,7 +156,7 @@ this curve looks can be influenced via a number of options.
 \end{codeexample}
     \end{key}
 
-    \begin{key}{/tikz/bend right=\meta{angle} (default \normalfont last  value)}
+    \begin{key}{/tikz/bend right=\meta{angle} (default \normalfont last value)}
         Works like the |bend left| option, only the bend is to the other side.
     \end{key}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex
@@ -22,7 +22,7 @@
     feature for \tikzname\ pictures. Its purpose is to convert each picture to
     a separate \pdf\ without changing the document as such.
 
-    It also externalizes |\label|  information (and other aux file related
+    It also externalizes |\label| information (and other aux file related
     stuff) using auxiliary files.
 \end{tikzlibrary}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-external.tex
@@ -49,7 +49,7 @@ The purpose of this library is to provide a way to export any \tikzname-picture
 to separate \pdf\ (or \eps) images without changing the main document. It is
 actually a simple user interface to the |\beginpgfgraphicnamed| $\dotsc$
 |\endpgfgraphicnamed| framework of \pgfname\ which is discussed in
-section~\ref{section-external}.
+Section~\ref{section-external}.
 
 
 \subsection{Requirements}
@@ -158,10 +158,10 @@ such a file to environments where \pgfname\ is not available.
     It is also possible to write |\tikzexternalize|\marg{main job name} if the
     argument is delimited by curly braces. This case is mainly for backwards
     compatibility and is no longer necessary. Since it might be useful in rare
-    circumstances, it is documented in section~\ref{sec:external:detail}.
+    circumstances, it is documented in Section~\ref{sec:external:detail}.
 
     A detailed description about the process of externalization is provided in
-    section~\ref{sec:external:detail}.
+    Section~\ref{sec:external:detail}.
 
     \begin{command}{\tikzexternalrealjob}
         After the library is loaded, this macro will \emph{always} contain the
@@ -325,7 +325,7 @@ filenames:
 
     Please note that |\tikzsetexternalprefix| is the \emph{only} way to assign
     a prefix in case you want to prepare your document for environments where
-    \pgfname\ is not installed (see section~\ref{section-libs-external-nopgf}).
+    \pgfname\ is not installed (see Section~\ref{section-libs-external-nopgf}).
 \end{command}
 
 \begin{command}{\tikzsetnextfilename\marg{file name}}
@@ -630,7 +630,7 @@ pdflatex -shell-escape main
     This file is not used by \TeX\ anymore, its purpose is to issue the
     required conversion commands |pdflatex -jobname |\marg{picture file name}
     \marg{main file} manually (or in a script). See
-    section~\ref{sec:external:detail} for the details about the expected system
+    Section~\ref{sec:external:detail} for the details about the expected system
     call (or activate |mode=convert with system call| and inspect your log
     file).
     %
@@ -1062,7 +1062,7 @@ command to the |system call| option.
 Alternatively, you can use |latex| and |dvips| for image conversion as is
 explained for the |system call| option, see
 page~\pageref{extlib:systemcall:option}. See the documentation for the basic
-level externalization in section~\ref{section-external} for restrictions of
+level externalization in Section~\ref{section-external} for restrictions of
 other drivers.
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-fadings.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-fadings.tex
@@ -13,7 +13,7 @@
 
 \begin{pgflibrary}{fadings}
     The package defines a number of fadings, see
-    Section~\ref{section-tikz-transparency} for an introduction.  The
+    Section~\ref{section-tikz-transparency} for an introduction. The
     \tikzname\ version defines special \tikzname\ commands for creating
     fadings. These commands are explained in
     Section~\ref{section-tikz-transparency}.

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-fadings.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-fadings.tex
@@ -13,7 +13,7 @@
 
 \begin{pgflibrary}{fadings}
     The package defines a number of fadings, see
-    Section~\ref{section-tikz-transparency} for an introduction. The
+    Section~\ref{section-tikz-transparency} for an introduction.  The
     \tikzname\ version defines special \tikzname\ commands for creating
     fadings. These commands are explained in
     Section~\ref{section-tikz-transparency}.

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-fpu.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-fpu.tex
@@ -460,7 +460,7 @@ numbers and allow arbitrarily large numbers.
     to |\pgfmathresult|.
 
     The desired precision can be configured with
-    |/pgf/number format/precision|, see section~\ref{pgfmath-numberprinting}.
+    |/pgf/number format/precision|, see Section~\ref{pgfmath-numberprinting}.
     This section does also contain application examples.
 
     Any trailing zeros after the period are discarded. The algorithm is purely
@@ -516,7 +516,7 @@ numbers and allow arbitrarily large numbers.
     writes the result to |\pgfmathresult|.
 
     The desired precision can be configured with
-    |/pgf/number format/precision|, see section~\ref{pgfmath-numberprinting}.
+    |/pgf/number format/precision|, see Section~\ref{pgfmath-numberprinting}.
 
     This method employs |\pgfmathroundto| to round the mantissa and applies
     renormalization if necessary.

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-math.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-math.tex
@@ -269,12 +269,12 @@ following keyword.
 \tikz\draw (\c) -- (\d);
 \end{codeexample}
 
-    In addition to assigning the $x$ and $y$ coordinates to \meta{variable}
+    In addition to assigning the $x$- and $y$-coordinates to \meta{variable}
     (possibly with an optional index), two further variables are defined. The
     first takes the name of \meta{variable} (e.g., |\c|) suffixed with |x|
-    (i.e., |\cx|) and is assigned the $x$ coordinate of |\c|. The second takes
+    (i.e., |\cx|) and is assigned the $x$-coordinate of |\c|. The second takes
     the name of \meta{variable} suffixed with |y| (i.e., |\cy|) and is assigned
-    the $y$ coordinate of |\c|.
+    the $y$-coordinate of |\c|.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{math}}]
 \tikzmath{

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-math.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-math.tex
@@ -43,7 +43,7 @@ For most purposes, the features provided by this library are accessed using the
 following command:
 
 \begin{command}{\tikzmath\texttt{\{}\meta{statements}\texttt{\}}}
-    This command process  a series of \meta{statements} which can represent
+    This command process a series of \meta{statements} which can represent
     assignments, function definitions, conditional evaluation, and iterations.
     It provides, in effect, a miniature mathematical language to perform basic
     mathematical operations. Perhaps the most important thing to remember is
@@ -180,7 +180,7 @@ the following keyword:
 \subsection{Integers, ``Real'' Numbers, and Coordinates}
 
 By default, assignments are made by evaluating expressions using the \pgfname\
-math-engine and results  are usually returned as number with a decimal point
+math-engine and results are usually returned as number with a decimal point
 (unless you are assigning to a count register or use the |int| function).
 %
 As this is not always desirable, the |math| library allows variables -- which
@@ -190,7 +190,7 @@ real numbers (numbers with a decimal point\footnote{Strictly speaking, due to
 the finite range and precision of \TeX\ numerical capabilities, the term
 ``real'' is not correct.}), and coordinates.
 
-To declare a variable as being one of the three types, you  can use the
+To declare a variable as being one of the three types, you can use the
 keywords shown below. It is important to remember that by telling the |math|
 library you want it to do a particular assignment for a variable, it will also
 do the same assignment when the variable is indexed.
@@ -450,7 +450,7 @@ options. Firstly, the following keyword can be used:
     %
 \end{math-keyword}
 
-Secondly, if a statement begins with  a brace |{|, then everything up to the
+Secondly, if a statement begins with a brace |{|, then everything up to the
 closing brace |}| is collected and executed (the closing brace \emph{must} be
 followed by a semi-colon). Like the |print| keyword, the contents of the braces
 is executed inside a \TeX\ group. Unlike the |print| keyword, the brace

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-matrices.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-matrices.tex
@@ -29,7 +29,7 @@ typesetting such matrices.
     of each cell and sets the |anchor| of the node to |base|. Furthermore, it
     adds the option |name| option to each node, where the name is set to
     \meta{matrix name}|-|\meta{row number}|-|\meta{column number}. For
-    example, if the matrix has the name |my matrix|, then the node in  the
+    example, if the matrix has the name |my matrix|, then the node in the
     upper left cell will get the name |my matrix-1-1|.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{matrix}}]

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-mindmaps.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-mindmaps.tex
@@ -70,7 +70,7 @@ is used. This style installs some internal settings.
 
     \paragraph{Remark:}
     Note that |mindmap| redefines |font| sizes and |sibling angle| depending on
-    the current concept level (i.e. inside of |level 1 concept|,
+    the current concept level (i.e.\ inside of |level 1 concept|,
     |level 2 concept| etc.). Thus, if you need to redefine these variables, use
 
     |level 1 concept/.append style={font=\small}|

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-mindmaps.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-mindmaps.tex
@@ -420,7 +420,7 @@ to-path that performs the necessary computations for you.
 In a mindmap we sometimes want colors to change from one concept color to
 another. Then, the connection bar should, ideally, consist of a smooth
 transition between these two colors. Getting this right using shadings is a bit
-tricky if you try this ``by hand'', so the  |mindmap| library provides a
+tricky if you try this ``by hand'', so the |mindmap| library provides a
 special option for facilitating this procedure.
 
 \begin{key}{/tikz/circle connection bar switch color=|from (|\meta{first color}|) to (|\meta{second color}|)|}

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-patterns.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-patterns.tex
@@ -150,7 +150,7 @@ future.
     %
     \begin{key}{/pgf/patterns/tile size=\meta{pgfpoint}}
         Width and height of a single of the pattern as a \pgfname\ point
-        specification, i.e. the $x$ coordinate is the width and the $y$
+        specification, i.e. the $x$-coordinate is the width and the $y$
         coordinate is the height, e.g.\ |\pgfqpoint{3pt}{3pt}|.
     \end{key}
     %

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-patterns.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-patterns.tex
@@ -150,7 +150,7 @@ future.
     %
     \begin{key}{/pgf/patterns/tile size=\meta{pgfpoint}}
         Width and height of a single of the pattern as a \pgfname\ point
-        specification, i.e. the $x$-coordinate is the width and the $y$
+        specification, i.e.\ the $x$-coordinate is the width and the $y$
         coordinate is the height, e.g.\ |\pgfqpoint{3pt}{3pt}|.
     \end{key}
     %

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-perspective.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-perspective.tex
@@ -190,7 +190,6 @@ projection.
 
     To turn off the perspective in $x$-direction, one must set the $x$ component
     of |p| to \texttt{0} (e.g.\ |p={(0,a,b)}|, where \texttt{a} and \texttt{b}
-
     can be any number and will be ignored). Or one can provide |q| and |r| and
     omit |p|.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-perspective.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-perspective.tex
@@ -189,7 +189,7 @@ projection.
     direction is turned off.
 
     To turn of the perspective in $x$-direction, one must set the $x$ component
-    of |p| to \texttt{0} (e.g. |p={(0,a,b)}|, where \texttt{a} and \texttt{b}
+    of |p| to \texttt{0} (e.g.\ |p={(0,a,b)}|, where \texttt{a} and \texttt{b}
     can be any number and will be ignored). Or one can provide |q| and |r| and
     omit |p|.
 
@@ -276,8 +276,8 @@ The issues include, but possibly are not limited to:
     \item Keys like |rotate around x|, |rotate around y|, and |rotate around z|
       are not working
     \item Units are not working
-    \item Most keys from the |3d| library are unsupported, e.g. all the
-      |canvas is .. plane| keys.
+    \item Most keys from the |3d| library are unsupported, e.g.\ all the
+        |canvas is .. plane| keys.
 \end{itemize}
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-plot-handlers.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-plot-handlers.tex
@@ -652,7 +652,7 @@ bars).
     \meta{dimension}. This dimension is a ``recommendation'' for plot mark code
     at which size the plot mark should be drawn; plot mark code may choose to
     ignore this \meta{dimension} altogether. For circles, \meta{dimension}
-    should  be the radius, for other shapes it should be about half the
+    should be the radius, for other shapes it should be about half the
     width/height.
 
     The predefined plot marks all take this dimension into account.

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-rdf.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-rdf.tex
@@ -178,7 +178,7 @@ You add an \textsc{rdf} statement to the output file using the following key:
   }}] { ... }
 \end{codeexample}
 
-    The statements are normally  added at the beginning of the scope where the
+    The statements are normally added at the beginning of the scope where the
     |rdf enging| command is used (except when the |object| is |scope content|,
     which is explained later). This means that when you use |prefix| inside an
     |rdf engine| command, it will apply to all statements, regardless of the
@@ -238,7 +238,7 @@ You add an \textsc{rdf} statement to the output file using the following key:
         for each use of |predicate| for the subject and object specified inside
         the use of |statement|. This behavior is not very systematic (it
         violates the rule ``one statement per |statement|'') and you should
-        normally use the  |statement| once for each use  of the |predicate|
+        normally use the |statement| once for each use of the |predicate|
         key. However, in conjunction with the object |scope content| it is
         necessary to allow this behavior.
   \end{key}
@@ -426,7 +426,7 @@ A \emph{container} is a resource that represents a set or a sequence of
 elements. In \textsc{rdf} this is modeled by having a statement say that the
 type of the resource is something special like |rdf:Seq| and then for each
 member resource of the container add a statement saying that the container has
-as its $i$th member the  member resource. Here is an example of a container
+as its $i$th member the member resource. Here is an example of a container
 with two elements:
 %
 \begin{codeexample}[code only]

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-spy.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-spy.tex
@@ -305,7 +305,7 @@ automatically.
             \begin{key}{/tikz/spy connection path=\meta{code} (initially \normalfont empty)}
                 The \meta{code} is executed after the spy-on and spy-in nodes
                 have just been created. Inside this \meta{code}, the two nodes
-                can be accessed as |tikzspyinnode| and  |tikzspyonnode|. For
+                can be accessed as |tikzspyinnode| and |tikzspyonnode|. For
                 example, the key |connect spies| sets this command to
                 %
 \begin{codeexample}[code only]

--- a/doc/generic/pgf/text-en/pgfmanual-en-math-commands.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-math-commands.tex
@@ -34,7 +34,7 @@ the following command is provided:
 
 In addition to the commands described in
 Section~\ref{pgfmath-functions-comparison}, the following command was provided
-by Christian Feuers\"anger:
+by Christian Feuersänger:
 
 \begin{command}{\pgfmathapproxequalto\marg{x}\marg{y}}
     Defines |\pgfmathresult| 1.0 if $ \rvert \meta{x} - \meta{y} \lvert <

--- a/doc/generic/pgf/text-en/pgfmanual-en-math-numberprinting.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-math-numberprinting.tex
@@ -37,7 +37,7 @@ precision.
 \pgfmathprintnumber{123456.12345}
 \end{codeexample}
 
-    See section~\ref{sec:number:styles} for how to change the appearance.
+    See Section~\ref{sec:number:styles} for how to change the appearance.
 \end{key}
 
 \begin{key}{/pgf/number format/fixed zerofill=\marg{boolean}  (default true)}
@@ -64,7 +64,7 @@ precision.
 \pgfmathprintnumber{123456.12345}
 \end{codeexample}
 
-    See section~\ref{sec:number:styles} for how to change the appearance.
+    See Section~\ref{sec:number:styles} for how to change the appearance.
 \end{key}
 
 \begin{key}{/pgf/number format/sci}
@@ -81,7 +81,7 @@ precision.
 \pgfmathprintnumber{123456.12345}
 \end{codeexample}
 
-    See section~\ref{sec:number:styles} for how to change the exponential
+    See Section~\ref{sec:number:styles} for how to change the exponential
     display style.
 \end{key}
 
@@ -100,7 +100,7 @@ precision.
     As with |fixed zerofill|, this option does only affect numbers drawn in
     |sci| format (or |std| if the scientific format is chosen).
 
-    See section~\ref{sec:number:styles} for how to change the exponential
+    See Section~\ref{sec:number:styles} for how to change the exponential
     display style.
 \end{key}
 
@@ -290,7 +290,7 @@ precision.
     |fixed relative| ``rounds from the left'': it takes the \emph{first}
     non-zero digit, temporarily places the period after this digit, and rounds
     that number. The rounding style |fixed| leaves the period where it is, and
-    rounds everything behind that digit. The |sci| style is similar to 
+    rounds everything behind that digit. The |sci| style is similar to
     |fixed relative|.
 \end{keylist}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-math-parsing.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-math-parsing.tex
@@ -108,7 +108,7 @@ mathematical engine is the following:
     according to the value in |\pgfmathresultunitscale| (which by default was
     |1|).
 
-    This scaling can be  turned on again using:
+    This scaling can be turned on again using:
     |\let\pgfmathpostparse=\pgfmathscaleresult|. Note, however that by scaling
     the result, the base conversion functions will not work, and the |"|
     character should not be used to quote parts of an expression.
@@ -184,7 +184,7 @@ scope.
 \end{command}
 
 \begin{command}{\pgfmathaddtocount\marg{count register}\marg{expression}}
-    Adds the \emph{truncated} value  of \meta{expression} to the \TeX{}
+    Adds the \emph{truncated} value of \meta{expression} to the \TeX{}
     \meta{count register}.
 \end{command}
 
@@ -194,11 +194,11 @@ scope.
 \end{command}
 
 \begin{command}{\pgfmathaddtocounter\marg{counter}\marg{expression}}
-    Adds the \emph{truncated} value  of \meta{expression} to \meta{counter}.
+    Adds the \emph{truncated} value of \meta{expression} to \meta{counter}.
 \end{command}
 
 \begin{command}{\pgfmathsetmacro\marg{macro}\marg{expression}}
-    Defines \meta{macro} as the  value of \meta{expression}. The result is a
+    Defines \meta{macro} as the value of \meta{expression}. The result is a
     decimal without units.
 \end{command}
 
@@ -225,7 +225,7 @@ For this, you can use the following commands:
 
 {\let\ifpgfmathunitsdeclared\relax
   \begin{command}{\ifpgfmathunitsdeclared}
-    After a call  of |\pgfmathparse| this if will be true exactly if
+    After a call of |\pgfmathparse| this if will be true exactly if
     some unit was encountered in the expression. It is always set
     globally in each call.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-module-parser.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-module-parser.tex
@@ -228,7 +228,7 @@ There are \the\mycount\ a's.
 \begin{command}{\pgfparserset\marg{key list}}%
   The |pgfparser| module has a few keys you can access through this macro. It
   is just a shortcut for |\pgfset{/pgfparser/.cd,#1}|. The available keys are
-  listed in subsection~\ref{sec:parser:keys}.
+  listed in Section~\ref{sec:parser:keys}.
 \end{command}%
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-oo.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-oo.tex
@@ -37,7 +37,7 @@ it only for non-time-critical things.
 Basically, the oo-system supports \emph{classes} (in the object-oriented sense,
 this has nothing to do with \LaTeX-classes), \emph{methods},
 \emph{constructors}, \emph{attributes}, \emph{objects}, \emph{object
-identities}, and (thanks to Sa\v o \v Zivanovi\'c) \emph{inheritance} and
+identities}, and (thanks to Saǒ Živanović) \emph{inheritance} and
 \emph{overloading.}
 
 The first step is to define a class, using the macro |\pgfooclass| (all normal

--- a/doc/generic/pgf/text-en/pgfmanual-en-oo.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-oo.tex
@@ -38,7 +38,6 @@ Basically, the oo-system supports \emph{classes} (in the object-oriented sense,
 this has nothing to do with \LaTeX-classes), \emph{methods},
 \emph{constructors}, \emph{attributes}, \emph{objects}, \emph{object
 identities}, and (thanks to Sašo Živanović) \emph{inheritance} and
-
 \emph{overloading.}
 
 The first step is to define a class, using the macro |\pgfooclass| (all normal

--- a/doc/generic/pgf/text-en/pgfmanual-en-pages.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pages.tex
@@ -452,7 +452,7 @@ are used to define the layout:
             has been filled.
         \item \declare{|physical height=|\meta{height}} specifies the height of
             the physical pages. This height is typically different from the
-            normal  |\paperheight|, which is used by \TeX\ for its typesetting
+            normal |\paperheight|, which is used by \TeX\ for its typesetting
             and page breaking purposes.
         \item \declare{|physical width=|\meta{width}} specifies the physical
             width.
@@ -557,7 +557,7 @@ are used to define the layout:
 
             You can also call |\pgfdiscardpath| and add your own path
             construction code (for example to paint a rectangle with rounded
-            corners). The coordinate system is  set up in such a way that a
+            corners). The coordinate system is set up in such a way that a
             rectangle starting at the origin and having the height and width of
             \TeX-box 0 will result in a rectangle filling exactly the logical
             page currently being put on the physical page. The logical page is

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgffor.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgffor.tex
@@ -111,7 +111,7 @@ This section describes the package |pgffor|, which is loaded automatically by
     number such that $x + md \le z$ if $d$ is positive or such that $x+md \ge
     z$ if $d$ is negative.
 
-    Perhaps it is best to explain this by some examples:  The following
+    Perhaps it is best to explain this by some examples: The following
     \meta{list} have the same effects:
 
     |\foreach \x in {1,2,...,6} {\x, }| yields \foreach \x in {1,2,...,6} {\x, }

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -451,7 +451,7 @@ starting with |"| and one for strings starting with |<|.
 
 Naturally, in the above examples, the two handling macros did not do something
 particularly exciting. In the next example, we setup a more elaborate macro
-that mimics a small part the behaviour of the |quotes| library, only for single
+that mimics a small part the behavior of the |quotes| library, only for single
 quotes:
 %
 \begin{codeexample}[]
@@ -576,7 +576,7 @@ Section~\ref{section-code-handlers}.
     net effect of all this is that you have then set up code for the key
     \meta{key} so that when you write |\pgfkeys{|\meta{key}|=|\meta{value}|}|,
     then the \meta{code} is executed with all occurrences of |#1| in
-    \meta{code} being replaced by \meta{value}. (This behaviour is quite
+    \meta{code} being replaced by \meta{value}. (This behavior is quite
     similar to the |\define@key| command of |keyval| and |xkeyval|).
     %
 \begin{codeexample}[]

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -781,7 +781,7 @@ There are some parameters for handled keys which prove to be useful in some
 
             A consequence of this configuration is to provide more meaningful
             processing of handled keys if a search path for keys is in effect,
-            see section~\ref{sec:pgf:unknown:keys} for an example.
+            see Section~\ref{sec:pgf:unknown:keys} for an example.
         \item[\texttt{full or existing}] Finally, the choice |full or existing|
             is a variant of |only existing|: it works in the same way for keys
             which do not have a full key path. For example, the style
@@ -1525,7 +1525,7 @@ Key 4:& \pgfkeys{/key4}
 \end{codeexample}
 
     Please note that the strategy of |/.search also| is different from the
-    first example provided in section~\ref{sec:pgf:unknown:keys} ``Unknown
+    first example provided in Section~\ref{sec:pgf:unknown:keys} ``Unknown
     Keys'' because |/.search also| only applies to keys that are not fully
     qualified.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeysfiltered.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeysfiltered.tex
@@ -551,7 +551,7 @@ Furthermore, the macro |\pgfkeyscasenumber| contains the current key's type as
 an integer:
 %
 \begin{itemize}
-    \item[\meta{1}] The key is a command key (i.e. |.../.@cmd| exists).
+    \item[\meta{1}] The key is a command key (i.e.\ |.../.@cmd| exists).
     \item[\meta{2}] The key contains its value directly.
     \item[\meta{3}] The key is handled (for example it is |.code| or |.cd|).
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeysfiltered.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeysfiltered.tex
@@ -146,7 +146,7 @@ options. It works as follows.
     |/pgf/key filter handlers/append filtered to=|\meta{macro} handler.
 
     The following example uses the same settings as in the intro
-    section~\ref{section-key-filter-example}.
+    Section~\ref{section-key-filter-example}.
     %
 \begin{codeexample}[]
 \pgfkeys{/pgf/key filter handlers/append filtered to/.install key filter handler=\remainingoptions}
@@ -198,7 +198,7 @@ Remaining: `\remainingoptions'.
     You can also use |\pgfkeysinstallkeyfilter|\meta{full key}\meta{optional
     arguments}, it has the same effect.
 
-    See section~\ref{section-key-writing-filters} for how to write key filters.
+    See Section~\ref{section-key-writing-filters} for how to write key filters.
 \end{handler}
 
 \begin{handler}{{.install key filter handler}|=|\meta{optional arguments}}
@@ -211,7 +211,7 @@ Remaining: `\remainingoptions'.
     |\pgfkeysinstallkeyfilterhandler|\meta{full key}\meta{optional arguments},
     which has the same effect.
 
-    See section~\ref{section-key-writing-filters} for how to write key filter
+    See Section~\ref{section-key-writing-filters} for how to write key filter
     handlers.
 \end{handler}
 
@@ -235,7 +235,7 @@ Remaining options: `\remainingoptions'.
 \end{codeexample}
     %
     This example uses the same keys as defined in the intro
-    section~\ref{section-key-filter-example}.
+    Section~\ref{section-key-filter-example}.
 \end{key}
 
 \begin{key}{/pgf/key filter handlers/ignore}
@@ -266,7 +266,7 @@ family $O(K)$).
 
 \begin{handler}{{.is family}}
     Defines a new family. This option has already been described in
-    section~\ref{section-is family-handler} on page~\pageref{section-is
+    Section~\ref{section-is family-handler} on page~\pageref{section-is
     family-handler}.
 \end{handler}
 
@@ -280,7 +280,7 @@ family $O(K)$).
     You can also use |\pgfkeysactivatefamily|\meta{full path} to get the same
     effect. Furthermore, you can use |\pgfkeysactivatefamilies|\meta{list of
     families}\meta{macro name for de-activation} to activate a list of families
-    (see section~\ref{section-key-filter-api}).
+    (see Section~\ref{section-key-filter-api}).
 \end{handler}
 
 \begin{handler}{{.deactivate family}}

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfsys-animations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfsys-animations.tex
@@ -595,7 +595,7 @@ The following attributes influence paths and how they are rendered.
 \end{sysanimateattribute}
 
 
-\subsection{Commands for Animating an Attribute: Transformations  and Views}
+\subsection{Commands for Animating an Attribute: Transformations and Views}
 
 The commands in this section allow you to animate the canvas transformation
 matrix of a scope. However, there is one command that needs to be explained

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfsys-commands.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfsys-commands.tex
@@ -46,7 +46,7 @@ bureaucratic tasks. For this reason, every stream will start with a
     have been put in box \meta{box}. This command should insert the box into
     the normal text. The box \meta{box} will still be a ``raw'' box that
     contains only the |\special|'s that make up the description of the picture.
-    The  job of this command is to resize and shift \meta{box} according to the
+    The job of this command is to resize and shift \meta{box} according to the
     baseline shift and the size of the box.
 
     This command has a default implementation and need not be implemented by a
@@ -139,7 +139,7 @@ The scoping commands are used to keep changes of the graphics state local.
 
 \begin{command}{\pgfsys@moveto\marg{x}\marg{y}}
     This command is used to start a path at a specific point $(x,y)$ or to move
-    the current point of the current path to  $(x,y)$ without drawing anything
+    the current point of the current path to $(x,y)$ without drawing anything
     upon stroking (the current path is ``interrupted'').
 
     Both \meta{x} and \meta{y} are given as \TeX\ dimensions. It is the
@@ -168,7 +168,7 @@ The scoping commands are used to keep changes of the graphics state local.
 
 \begin{command}{\pgfsys@curveto\marg{$x_1$}\marg{$y_1$}\marg{$x_2$}\marg{$y_2$}\marg{$x_3$}\marg{$y_3$}}
     Continue the current path to $(x_3,y_3)$ with a Bézier curve that has the
-    two control points  $(x_1,y_1)$ and  $(x_2,y_2)$.
+    two control points $(x_1,y_1)$ and $(x_2,y_2)$.
 
     \example Draw a good approximation of a quarter circle:
     %
@@ -183,7 +183,7 @@ The scoping commands are used to keep changes of the graphics state local.
 
 \begin{command}{\pgfsys@rect\marg{x}\marg{y}\marg{width}\marg{height}}
     Append a rectangle to the current path whose lower left corner is at
-    $(x,y)$ and whose width and height in big points are  given by \meta{width}
+    $(x,y)$ and whose width and height in big points are given by \meta{width}
     and \meta{height}.
 
     This command can be ``mapped back'' to |\pgfsys@moveto| and
@@ -252,9 +252,9 @@ The scoping commands are used to keep changes of the graphics state local.
 \end{command}
 
 \begin{command}{\pgfsys@transformxyscale\marg{x scale}\marg{y scale}}
-    This command will scale the canvas (and  everything that is drawn) by a
+    This command will scale the canvas (and everything that is drawn) by a
     factor of \meta{x scale} in the $x$-direction and \meta{y scale} in the
-    $y$-direction. Note that this applies to everything, including  lines. So a
+    $y$-direction. Note that this applies to everything, including lines. So a
     scaled line will have a different width and may even have a different width
     when going along the $x$-axis and when going along the $y$-axis, if the
     scaling is different in these directions. Usually, you do not want this.

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-actions.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-actions.tex
@@ -1260,7 +1260,7 @@ transparency in general.
 
 If more than one of the basic actions like drawing, clipping and filling are
 requested, they are automatically applied in a sensible order: First, a path is
-filled, then drawn, and then clipped (although it took Apple two mayor
+filled, then drawn, and then clipped (although it took Apple two major
 revisions of their operating system to get this right\dots). Sometimes,
 however, you need finer control over what is done with a path. For instance,
 you might wish to first fill a path with a color, then repaint the path with a

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-actions.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-actions.tex
@@ -1088,11 +1088,11 @@ keys:
 \begin{key}{/tikz/trim left=\meta{dimension or coordinate or \texttt{default}} (default 0pt)}
     The |trim left| key tells \pgfname\space to discard everything which is
     left of the provided \meta{dimension or coordinate}. Here, \meta{dimension}
-    is a single $x$ coordinate of the picture and \meta{coordinate} is a point
-    with $x$ and $y$ coordinates (but only its $x$ coordinate will be used).
+    is a single $x$-coordinate of the picture and \meta{coordinate} is a point
+    with $x$- and $y$-coordinates (but only its $x$-coordinate will be used).
     The effect is the same as if you issue |\hspace{-s}| where |s| is the
-    difference of the picture's bounding box lower left $x$ coordinate and the
-    $x$ coordinate specified as \meta{dimension or coordinate}:
+    difference of the picture's bounding box lower left $x$-coordinate and the
+    $x$-coordinate specified as \meta{dimension or coordinate}:
     %
 \begin{codeexample}[]
 Text before image.%
@@ -1141,7 +1141,7 @@ Text after image.
 \begin{key}{/tikz/trim right=\meta{dimension or coordinate or \texttt{default}}}
     This key is similar to |trim left|: it discards everything which is right
     of the provided \meta{dimension or coordinate}. As for |trim left|,
-    \meta{dimension} denotes a single $x$ coordinate of the picture and
+    \meta{dimension} denotes a single $x$-coordinate of the picture and
     \meta{coordinate} a coordinate with $x$ and $y$ value (although only its
     $x$ component will be used).
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-actions.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-actions.tex
@@ -1212,7 +1212,7 @@ transparency in general.
 \end{tikzpicture}
 \end{codeexample}
 
-    It  is usually a \emph{very} good idea to apply the |clip| option only to
+    It is usually a \emph{very} good idea to apply the |clip| option only to
     the first path command in a scope.
 
     If you ``only wish to clip'' and do not wish to draw anything, you can use

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-animations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-animations.tex
@@ -893,7 +893,7 @@ animate = {
 }
 \end{codeexample}
 %
-Note how both in  |mynode:| and in |:opacity| and |:color| you must provide the
+Note how both in |mynode:| and in |:opacity| and |:color| you must provide the
 colon. Its presence signals that an object--attribute pair is being specified;
 only now either the object or the attribute is missing.
 
@@ -2209,7 +2209,7 @@ the moment a specific \emph{event} happens using the following key:
         animation is displayed, the output format (\textsc{svg} or some other
         format), and the setup of scripts, but here is a list of events
         supported by ``plain \textsc{svg}'': |click|, |focusin|, |focusout|,
-        |mousedown|,  |mouseup|, |mouseover|, |mousemove|, |mouseout|, |begin|,
+        |mousedown|, |mouseup|, |mouseover|, |mousemove|, |mouseout|, |begin|,
         |end|. However, the following keys make using these events simpler:
         %
         \begin{key}{/pgf/animate/events/click}
@@ -2494,7 +2494,7 @@ between the two values |50| and |100| over a time of 10\,s. The simplest way of
 doing so is to do a linear interpolation, where the value as, say, 1\,s is 55,
 at 2\,s it is 60, and so on. Unfortunately, the linear interpolation does not
 ``look'' nice in many cases since the acceleration of a linear interpolation is
-zero  during the animation, but infinite at the beginning and at the end; which
+zero during the animation, but infinite at the beginning and at the end; which
 looks ``jerky''.
 
 To avoid this, you can specify that the time--attribute curve should not be a

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
@@ -104,7 +104,7 @@ Let us start with an introduction to the basics of the |arrows| key:
     is |>|. The end specifications are |>| for the first line and |Stealth| for
     the second line. Note that it makes a difference whether |>| is used in a
     start specification or in an end specification: In an end specification it
-    creates, as one would expect, a pointed tip  at the end of the line. In the
+    creates, as one would expect, a pointed tip at the end of the line. In the
     start specification, however, it creates a ``reversed'' version if this
     arrow -- which happens to be what one would expect here.
 
@@ -1893,7 +1893,7 @@ classified in different groups:
     by the |arc| option. The |length| and |width| parameters refer to the size
     of the arrow tip for |arc| set to 180 degrees, which is why in the example
     for |arc=210| the actual length is larger than the specified |length|. The
-    line width is taken into account for the computation  of the length and
+    line width is taken into account for the computation of the length and
     width. Use the |round| option to add round caps to the end of the arcs.
 }%
 {length=1.5cm,arc=210}%

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
@@ -741,7 +741,7 @@ The following options allow you to configure how arrow tips are colored:
     known as ``stroke color'', which you can set using |draw=|\meta{some
     color}. By adding the option |color=| to an arrow tip (note that an
     ``empty'' color is specified in this way), you ask that the arrow tip gets
-    this default draw color of the path. Since this is the default behaviour,
+    this default draw color of the path. Since this is the default behavior,
     you usually do not need to specify anything:
     %
 \begin{codeexample}[width=3cm,preamble={\usetikzlibrary{arrows.meta}}]
@@ -1625,7 +1625,7 @@ done using the following handler:
     \end{quote}
     %
     then |dup| will have the effect as if you had written
-    |whatever[]whatever[]|. You will find that this behaviour is what one would
+    |whatever[]whatever[]|. You will find that this behavior is what one would
     expect.
 
     There is one problem we have not yet addressed: The asymmetry of single

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex
@@ -715,7 +715,7 @@ point $q$. For this situation there is a useful coordinate system.
     Here, you write \declare{|(|\meta{p}\verb! |- !\meta{q}|)|} or
     \declare{|(|\meta{q}\verb! -| !\meta{p}|)|}.
 
-    For example, \verb!(2,1 |- 3,4)! and  \verb!(3,4 -| 2,1)! both yield the
+    For example, \verb!(2,1 |- 3,4)! and \verb!(3,4 -| 2,1)! both yield the
     same as \verb!(2,4)! (provided the $xy$-co\-or\-di\-nate system has not
     been modified).
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex
@@ -1041,7 +1041,7 @@ which you need.
 \end{tikzpicture}
 \end{codeexample}
     %
-    If you set this key to |true|, this behaviour changes. In this case, at the
+    If you set this key to |true|, this behavior changes. In this case, at the
     end of a group created on a path, the last current position reverts to
     whatever value it had at the beginning of the scope. More precisely, when
     \tikzname\ encounters |}| on a path, it checks whether at this particular

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
@@ -714,7 +714,7 @@ written |->| between them. Then the following happens:
 %
 \begin{enumerate}
     \item The \meta{options} are executed (inside a local scope) with the path
-        |/tikz/graphs|. These options may setup the connector algorithm (see
+        |/tikz/graphs|.  These options may setup the connector algorithm (see
         below) and may also use keys like |edge| or |edge label| to specify how
         the edge should look like. As a convenience, whenever an unknown key is
         encountered for the path |/tikz/graphs|, the key is passed to the
@@ -2724,7 +2724,7 @@ work together in perfect harmony.
 \end{key}
 
 \begin{key}{/tikz/graphs/branch up=\meta{distance} (default 1)}
-    Sets the |group shift| so that groups ``branch upward''. The distance by
+    Sets the |group shift| so that groups ``branch upward''.  The distance by
     which the center of each new element is removed from the center of the
     previous one is \meta{distance}.
     %

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
@@ -714,7 +714,7 @@ written |->| between them. Then the following happens:
 %
 \begin{enumerate}
     \item The \meta{options} are executed (inside a local scope) with the path
-        |/tikz/graphs|.  These options may setup the connector algorithm (see
+        |/tikz/graphs|. These options may setup the connector algorithm (see
         below) and may also use keys like |edge| or |edge label| to specify how
         the edge should look like. As a convenience, whenever an unknown key is
         encountered for the path |/tikz/graphs|, the key is passed to the
@@ -1430,7 +1430,7 @@ large, algorithmically generated graphs.
             \end{quote}
 
             The quotation marks are mandatory. The part |/"|\meta{node text}|"|
-            may  be missing, in which case the node name is used as the node
+            may be missing, in which case the node name is used as the node
             text. The \meta{options} may also be missing. The \meta{node name}
             may not contain any ``funny'' characters (unlike in the normal
             graph command).
@@ -2337,9 +2337,9 @@ from |e| to |f|. Then, in the resulting group |e->f| the only source vertex is
 |e| and the only target vertex is |f|. This implies that in the group
 |{d,e->f}| the sources are |d| and |e| and the targets are |d| and~|f|.
 
-Now, in |{a,b,c} -> {d,e->f}| the targets  of |{a,b,c}| (which are all three of
+Now, in |{a,b,c} -> {d,e->f}| the targets of |{a,b,c}| (which are all three of
 them) are connected to the sources of |{d,e->f}| (which are just |d| and~|e|).
-Finally, in the whole graph only |a|, |b|, and |c| are sources while only  |d|
+Finally, in the whole graph only |a|, |b|, and |c| are sources while only |d|
 and |f| are targets.
 %
 \begin{codeexample}[preamble={\usetikzlibrary{graphs}}]
@@ -2724,7 +2724,7 @@ work together in perfect harmony.
 \end{key}
 
 \begin{key}{/tikz/graphs/branch up=\meta{distance} (default 1)}
-    Sets the |group shift| so that groups ``branch upward''.  The distance by
+    Sets the |group shift| so that groups ``branch upward''. The distance by
     which the center of each new element is removed from the center of the
     previous one is \meta{distance}.
     %

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
@@ -291,7 +291,7 @@ add labels to the edges easily by putting the labels in quotes:
 For the first edge, the effect is as desired, however between |b| and the group
 |{c,d}| two edges are inserted and the options |thick| and the label option
 |"bar"| is applied to both of them. While this is the correct and consistent
-behaviour, we typically might wish to specify different labels for the edge
+behavior, we typically might wish to specify different labels for the edge
 going from |b| to |c| and the edge going from |b| to |d|. To achieve this
 effect, we can no longer specify the label as part of the options of |--|.
 Rather, we must pass the desired label to the nodes |c| and |d|, but we must
@@ -339,8 +339,8 @@ created by default unless this node has already been created inside the same
 |graph| command. In particular, if a node has already been declared outside of
 the current |graph| command, a new node of the same name gets created.
 
-This is not always the desired behaviour. Often, you may wish to make nodes
-part of a graph than have already been defined prior to the use of the |graph|
+This is not always the desired behavior. Often, you may wish to make nodes part
+of a graph than have already been defined prior to the use of the |graph|
 command. For this, simply surround a node name by parentheses. This will cause
 a reference to be created to an already existing node:
 %
@@ -899,7 +899,7 @@ the node is \emph{fresh}.
 };
 \end{codeexample}
 
-This behaviour of deciding whether a node is fresh or referenced can, however,
+This behavior of deciding whether a node is fresh or referenced can, however,
 be modified by using the following keys:
 %
 \begin{key}{/tikz/graphs/use existing nodes=\opt{\meta{true or false}} (default true)}
@@ -1336,7 +1336,7 @@ several nodes have the same label.
             get created.
     \end{enumerate}
     %
-    In total, this is exactly the behaviour you would expect of a trie:
+    In total, this is exactly the behavior you would expect of a trie:
     %
 \begin{codeexample}[preamble={\usetikzlibrary{graphs}}]
 \tikz \graph [trie] {

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
@@ -243,8 +243,9 @@ Chain groups make it easy to create tree structures:
 
 As can be seen, the placement is not particularly nice by default, use the
 algorithms from the graph drawing libraries to get a better layout. For
-instance, adding |tree layout| to the above code results in the following
-somewhat more pleasing rendering:
+instance, adding |tree layout| to the above code (and
+|\usetikzlibrary{graphdrawing}| as well as |\usegdlibrary{trees}| to the
+preamble) results in the following somewhat more pleasing rendering:
 %
 \ifluatex
 \medskip

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
@@ -539,8 +539,8 @@ The \emph{arc operation} allows you to add an arc to the current path.
 \begin{pathoperation}{arc}{\oarg{options}}
     The |arc| operation adds a part of an ellipse to the current path. The
     radii of the ellipse are given by the values of |x radius| and |y radius|,
-    which should be set in the \meta{options}. The arc will start at   the
-    current point and will end at the end of the arc. The arc  will start and
+    which should be set in the \meta{options}. The arc will start at the
+    current point and will end at the end of the arc. The arc will start and
     end at angles computed from the three keys |start angle|, |end angle|, and
     |delta angle|. Normally, the first two keys specify the start and end
     angle. However, in case one of them is empty, it is computed from the other
@@ -852,7 +852,7 @@ specification for details.
     Instead of curly braces, you can also use quotation marks to indicate the
     start and end of the \textsc{svg} path.
 
-    \emph{Warning:} The arc operations (|a| and |A|) are  numerically instable.
+    \emph{Warning:} The arc operations (|a| and |A|) are numerically instable.
     This means that they will be quite imprecise, except when the angle is a
     multiple of $90^\circ$ (as is, fortunately, most often the case).
 \end{pathoperation}
@@ -1155,7 +1155,7 @@ not actually extend that path, but have different, mostly local, effects.
     |\pgfmathparse| operation. The result is stored in the \meta{number
     register}. If the \meta{formula} involves a dimension anywhere (as in
     |2*3cm/2|), then the \meta{number register} stores the resulting dimension
-    with a trailing |pt|.  A \meta{number register} can be named arbitrarily
+    with a trailing |pt|. A \meta{number register} can be named arbitrarily
     and is a normal \TeX\ parameter to the |\n| macro. Possible names are
     |{left corner}|, but also just a single digit like~|5|.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
@@ -1155,7 +1155,7 @@ not actually extend that path, but have different, mostly local, effects.
     |\pgfmathparse| operation. The result is stored in the \meta{number
     register}. If the \meta{formula} involves a dimension anywhere (as in
     |2*3cm/2|), then the \meta{number register} stores the resulting dimension
-    with a trailing |pt|. A \meta{number register} can be named arbitrarily
+    with a trailing |pt|.  A \meta{number register} can be named arbitrarily
     and is a normal \TeX\ parameter to the |\n| macro. Possible names are
     |{left corner}|, but also just a single digit like~|5|.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
@@ -1396,7 +1396,7 @@ During construction \tikzname\ stores the path internally as a \emph{soft
 path}. Sometimes it is desirable to save a path during the stage of
 construction, restore it elsewhere and continue using it. There are two keys to
 facilitate this operation, which are explained below. To learn more about the
-soft path subsystem, refer to section~\ref{section-soft-paths}.
+soft path subsystem, refer to Section~\ref{section-soft-paths}.
 
 \begin{key}{/tikz/save path=\meta{macro}}
     Save the current soft path into \meta{macro}.

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
@@ -865,7 +865,7 @@ goes through a large number of coordinates. These coordinates are either given
 in a simple list of coordinates, read from some file, or they are computed on
 the fly.
 
-Since the syntax and the behaviour of this command are a bit complex, they are
+Since the syntax and the behavior of this command are a bit complex, they are
 described in the separated Section~\ref{section-tikz-plots}.
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-plots.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-plots.tex
@@ -132,7 +132,7 @@ following: Each line of the \meta{filename} should contain one line starting
 with two numbers, separated by a space. A line may also be empty or, if it
 starts with |#| or |%| it is considered empty. For such lines, a ``new data
 set'' is started, typically resulting in a new subpath being started in the
-plot (see Section~\ref{section-plot-jumps} on how to change this behaviour, if
+plot (see Section~\ref{section-plot-jumps} on how to change this behavior, if
 necessary). For lines containing two numbers, they must be separated by a
 space. They may be following by arbitrary text, which is ignored, \emph{except}
 if it is |o| or |u|. In the first case, the point is considered to be an

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-plots.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-plots.tex
@@ -716,7 +716,7 @@ behavior of |plot|.
 \end{codeexample}
     %
     The use of |bar width| and |bar shift| is explained in the |plothandlers|
-    library documentation, section~\ref{section-plotlib-bar-handlers}. Please
+    library documentation, Section~\ref{section-plotlib-bar-handlers}. Please
     refer to page~\pageref{key-bar-width}.
 \end{key}
 
@@ -748,7 +748,7 @@ behavior of |plot|.
 
     You can configure relative shifts and relative bar widths, which is
     explained in the |plothandlers| library documentation,
-    section~\ref{section-plotlib-bar-handlers}. Please refer to
+    Section~\ref{section-plotlib-bar-handlers}. Please refer to
     page~\pageref{key-bar-interval-width}.
 \end{key}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-scopes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-scopes.tex
@@ -69,7 +69,7 @@ is possible in many other packages) will result in chaos.
 In \tikzname, the way graphics are rendered is strongly influenced by graphic
 options. For example, there is an option for setting the color used for
 drawing, another for setting the color used for filling, and also more obscure
-ones like the option  for setting the prefix used in the filenames of temporary
+ones like the option for setting the prefix used in the filenames of temporary
 files written while plotting functions using an external program. The graphic
 options are specified in \emph{key lists}, see
 Section~\ref{section-graphic-options} below for details. All graphic options
@@ -164,7 +164,7 @@ Top align:
         on. The effect of multiply setting this option accumulates.
 
         This option is mainly used in styles like the |every picture| style to
-        execute certain code at the start  of a picture.
+        execute certain code at the start of a picture.
     \end{key}
 
     \begin{key}{/tikz/execute at end picture=\meta{code}}

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -180,10 +180,10 @@ The syntax for specifying nodes is the following:
 
     \begin{key}{/tikz/in front of path}
         This is the opposite of |behind path|: It causes nodes to be drawn on
-        top of the path. Since this is the default behaviour, you usually do
+        top of the path. Since this is the default behavior, you usually do
         not need this option; it is only needed when an enclosing scope has
         used |behind path| and you now wish to ``switch back'' to the normal
-        behaviour.
+        behavior.
     \end{key}
 
     \medskip
@@ -477,7 +477,7 @@ filling. Here is an example that demonstrates the difference:
 \label{section-shape-seps}
 \label{section-shape-common-options}
 
-The \todosp{why two labels for the same point?} exact behaviour of shapes
+The \todosp{why two labels for the same point?} exact behavior of shapes
 differs, shapes defined for more special purposes (like a, say, transistor
 shape) will have even more custom behaviors. However, there are some options
 that apply to most shapes:
@@ -1206,8 +1206,8 @@ anchor of the second node is at coordinate |(1,1)|.
             rectangle (1,1) node[anchor=west] {second node};
 \end{codeexample}
 
-Since the default anchor is |center|, the default behaviour is to shift the
-node in such a way that it is centered on the current position.
+Since the default anchor is |center|, the default behavior is to shift the node
+in such a way that it is centered on the current position.
 
 \begin{key}{/tikz/anchor=\meta{anchor name}}
     Causes the node to be shifted such that its anchor \meta{anchor name} lies
@@ -1492,7 +1492,7 @@ differently.
 \end{tikzpicture}
 \end{codeexample}
             %
-            It is possible to change the behaviour of this \meta{specification}
+            It is possible to change the behavior of this \meta{specification}
             rather drastically, using the following key:
             %
             \begin{key}{/tikz/on grid=\meta{boolean} (initially false)}
@@ -1564,7 +1564,7 @@ differently.
 \end{key}
 
 \begin{key}{/tikz/above left=\opt{\meta{specification}}}
-    This key is also redefined in a manner similar to the above, but behaviour
+    This key is also redefined in a manner similar to the above, but behavior
     of the \meta{shifting part} is more complicated:
     %
     \begin{enumerate}

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -95,7 +95,7 @@ The syntax for specifying nodes is the following:
     Everything between ``|node|'' and the opening brace of a node is optional.
     If there are \meta{foreach statements}, they must come first, directly
     following ``|node|''. Other than that, the ordering of all the other
-    elements of a node specification (the \meta{options}, the  \meta{name},
+    elements of a node specification (the \meta{options}, the \meta{name},
     \meta{coordinate}, and \meta{animation attribute}) is arbitrary, indeed,
     there can be multiple occurrences of any of these elements (although for
     the name and the coordinate this makes no sense).
@@ -1045,7 +1045,7 @@ Let us now first have a look at the |text width| command.
         \item[|align=|\declare{\texttt{flush center}}] Works like |flush left|
             or |flush right|, only for center alignment. Because of all the
             trouble that results from the |center| option in conjunction with
-            narrow lines, I suggest picking this option rather than  |center|
+            narrow lines, I suggest picking this option rather than |center|
             \emph{unless} you have longer text, in which case |center| will
             give the typographically better results.
             %
@@ -1286,7 +1286,7 @@ you to select the standard anchors more intuitively:
 \end{key}
 
 \begin{key}{/tikz/above right}
-    Similar to  |above left|.
+    Similar to |above left|.
     %
 \begin{codeexample}[]
 \tikz \fill (0,0) circle (2pt) node[above right] {above right};
@@ -1578,7 +1578,7 @@ differently.
             resulting coordinate and horizontally be the negated $x$-part of
             the result. (This is exactly what you expect, except possibly when
             you have used the |x| and |y| options to modify the |xy|-coordinate
-            system so that the unit  vectors no longer point in the expected
+            system so that the unit vectors no longer point in the expected
             directions.)
         \item When the \meta{shifting part} is of the form \meta{number or
             dimension}, the node is shifted by this \meta{number or dimension}
@@ -3003,7 +3003,7 @@ version of the |node| path command can be used:
     given. Also, the ordering of options and node label must be as above.
 
     The effect of the above is the following effect: The node \meta{name} must
-    already  be existing. Now, the \meta{late options} are executed in a local
+    already be existing. Now, the \meta{late options} are executed in a local
     scope. Most of these options will have no effect since you \emph{cannot
     change the appearance of the node,} that is, you cannot change a red node
     into a green node using these ``late'' options. However, giving the

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-transformations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-transformations.tex
@@ -17,7 +17,7 @@ how you can access it in \tikzname.
 
 \subsection{The Different Coordinate Systems}
 
-It is a long process from  a coordinate like, say, $(1,2)$ or
+It is a long process from a coordinate like, say, $(1,2)$ or
 $(1\mathrm{cm},5\mathrm{pt})$, to the position a point is finally placed on the
 display or paper. In order to find out where the point should go, it is
 constantly ``transformed'', which means that it is mostly shifted around and
@@ -27,7 +27,7 @@ In detail, (at least) the following transformations are applied to a coordinate
 like $(1,2)$ before a point on the screen is chosen:
 %
 \begin{enumerate}
-    \item \pgfname\ interprets a coordinate like $(1,2)$  in its
+    \item \pgfname\ interprets a coordinate like $(1,2)$ in its
         $xy$-coordinate system as ``add the current $x$-vector once and the
         current $y$-vector twice to obtain the new point''.
     \item \pgfname\ applies its coordinate transformation matrix to the

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-transparency.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-transparency.tex
@@ -17,7 +17,7 @@ Normally, when you paint something using any of \tikzname's commands (this
 includes stroking, filling, shading, patterns, and images), the newly painted
 objects totally obscure whatever was painted earlier in the same area.
 
-You can change this behaviour by using something that can be thought of as
+You can change this behavior by using something that can be thought of as
 ``(semi)transparent colors''. Such colors do not completely obscure the
 background, rather they blend the background with the new color. At first
 sight, using such semitransparent colors might seem quite straightforward, but

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-trees.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-trees.tex
@@ -11,7 +11,7 @@
 \section{Making Trees Grow}
 \label{section-trees}
 
-\subsection{Introduction to the  Child Operation}
+\subsection{Introduction to the Child Operation}
 
 \emph{Trees} are a common way of visualizing hierarchical structures. A simple
 tree looks like this:

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-trees.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-trees.tex
@@ -512,7 +512,7 @@ parent node is given by the |level distance|.
     strange effect: It sets the sibling distance for the current level to
     |0pt|, but leaves the sibling distance for later levels unchanged.
 
-    This somewhat strange behaviour has a highly desirable effect: If you give
+    This somewhat strange behavior has a highly desirable effect: If you give
     this option before the list of children of a node starts, the ``current
     level'' is still the parent level. Each child will be on a later level and,
     hence, the sibling distance will be as specified originally. This will
@@ -845,7 +845,7 @@ the following path operation is encountered:
         the |edge from parent| command, the second parameter will be the
         \meta{node specifications} that following the command.
 
-        The standard behaviour of drawing a straight line from the parent node
+        The standard behavior of drawing a straight line from the parent node
         to the child node could be achieved by setting the \meta{macro} to the
         following:
         %

--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial-Euclid.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial-Euclid.tex
@@ -95,7 +95,7 @@ found on his website at Clark University.}
     therefore \A\C\ also equals \B\C. Therefore the three straight
     lines \A\C, \A\B, and \B\C\ equal one another.
     Therefore the \textcolor{triangle}{triangle} \A\B\C\ is
-    equilateral, and it has been  constructed on the given finite
+    equilateral, and it has been constructed on the given finite
     \textcolor{input}{straight line}~\A\B.
   };
 \end{tikzpicture}
@@ -182,7 +182,7 @@ This works fine. However, Euclid is not quite satisfied since he would prefer
 that the ``main coordinates'' $(0,0)$ and $(1.25,0.25)$ are ``kept separate''
 from the perturbation $0.1(\mathit{rand},\mathit{rand})$. This means, he would
 like to specify that coordinate $A$ as ``the point that is at $(0,0)$ plus one
-tenth of the vector  $(\mathit{rand},\mathit{rand})$''.
+tenth of the vector $(\mathit{rand},\mathit{rand})$''.
 
 It turns out that the |calc| library allows him to do exactly this kind of
 computation. When this library is loaded, you can use special coordinates that
@@ -489,20 +489,20 @@ The second proposition in the Elements is the following:
 
     Produce the straight lines \A\E\ and \B\F\ in a straight line with
     \D\A\ and \D\B. Describe the circle \C\G\H\ with center \B\ and
-    radius \B\C, and  again, describe the circle \G\K\L\ with center
+    radius \B\C, and again, describe the circle \G\K\L\ with center
     \D\ and radius \D\G.
 
     Since the point \B\ is the center of the circle \C\G\H, therefore
     \B\C\ equals \B\G. Again, since the point \D\ is the center of the
     circle \G\K\L, therefore \D\L\ equals \D\G. And in these \D\A\
     equals \D\B, therefore the remainder \A\L\ equals the remainder
-    \B\G. But \B\C\ was also proved  equal to \B\G, therefore each of
+    \B\G. But \B\C\ was also proved equal to \B\G, therefore each of
     the straight lines \A\L\ and \B\C\ equals \B\G. And things which
     equal the same thing also equal one another, therefore \A\L\ also
     equals \B\C.
 
     Therefore the \textcolor{output}{straight line} \A\L\ equal to the
-    given \textcolor{input}{straight line} \B\C\  has been placed with
+    given \textcolor{input}{straight line} \B\C\ has been placed with
     one end at the \textcolor{orange}{given point}~\A.
   };
 \end{tikzpicture}

--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial-chains.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial-chains.tex
@@ -644,7 +644,7 @@ specify, as shown in the next example. Additionally, by using the
   \matrix[column sep=4mm] { \matrixcontent };
 
   \graph [use existing nodes] {
-    p1 -> ui1 -- p2 -> dot -- p3 -> digit -- p4 -- p5  -- p6 -> e -- p7 -- p8 -> ui2 -- p9 -> p10;
+    p1 -> ui1 -- p2 -> dot -- p3 -> digit -- p4 -- p5 -- p6 -> e -- p7 -- p8 -> ui2 -- p9 -> p10;
     p4 ->[skip loop=-5mm]  p3;
     p2 ->[skip loop=5mm]   p5;
     p6 ->[skip loop=-11mm] p9;
@@ -907,11 +907,11 @@ edges, we get the final diagram with its complete code:
 % which is why it is joined correctly with the |E| node. The two
 % additional |join| options get a special |with| parameter. This allows
 % you to join a node with a node other than the predecessor on the
-% chain. The  |with| should be followed by the name of a node.
+% chain. The |with| should be followed by the name of a node.
 %
 % Since Ilka will need scopes more often in the following, she includes
 % the |scopes| library. This allows her to replace |\begin{scope}|
-%   simply by an opening brace and  |\end{scope}| by the corresponding
+% simply by an opening brace and |\end{scope}| by the corresponding
 % closing brace. Also, in the following example we reference
 % the nodes |plus| and |minus| using
 % their automatic name: The $i$th node on a chain is called

--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial-map.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial-map.tex
@@ -935,7 +935,7 @@ has a detailed plan of when which subject will be addressed.
 
 Johannes intends to share this plan with his students by adding a calendar to
 the lecture map. In addition to serving as a reference on which particular day
-a certain  topic will be addressed, the calendar is also useful to show the
+a certain topic will be addressed, the calendar is also useful to show the
 overall chronological order of the course.
 
 In order to add a calendar to a \tikzname\ graphic, the |calendar| library is

--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
@@ -212,7 +212,7 @@ file |pgf.cfg| or can write |\def\pgfsysdriver{pgfsys-dvipdfm.def}| somewhere
 
 Karl's uncle Hans uses Con\TeX t. Like Gerda, Hans can also use \tikzname.
 Instead of |\usepackage{tikz}| he says |\usemodule[tikz]|. Instead of
-|\begin{tikzpicture}| he writes |\starttikzpicture| and  instead of
+|\begin{tikzpicture}| he writes |\starttikzpicture| and instead of
 |\end{tikzpicture}| he writes |\stoptikzpicture|.
 
 His version of the example looks like this:
@@ -418,7 +418,7 @@ and everything else on top.
 \end{codeexample}
 
 
-\subsection{Adding a Touch of  Style}
+\subsection{Adding a Touch of Style}
 
 Instead of the options |gray,very thin| Karl could also have said |help lines|.
 \emph{Styles} are predefined sets of options that can be used to organize how a
@@ -487,7 +487,7 @@ the color for the lines only and a different color can be used for filling
 
 He saw that the style |very thin| yields very thin lines. Karl is not really
 surprised by this and neither is he surprised to learn that |thin| yields thin
-lines,  |thick| yields thick lines, |very thick| yields very thick lines,
+lines, |thick| yields thick lines, |very thick| yields very thick lines,
 |ultra thick| yields really, really thick lines and |ultra thin| yields lines
 that are so thin that low-resolution printers and displays will have trouble
 showing them. He wonders what gives lines of ``normal'' thickness. It turns out
@@ -500,7 +500,7 @@ the two styles |dashed| and |dotted| can be used, yielding \tikz[baseline]
 \draw[dashed] (0,.5ex) -- ++(2em,0pt); and \tikz[baseline] \draw[dotted]
 (0,.5ex) -- ++(2em,0pt);. Both options also exist in a loose and a dense
 version, called |loosely dashed|, |densely dashed|, |loosely dotted|, and
-|densely dotted|. If he really, really  needs to, Karl can also define much
+|densely dotted|. If he really, really needs to, Karl can also define much
 more complex dashing patterns with the |dash pattern| option, but his son
 insists that dashing is to be used with utmost care and mostly distracts.
 Karl's son claims that complicated dashing patterns are evil. Karl's students
@@ -921,7 +921,7 @@ offered by many other packages. However, he expects that, sometimes, he might
 need to use some other kinds of arrow. To do so, Karl can say |>=|\meta{kind of
 end arrow tip}, where \meta{kind of end arrow tip} is a special arrow tip
 specification. For example, if Karl says |>=Stealth|, then he tells \tikzname\
-that he would like  ``stealth-fighter-like'' arrow tips:
+that he would like ``stealth-fighter-like'' arrow tips:
 \todosp{remaining instance of bug \#473}
 %
 \begin{codeexample}[preamble={\usetikzlibrary{arrows.meta}}]
@@ -996,7 +996,7 @@ during a path construction apply only to this path.
 
 \subsection{Transformations}
 
-When you specify a  coordinate like |(1cm,1cm)|, where is that coordinate
+When you specify a coordinate like |(1cm,1cm)|, where is that coordinate
 placed on the page? To determine the position, \tikzname, \TeX, and
 \textsc{pdf} or PostScript all apply certain transformations to the given
 coordinate in order to determine the final position on the page.
@@ -1185,7 +1185,7 @@ called |below|, which does the same as |anchor=north|. Similarly, |above right|
 does the same as |anchor=south west|. In addition, |below| takes an optional
 dimension argument. If given, the shape will additionally be shifted downwards
 by the given amount. So, |below=1pt| can be used to put a text label below some
-point and, additionally shift it  1pt downwards.
+point and, additionally shift it 1pt downwards.
 
 Karl is not quite satisfied with the ticks. He would like to have $1/2$ or
 $\frac{1}{2}$ shown instead of $0.5$, partly to show off the nice capabilities
@@ -1197,7 +1197,7 @@ over $1/2$ since they are not too fond of fractions in general.
 Karl now faces a problem: For the |\foreach| statement, the position |\x|
 should still be given as |0.5| since \tikzname\ will not know where
 |\frac{1}{2}| is supposed to be. On the other hand, the typeset text should
-really be  |\frac{1}{2}|. To solve this problem, |\foreach| offers a special
+really be |\frac{1}{2}|. To solve this problem, |\foreach| offers a special
 syntax: Instead of having one variable |\x|, Karl can specify two (or even
 more) variables separated by a slash as in |\x / \xtext|. Then, the elements in
 the set over which |\foreach| iterates must also be of the form
@@ -1231,7 +1231,7 @@ the text shape with a white color.
 
 The next thing Karl wants to do is to add the labels like $\sin \alpha$. For
 this, he would like to place a label ``in the middle of the line''. To do so,
-instead of specifying the label |node {$\sin\alpha$}|  directly after one of
+instead of specifying the label |node {$\sin\alpha$}| directly after one of
 the endpoints of the line (which would place the label at that endpoint), Karl
 can give the label directly after the |--|, before the coordinate. By default,
 this places the label in the middle of the line, but the |pos=| options can be

--- a/doc/generic/pgf/version-for-luatex/en/pgfmanual.tex
+++ b/doc/generic/pgf/version-for-luatex/en/pgfmanual.tex
@@ -21,8 +21,6 @@
 % ToDo for Stefan Pinnow
 %
 % - search and replace for
-%   - $x$-coordinate --> $x$ coordinate
-%     (and similar)
 %   - to-path vs. to--path
 %
 % - remove "spurious" spaces when loading libraries

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc/ogdf/energybased/FMMMLayout.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc/ogdf/energybased/FMMMLayout.lua
@@ -31,7 +31,7 @@ evaluating potential fields.
 The implementation is based on the following publication:
 %
 \begin{itemize}
-  \item Stefan Hachul, Michael J\"unger: Drawing Large Graphs with
+  \item Stefan Hachul, Michael Jünger: Drawing Large Graphs with
     a Potential-Field-Based Multilevel Algorithm. \emph{12th
       International Symposium on Graph Drawing 1998 (GD '04)},
       New York, LNCS 3383, pp. 285--295, 2004.

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc/ogdf/energybased/SpringEmbedderKK.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc/ogdf/energybased/SpringEmbedderKK.lua
@@ -32,7 +32,7 @@ documentation [[
   First of all note that the algorithm uses all pairs shortest path
   to compute the graph theoretic distance. This can be done either
   with BFS (ignoring node sizes) in quadratic time or by using
-  e.g. Floyd's algorithm in cubic time with given edge lengths
+  e.g.\ Floyd's algorithm in cubic time with given edge lengths
   that may reflect the node sizes. Also |m_computeMaxIt| decides
   if the computation is stopped after a fixed maximum number of
   iterations. The desirable edge length can either be set or computed

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc/ogdf/misclayout/CircularLayout.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc/ogdf/misclayout/CircularLayout.lua
@@ -25,7 +25,7 @@ documentation
 The implementation used in CircularLayout is based on the following publication:
 %
 \begin{itemize}
-  \item Ugur Dogrus\"oz, Brendan Madden, Patrick Madden: Circular
+  \item Ugur Dogrusöz, Brendan Madden, Patrick Madden: Circular
     Layout in the Graph Layout Toolkit. \emph{Proc. Graph Drawing 1996,}
     LNCS 1190, pp. 92--100, 1997.
 \end{itemize}

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/jedi/base/ForceController.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/jedi/base/ForceController.lua
@@ -457,7 +457,7 @@ end
 --
 -- @return A table of coordinate-objects associated with vertices. The
 --          coordinate object hold the calculated net displacement for
---          the $x$ and $y$ coordinate.
+--          the $x$- and $y$-coordinate.
 function get_net_force(vertices, j, t_now, epoch)
   local net_forces = {}
   local natural_spring_length = options["node distance"]

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/jedi/forcetypes/ForceAbsoluteValue.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/jedi/forcetypes/ForceAbsoluteValue.lua
@@ -9,7 +9,7 @@
 
 --- This is a subclass of ForceTemplate, which is used to implement forces
 -- that work on individual vertices. Forces of this kind simply add an
--- absolute value set in the force data to each vertex' $x$ and $y$ coordinate
+-- absolute value set in the force data to each vertex' $x$- and $y$- coordinate
 
 -- Imports
 local ForceTemplate = require "pgf.gd.force.jedi.base.ForceTemplate"

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/library.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/library.lua
@@ -93,8 +93,8 @@
 --     \newblock \emph{Configurable Graph Drawing Algorithms
 --       for the \tikzname\ Graphics Description Language,}
 --     \newblock Diploma Thesis,
---     \newblock Institute of Theoretical Computer Science, Universit\"at
---       zu L\"ubeck, 2011.\\[.5em]
+--     \newblock Institute of Theoretical Computer Science, Universität
+--       zu Lübeck, 2011.\\[.5em]
 --     \newblock Online at
 --       \url{http://www.tcs.uni-luebeck.de/downloads/papers/2011/}\\ \url{2011-configurable-graph-drawing-algorithms-jannis-pohlmann.pdf}
 -- \end{itemize}
@@ -123,4 +123,3 @@ require "pgf.gd.force.SpringElectricalLayouts"
 require "pgf.gd.force.SpringHu2006"
 require "pgf.gd.force.SpringElectricalHu2006"
 require "pgf.gd.force.SpringElectricalWalshaw2000"
-

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/interface/InterfaceToDisplay.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/interface/InterfaceToDisplay.lua
@@ -464,7 +464,7 @@ end
 --
 -- @param tail           Name of the node the edge begins at.
 -- @param head           Name of the node the edge ends at.
--- @param direction      Direction of the edge (e.g. |--| for an undirected edge
+-- @param direction      Direction of the edge (e.g.\ |--| for an undirected edge
 --                       or |->| for a directed edge from the first to the second
 --                       node).
 -- @param height         The option stack height, see for instance |createVertex|.

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/layered/library.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/layered/library.lua
@@ -37,8 +37,8 @@
 --     \newblock \emph{Configurable Graph Drawing Algorithms
 --       for the \tikzname\ Graphics Description Language,}
 --     \newblock Diploma Thesis,
---     \newblock Institute of Theoretical Computer Science, Universit\"at
---       zu L\"ubeck, 2011.\\[.5em]
+--     \newblock Institute of Theoretical Computer Science, Universität
+--       zu Lübeck, 2011.\\[.5em]
 --     \newblock Available online via
 --       \url{http://www.tcs.uni-luebeck.de/downloads/papers/2011/}\\
 --       \url{2011-configurable-graph-drawing-algorithms-jannis-pohlmann.pdf}
@@ -91,4 +91,3 @@ require "pgf.gd.layered.node_ranking"
 require "pgf.gd.layered.crossing_minimization"
 require "pgf.gd.layered.node_positioning"
 require "pgf.gd.layered.edge_routing"
-

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/lib/Bezier.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/lib/Bezier.lua
@@ -12,7 +12,7 @@
 
 
 ---
--- This library offers a number of methods for working with Bezi\'er
+-- This library offers a number of methods for working with Beziér
 -- curves.
 
 local Bezier = {}

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
@@ -132,7 +132,7 @@ child):
   { a -> { b -> c -> d, e -> f -> g } };
 \end{codeexample}
 %
-This behaviour of ``ignoring'' missing children in later stages of
+This behavior of ``ignoring'' missing children in later stages of
 the recursion can be changed using the key |missing nodes get space|.
 
 \noindent\textbf{Significant Pairs of Siblings.}

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
@@ -39,12 +39,12 @@ introduces some nice extensions of the basic algorithm:
 %
 \begin{itemize}
   \item
-    A.\ Br\"uggemann-Klein, D.\ Wood,
+    A.\ Brüggemann-Klein, D.\ Wood,
     \newblock Drawing trees nicely with \TeX,
     \emph{Electronic Publishing,} 2(2), 101--115, 1989.
 \end{itemize}
 %
-As a historical remark, Br\"uggemann-Klein and Wood have implemented
+As a historical remark, Brüggemann-Klein and Wood have implemented
 their version of the Reingold--Tilford algorithm directly in \TeX\
 (resulting in the Tree\TeX\ style). With the power of Lua\TeX\ at
 our disposal, the 2012 implementation in the |graphdrawing.tree|
@@ -136,7 +136,7 @@ This behaviour of ``ignoring'' missing children in later stages of
 the recursion can be changed using the key |missing nodes get space|.
 
 \noindent\textbf{Significant Pairs of Siblings.}
-Br\"uggemann-Klein and Wood have proposed an extension of the
+Brüggemann-Klein and Wood have proposed an extension of the
 Reingold--Tilford method that is intended to better highlight the
 overall structure of a tree. Consider the following two trees:
 %
@@ -154,7 +154,7 @@ overall structure of a tree. Consider the following two trees:
   };
 \end{codeexample}
 %
-As observed by Br\"uggemann-Klein and Wood, the two trees are
+As observed by Brüggemann-Klein and Wood, the two trees are
 structurally quite different, but the Reingold--Tilford method
 places the nodes at exactly the same positions and only one edge
 ``switches'' positions. In order to better highlight the differences
@@ -279,7 +279,7 @@ This key executes:
 \end{enumerate}
 %
 In the examples, the last one is taken from the paper of
-Br\"uggemann-Klein and Wood. It demonstrates nicely the
+Brüggemann-Klein and Wood. It demonstrates nicely the
 advantages of having the full power of \tikzname's anchoring and the
 graph drawing engine's orientation mechanisms at one's disposal.
 ]]


### PR DESCRIPTION
So far fixed some typos and removed double/multiple spaces.

Things that still can be done to harmonize/correct stuff in manual:
- [x] UK spelling <--> US spelling, e.g. `behavior` vs. `behaviour` --> I prefer US spelling
- [x] `section~` <--> `Section~` --> most of the `\ref` prefixes use the latter, so I'd harmonize to that
- [x] e.g. `$x$ coordinate` <--> `$x$-coordinate`
- [x] `\emph{Note:\/}` <--> `\emph{Note:}`
- [x] e.g. `Mineral\"olprodukte` --> replace by UTF-8 character --> `Mineralölprodukte`

Are there any opinions/arguments against that proposed changes? If not, I would apply them one by one.