### PR TITLE
[doc] Fix pdf destinations

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -200,7 +200,7 @@ local function manual()
     until(run == maxruns or not rerun)
 
     if run == maxruns and rerun then
-        error("Document did not converge after 5 runs!")
+        error("Document did not converge after " .. tostring(maxruns) .. " runs!")
     end
 
     -- Run the postaction

--- a/doc/generic/pgf/macros/pgfmanual-en-macros.tex
+++ b/doc/generic/pgf/macros/pgfmanual-en-macros.tex
@@ -18,7 +18,9 @@
 \definecolor{animationgraphicbackground}{rgb}{0.96,0.96,0.8}
 
 \newenvironment{pgfmanualentry}{\list{}{\leftmargin=2em\itemindent-\leftmargin\def\makelabel##1{\hss##1}}}{\endlist}
-\newcommand\pgfmanualentryheadline[1]{\itemsep=0pt\parskip=0pt{\raggedright\item\strut{#1}\par}\topsep=0pt}
+\newcounter{dummy}
+\newcommand\pgfmanualentryheadline[1]{%
+  \itemsep=0pt\parskip=0pt{\raggedright\item\refstepcounter{dummy}\strut{#1}\par}\topsep=0pt}
 \newcommand\pgfmanualbody{\parskip3pt}
 
 \let\origtexttt=\texttt

--- a/doc/generic/pgf/macros/pgfmanual-en-macros.tex
+++ b/doc/generic/pgf/macros/pgfmanual-en-macros.tex
@@ -18,9 +18,9 @@
 \definecolor{animationgraphicbackground}{rgb}{0.96,0.96,0.8}
 
 \newenvironment{pgfmanualentry}{\list{}{\leftmargin=2em\itemindent-\leftmargin\def\makelabel##1{\hss##1}}}{\endlist}
-\newcounter{dummy}
+\newcounter{pgfmanualentry}
 \newcommand\pgfmanualentryheadline[1]{%
-  \itemsep=0pt\parskip=0pt{\raggedright\item\refstepcounter{dummy}\strut{#1}\par}\topsep=0pt}
+  \itemsep=0pt\parskip=0pt{\raggedright\item\refstepcounter{pgfmanualentry}\strut{#1}\par}\topsep=0pt}
 \newcommand\pgfmanualbody{\parskip3pt}
 
 \let\origtexttt=\texttt

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-axes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-axes.tex
@@ -3016,7 +3016,7 @@ left axis={ visualize axis={ x axis={ goto=min } }
 
     \begin{stylekey}{/tikz/data visualization/axis layer (initially on background layer)}
         The layer on which the axis is drawn. See the description of
-        |grid layer| on page~\ref{section-dv-grid-layer} for details.
+        |grid layer| on page~\pageref{section-dv-grid-layer} for details.
     \end{stylekey}
 
     \begin{stylekey}{/tikz/data visualization/every axis}

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-calendar.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-calendar.tex
@@ -76,7 +76,7 @@ say, the |\draw| command).
     %
     \begin{key}{/tikz/dates=\meta{start date}| to |\meta{end date}}
         This option specifies the date range. Both the start and end date are
-        specified as described on page~\pageref{calendar-date-format}. In
+        specified and described on page~\pageref{calendar-date-format}. In
         short: You can provide ISO-format type dates like |2006-01-02|, you can
         replace the day of month by |last| to refer to the last day of a month
         (so |2006-02-last| is the same as |2006-02-28|), and you can add a plus

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-plot-handlers.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-plot-handlers.tex
@@ -439,8 +439,8 @@ bars).
     relative bar sizes and offsets, one bar for each $y$~coordinate interval.
 \end{command}
 
-\label{key-bar-interval-shift}%
 \begin{key}{/pgf/bar interval shift=\marg{factor} (initially 0.5)}
+\label{key-bar-interval-shift}%
 \keyalias{tikz}
     Sets the \emph{relative} shift of |\pgfplothandlerxbarinterval| and
     |\pgfplothandlerybarinterval| to \meta{factor}. As
@@ -450,8 +450,8 @@ bars).
     The argument \marg{scale} will be evaluated using the math parser.
 \end{key}
 
-\label{key-bar-interval-width}%
 \begin{key}{/pgf/bar interval width=\marg{scale} (initially 1)}
+\label{key-bar-interval-width}%
 \keyalias{tikz}
     Sets the \emph{relative} width of |\pgfplothandlerxbarinterval| and
     |\pgfplothandlerybarinterval| to \marg{scale}. The argument is relative to

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-spy.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-spy.tex
@@ -20,7 +20,7 @@
 
 \subsection{Magnifying a Part of a Picture}
 
-The idea behind the |spy| library is to make is easy to create high-density
+The idea behind the |spy| library is to make it easy to create high-density
 pictures in which some important parts are repeated somewhere, but magnified as
 if you were looking through a spyglass:
 %


### PR DESCRIPTION
By stepping a dummy counter in `\pgfmanualentryheadline`, labels used inside environments based on `pgfmanualentry` env now create right pdf destinations.

 - Pros: Only one place is changed.
 - Cons: `\refstepcounter{dummy}` is run 2000+ times, which slows down manual building.
 - Current result: I've manually checked every occurrence of word "page" in the locally built manual, so far so good.

Related: #885 