### PR TITLE
gs-9.53 transparency (fixes #862); blend mode; transparency groups 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 *.pdf
 *.svg
 *.toc
+# vim swap files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]

--- a/tex/generic/pgf/systemlayer/pgfsys-common-postscript.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-common-postscript.def
@@ -150,10 +150,10 @@
 % Opacity
 
 \def\pgfsys@fill@opacity#1{%
-  \pgfsysprotocol@literal{#1 .pgfsetfillopacityalpha}
+  \pgfsysprotocol@literal{#1 .pgfsetfillopacityalpha}%
 }
 \def\pgfsys@stroke@opacity#1{%
-  \pgfsysprotocol@literal{#1 .pgfsetstrokeopacityalpha}
+  \pgfsysprotocol@literal{#1 .pgfsetstrokeopacityalpha}%
 }
 
 % Objects
@@ -181,6 +181,35 @@
     \pgfsys@invoke{pgf\csname#1\endcsname}%
   }%
   \pgfsysprotocol@setcurrentprotocol\pgfsys@temp}
+
+% Blending
+\def\pgfsys@blend@mode#1{%
+  \expandafter\ifx\csname pgf@sys@pdf@bm@#1\endcsname\relax%
+    \expandafter\let\expandafter\pgf@temp\csname pgf@sys@pdf@blend@mode@map@#1\endcsname%
+    \expandafter\xdef\csname pgf@sys@pdf@bm@#1\endcsname{/\pgf@temp}%
+    \ifx\pgf@temp\relax%
+      \pgferror{Unknown blend mode '#1'}%
+      \def\pgf@temp{Normal}%
+    \fi%
+  \fi%
+  \pgfsysprotocol@literal{\csname pgf@sys@pdf@bm@#1\endcsname\space .setblendmode}%
+}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@normal\endcsname{Normal}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@multiply\endcsname{Multiply}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@screen\endcsname{Screen}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@overlay\endcsname{Overlay}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@darken\endcsname{Darken}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@lighten\endcsname{Lighten}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@color dodge\endcsname{ColorDodge}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@color burn\endcsname{ColorBurn}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@hard light\endcsname{HardLight}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@soft light\endcsname{SoftLight}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@difference\endcsname{Difference}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@exclusion\endcsname{Exclusion}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@saturation\endcsname{Saturation}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@color\endcsname{Color}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@hue\endcsname{Hue}
+\expandafter\def\csname pgf@sys@pdf@blend@mode@map@luminosity\endcsname{Luminosity}
 
 % Shadings
 

--- a/tex/generic/pgf/systemlayer/pgfsys-dvips.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvips.def
@@ -138,6 +138,30 @@
 
 \fi
 
+%
+% Transparency groups
+%
+\def\pgfsys@transparencygroupfrombox#1{%
+  \special{ps:
+    mark /NamespacePush pdfmark % limit `{pgfxform}' name visibility
+    mark /_objdef {pgfxform} /BBox [clippath pathbbox newpath] /BP pdfmark
+    save gsave
+    /.setstrokeconstantalpha where
+      {pop 1 .pgfsetfillopacityalpha 1 .pgfsetstrokeopacityalpha} if
+  }%
+  \ht#1=0pt%
+  \dp#1=0pt%
+  \hskip\pgf@picminx\hbox to 0pt{\box#1\hss}%
+  \special{ps:
+    grestore restore
+    mark /EP pdfmark
+    mark {pgfxform} << /Group << /S /Transparency
+      /I \ifpgfsys@transparency@group@isolated true \else false \fi
+      /K \ifpgfsys@transparency@group@knockout true \else false \fi  >> >> /PUT pdfmark
+  }%
+  \setbox#1=\hbox{\special{ps: mark {pgfxform} /SP pdfmark mark /NamespacePop pdfmark}}%
+}
+
 \endinput
 
 %%% Local Variables:

--- a/tex/generic/pgf/systemlayer/pgfsys-dvips.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvips.def
@@ -80,24 +80,33 @@
     /pgfsd{globaldict /pgfdelta /delta where {pop delta} {0} ifelse put}bind def% save delta
     /pgfpd{/delta globaldict /pgfdelta get def}bind def % put delta
     /.setblendmode where {pop} {/.setblendmode{pop}def} ifelse % install .setblendmode
-    /.setfillconstantalpha where {
-      pop /.setopacityalpha {.setfillconstantalpha} def
-    } {
-      /.setopacityalpha where {pop} {/.setopacityalpha {pop} def} ifelse % install .setopacityalpha (fallback)
+    /.setfillconstantalpha where {%
+      pop /.setopacityalpha {.setfillconstantalpha} def%
+    } {%
+      /.setopacityalpha where {pop} {/.setopacityalpha {pop} def} ifelse% install .setopacityalpha (fallback)
     } ifelse
     /.pgfsetfillopacityalpha{/pgffoa exch def
-      /.setfillconstantalpha where {pop pgffoa .setfillconstantalpha} {
+      /.setfillconstantalpha where {pop pgffoa .setfillconstantalpha} {%
         /pgffill{gsave pgffoa .setopacityalpha fill 1 .setopacityalpha newpath fill grestore newpath}bind def
-        /pgfeofill{gsave pgffoa .setopacityalpha eofill 1 .setopacityalpha newpath eofill grestore newpath}bind def
-      } ifelse
+        /pgfeofill{gsave pgffoa .setopacityalpha eofill 1 .setopacityalpha newpath eofill grestore newpath}bind def%
+      } ifelse%
     } bind def
     /.pgfsetstrokeopacityalpha{/pgfsoa exch def
-      /.setstrokeconstantalpha where {pop pgfsoa .setstrokeconstantalpha} {
-        /pgfstr{gsave pgfsoa .setopacityalpha stroke grestore newpath}bind def
-      } ifelse
+      /.setstrokeconstantalpha where {pop pgfsoa .setstrokeconstantalpha} {%
+        /pgfstr{gsave pgfsoa .setopacityalpha stroke grestore newpath}bind def%
+      } ifelse%
     }bind def
     /pgffoa 1 def
     /pgfsoa 1 def
+    % mandatory, transparency-related per-page operations, see
+    % https://www.ghostscript.com/doc/current/Language.htm#Transparency
+    % (bop-hook & eop-hook automatically executed if defined in userdict, see texdoc dvips)
+    /.pushpdf14devicefilter where {pop
+      [userdict /bop-hook known {userdict /bop-hook get aload pop} if
+        {0 .pushpdf14devicefilter} aload pop] cvx userdict exch /bop-hook exch put
+      [userdict /eop-hook known {userdict /eop-hook get aload pop} if
+        {.poppdf14devicefilter} aload pop] cvx userdict exch /eop-hook exch put%
+    } if
     end
   }%
 }

--- a/tex/generic/pgf/systemlayer/pgfsys-dvips.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvips.def
@@ -79,11 +79,23 @@
     /pgfc{newpath @endspecial pgfpd}bind def %close
     /pgfsd{globaldict /pgfdelta /delta where {pop delta} {0} ifelse put}bind def% save delta
     /pgfpd{/delta globaldict /pgfdelta get def}bind def % put delta
-    /.setopacityalpha where {pop} {/.setopacityalpha{pop}def} ifelse % install .setopacityalpha
+    /.setblendmode where {pop} {/.setblendmode{pop}def} ifelse % install .setblendmode
+    /.setfillconstantalpha where {
+      pop /.setopacityalpha {.setfillconstantalpha} def
+    } {
+      /.setopacityalpha where {pop} {/.setopacityalpha {pop} def} ifelse % install .setopacityalpha (fallback)
+    } ifelse
     /.pgfsetfillopacityalpha{/pgffoa exch def
-      /pgffill{gsave pgffoa .setopacityalpha fill 1 .setopacityalpha newpath fill grestore newpath}bind def
-      /pgfeofill{gsave pgffoa .setopacityalpha eofill 1 .setopacityalpha newpath eofill grestore newpath}bind def}bind def
-    /.pgfsetstrokeopacityalpha{/pgfsoa exch def /pgfstr{gsave pgfsoa .setopacityalpha stroke grestore newpath}bind def}bind def
+      /.setfillconstantalpha where {pop pgffoa .setfillconstantalpha} {
+        /pgffill{gsave pgffoa .setopacityalpha fill 1 .setopacityalpha newpath fill grestore newpath}bind def
+        /pgfeofill{gsave pgffoa .setopacityalpha eofill 1 .setopacityalpha newpath eofill grestore newpath}bind def
+      } ifelse
+    } bind def
+    /.pgfsetstrokeopacityalpha{/pgfsoa exch def
+      /.setstrokeconstantalpha where {pop pgfsoa .setstrokeconstantalpha} {
+        /pgfstr{gsave pgfsoa .setopacityalpha stroke grestore newpath}bind def
+      } ifelse
+    }bind def
     /pgffoa 1 def
     /pgfsoa 1 def
     end
@@ -137,6 +149,28 @@
 \def\pgf@sys@pdf@mark@pos@pgfpageorigin{\pgfpointorigin}
 
 \fi
+
+%
+% Transparency groups
+%
+\def\pgfsys@transparencygroupfrombox#1{%
+  \special{ps:
+    mark /NamespacePush pdfmark % limit `{pgfxform}' name visibility
+    mark /_objdef {pgfxform} /BBox [clippath pathbbox newpath] /BP pdfmark
+    save gsave
+    /.setstrokeconstantalpha where
+      {pop 1 .pgfsetfillopacityalpha 1 .pgfsetstrokeopacityalpha} if
+  }%
+  \hskip\pgf@picminx\rlap{\smash{\box#1}}%
+  \special{ps:
+    grestore restore
+    mark /EP pdfmark
+    mark {pgfxform} << /Group << /S /Transparency
+      /I \ifpgfsys@transparency@group@isolated true \else false \fi
+      /K \ifpgfsys@transparency@group@knockout true \else false \fi  >> >> /PUT pdfmark
+  }%
+  \setbox#1=\hbox{\special{ps: mark {pgfxform} /SP pdfmark mark /NamespacePop pdfmark}}%
+}
 
 \endinput
 

--- a/tex/generic/pgf/systemlayer/pgfsys-dvips.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvips.def
@@ -161,7 +161,9 @@
     /.setstrokeconstantalpha where
       {pop 1 .pgfsetfillopacityalpha 1 .pgfsetstrokeopacityalpha} if
   }%
-  \hskip\pgf@picminx\rlap{\smash{\box#1}}%
+  \ht#1=0pt
+  \dp#1=0pt
+  \hskip\pgf@picminx\hbox to 0pt{\box#1\hss}%
   \special{ps:
     grestore restore
     mark /EP pdfmark

--- a/tex/generic/pgf/systemlayer/pgfsys-dvips.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvips.def
@@ -161,8 +161,8 @@
     /.setstrokeconstantalpha where
       {pop 1 .pgfsetfillopacityalpha 1 .pgfsetstrokeopacityalpha} if
   }%
-  \ht#1=0pt
-  \dp#1=0pt
+  \ht#1=0pt%
+  \dp#1=0pt%
   \hskip\pgf@picminx\hbox to 0pt{\box#1\hss}%
   \special{ps:
     grestore restore


### PR DESCRIPTION
**1.** GS 9.52 introduced new transparency operators

````
.setfillconstantalpha
.setstrokeconstantalpha
````

Cf. issue #862.

They are supposed to replace `.setopacityalpha` and allow opacity to be set individually for stroking and filling operations. `.setopacityalpha` will be deprecated with the upcoming version 9.53. This PR makes use of the new operators, but keeps `.setopacityalpha` as a fallback.

**2.** This PR also implements Transparency Groups and Blend Modes.

----

The code listing below contains examples from the PGF manual. Typeset with:
````
latex example.tex
dvips example
ps2pdf -dALLOWPSTRANSPARENCY example.ps
````
Outputs from `ps2pdf` and `pdftex` for comparison:
[transparencyExamples-dvips.pdf](https://github.com/pgf-tikz/pgf/files/4846538/transparencyExamples-dvips.pdf)
[transparencyExamples-pdftex.pdf](https://github.com/pgf-tikz/pgf/files/4846539/transparencyExamples-pdftex.pdf)

(Poppler-based viewers don't render correctly the knockout example in the `pdftex` output, but MuPDF and AcroReader do.)

````latex
\documentclass{article}
\pagestyle{empty}

\usepackage{tikz}
\usetikzlibrary {patterns,shapes.symbols}

\begin{document}
  \begin{tikzpicture}[thick,fill opacity=0.5]
    \filldraw[fill=red] (0:1cm) circle (12mm);
    \filldraw[fill=green] (120:1cm) circle (12mm);
    \filldraw[fill=blue] (-120:1cm) circle (12mm);
  \end{tikzpicture}
%
  \begin{tikzpicture}[every node/.style={fill,draw}]
    \draw[line width=2mm,blue!50,line cap=round] (0,0) grid (3,2);
    \node[opacity=0.5] at (1.5,2) {Upper node};
    \node[draw opacity=0.8,fill opacity=0.2,text opacity=1] at (1.5,0) {Lower node};
  \end{tikzpicture}
%
  \begin{tikzpicture}[fill opacity=0.5]
    \fill[red] (0,0) circle (1);
    \fill[red] (1,0) circle (1);
  \end{tikzpicture}

  transparency group:
  \begin{tikzpicture}[opacity=0.5]
    \begin{scope}[transparency group]
      \draw [line width=5mm] (0,0) -- (2,2);
      \draw [line width=5mm] (2,0) -- (0,2);
    \end{scope}
  \end{tikzpicture}

  \begin{tikzpicture}
    \pattern[pattern=checkerboard,pattern color=black!15](-1,-1) rectangle (3,1);
    \node at (0,0) [forbidden sign,line width=2ex,draw=red,fill=white] {Smoking};
    \begin{scope}[transparency group,opacity=.5]
      \node at (2,0) [forbidden sign,line width=2ex,draw=red,fill=white] {Smoking};
    \end{scope}
  \end{tikzpicture}
%
  \begin{tikzpicture}
    \pattern[pattern=checkerboard,pattern color=black!15](-1,-1) rectangle (3,1);
    \node at (0,0) [forbidden sign,line width=2ex,draw=red,fill=white] {Smoking};
    \begin{scope}[transparency group,opacity=.5]
      \node (s) at (2,0) [forbidden sign,line width=2ex,draw=red,fill=white] {Smoking};
      \draw [opacity=.5, line width=2ex, blue] (1.2,0) -- (2.8,0);
    \end{scope}
  \end{tikzpicture}

  blend-mode `screen':
  \tikz {
    \begin{scope}[transparency group]
      \begin{scope}[blend mode=screen]
        \fill[red!90!black] ( 90:.6) circle (1);
        \fill[green!80!black] (210:.6) circle (1);
        \fill[blue!90!black] (330:.6) circle (1);
      \end{scope}
    \end{scope}
  }

  knockout example:
  \begin{tikzpicture}
    \shade [left color=red,right color=blue] (-2,-1) rectangle (2,1);
    \begin{scope}[transparency group=knockout]
      \fill [white] (-1.9,-.9) rectangle (1.9,.9);
      \node [opacity=0,font=\fontencoding{T1}\fontfamily{ptm}\fontsize{45}{45}\bfseries] {Ti\emph{k}Z};
    \end{scope}
  \end{tikzpicture}
  
\end{document}
````