### PR TITLE
Fix for mindmap connection bar glitches

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarymindmap.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarymindmap.code.tex
@@ -17,72 +17,58 @@
 %
 % Parameters: start radius, end radius, amplitude, angle
 
+\newdimen\tikz@lib@mm@startflarelength
+\newdimen\tikz@lib@mm@endflarelength
 \pgfdeclaredecoration{circle connection bar}{initial}
 {%
-  \state{initial}[width=0pt,next state=bar]
+  \state{initial}[width=0pt,next state=final]
   {
+    \pgfmathsetlength\pgfutil@tempdimb{\pgfdecorationsegmentamplitude}%
     {
     \pgftransformxshift{-\pgfkeysvalueof{/pgf/decoration/start radius}}%
-    \pgfpathmoveto{\pgfpointpolar{\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/start radius}}}
-    \pgfpatharc{\pgfdecorationsegmentangle}{-\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/start radius}}
-    \pgfutil@tempcnta=-\pgfdecorationsegmentangle\relax
-    \advance\pgfutil@tempcnta by90\relax
     \pgfmathsetlength\pgfutil@tempdima{\pgfkeysvalueof{/pgf/decoration/start radius}}
-    \pgfmathsetlength\pgfutil@tempdimb{\pgfdecorationsegmentamplitude}
-    \pgfpathcurveto
-    {\pgfpointadd
-      {\pgfpointpolar{-\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/start radius}}}
-      {\pgfpointpolar{\the\pgfutil@tempcnta}{.25\pgfutil@tempdima}}}
-    {\pgfqpoint{1.25\pgfutil@tempdima}{-.5\pgfutil@tempdimb}}
-    {\pgfqpoint{1.5\pgfutil@tempdima}{-.5\pgfutil@tempdimb}}
-    \pgfpathlineto{\pgfpoint{1.5\pgfutil@tempdima}{.5\pgfutil@tempdimb}}
+    \pgfpathmoveto{\pgfpoint{\pgfutil@tempdima+1.0\tikz@lib@mm@startflarelength}{.5\pgfutil@tempdimb}}
     \pgfutil@tempcnta=\pgfdecorationsegmentangle\relax
     \advance\pgfutil@tempcnta by-90\relax
     \pgfpathcurveto
-    {\pgfpoint{1.25\pgfutil@tempdima}{.5\pgfutil@tempdimb}}
+    {\pgfpoint{\pgfutil@tempdima+0.5\tikz@lib@mm@startflarelength}{.5\pgfutil@tempdimb}}
     {\pgfpointadd
       {\pgfpointpolar{\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/start radius}}}
       {\pgfpointpolar{\the\pgfutil@tempcnta}{.25\pgfutil@tempdima}}}
     {\pgfpointpolar{\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/start radius}}}
-    \pgfpathclose
-    }
-  }%
-  \state{bar}[width=0pt,next state=end]
-  {
-    \pgfmathsetlength\pgfutil@tempdima{\pgfkeysvalueof{/pgf/decoration/start radius}}%
-    \pgfmathsetlength\pgfutil@tempdimb{\pgfkeysvalueof{/pgf/decoration/end radius}}%
-    \pgfmathsetlength\pgf@xc{\pgfdecorationsegmentamplitude}%
-    \pgfpathrectangle
-    {\pgfqpoint{.5\pgfutil@tempdima}{-.5\pgf@xc}}
-    {\pgfpoint{\pgfdecoratedremainingdistance+-.5\pgfutil@tempdimb+-.5\pgfutil@tempdima}{\pgf@xc}}
-  }%
-  \state{end}[width=0pt,next state=final]
-  {
-    {
-    \pgftransformxshift{\pgfdecoratedremainingdistance}%
-    \pgftransformxscale{-1}%
-    \pgftransformxshift{-\pgfkeysvalueof{/pgf/decoration/end radius}}%
-    \pgfpathmoveto{\pgfpointpolar{\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/end radius}}}
-    \pgfpatharc{\pgfdecorationsegmentangle}{-\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/end radius}}
+    \pgfpatharc{\pgfdecorationsegmentangle}{-\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/start radius}}
     \pgfutil@tempcnta=-\pgfdecorationsegmentangle\relax
     \advance\pgfutil@tempcnta by90\relax
-    \pgfmathsetlength\pgfutil@tempdima{\pgfkeysvalueof{/pgf/decoration/end radius}}
-    \pgfmathsetlength\pgfutil@tempdimb{\pgfdecorationsegmentamplitude}%
     \pgfpathcurveto
     {\pgfpointadd
-      {\pgfpointpolar{-\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/end radius}}}
+      {\pgfpointpolar{-\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/start radius}}}
       {\pgfpointpolar{\the\pgfutil@tempcnta}{.25\pgfutil@tempdima}}}
-    {\pgfqpoint{1.25\pgfutil@tempdima}{-.5\pgfutil@tempdimb}}
-    {\pgfqpoint{1.5\pgfutil@tempdima}{-.5\pgfutil@tempdimb}}
-    \pgfpathlineto{\pgfpoint{1.5\pgfutil@tempdima}{.5\pgfutil@tempdimb}}
+    {\pgfpoint{\pgfutil@tempdima+0.5\tikz@lib@mm@startflarelength}{-.5\pgfutil@tempdimb}}
+    {\pgfpoint{\pgfutil@tempdima+1.0\tikz@lib@mm@startflarelength}{-.5\pgfutil@tempdimb}}
+    }
+    {
+    \pgftransformxshift{\pgfdecoratedremainingdistance}%
+    \pgftransformscale{-1}%
+    \pgftransformxshift{-\pgfkeysvalueof{/pgf/decoration/end radius}}%
+    \pgfmathsetlength\pgfutil@tempdima{\pgfkeysvalueof{/pgf/decoration/end radius}}
+    \pgfpathlineto{\pgfpoint{\pgfutil@tempdima+1.0\tikz@lib@mm@endflarelength}{.5\pgfutil@tempdimb}}
     \pgfutil@tempcnta=\pgfdecorationsegmentangle\relax
     \advance\pgfutil@tempcnta by-90\relax
     \pgfpathcurveto
-    {\pgfpoint{1.25\pgfutil@tempdima}{.5\pgfutil@tempdimb}}
+    {\pgfpoint{\pgfutil@tempdima+0.5\tikz@lib@mm@endflarelength}{.5\pgfutil@tempdimb}}
     {\pgfpointadd
       {\pgfpointpolar{\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/end radius}}}
       {\pgfpointpolar{\the\pgfutil@tempcnta}{.25\pgfutil@tempdima}}}
     {\pgfpointpolar{\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/end radius}}}
+    \pgfpatharc{\pgfdecorationsegmentangle}{-\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/end radius}}
+    \pgfutil@tempcnta=-\pgfdecorationsegmentangle\relax
+    \advance\pgfutil@tempcnta by90\relax
+    \pgfpathcurveto
+    {\pgfpointadd
+      {\pgfpointpolar{-\pgfdecorationsegmentangle}{\pgfkeysvalueof{/pgf/decoration/end radius}}}
+      {\pgfpointpolar{\the\pgfutil@tempcnta}{.25\pgfutil@tempdima}}}
+    {\pgfpoint{\pgfutil@tempdima+0.5\tikz@lib@mm@endflarelength}{-.5\pgfutil@tempdimb}}
+    {\pgfpoint{\pgfutil@tempdima+1.0\tikz@lib@mm@endflarelength}{-.5\pgfutil@tempdimb}}
     \pgfpathclose
     }
   }%
@@ -121,6 +107,33 @@ append after command={[fill=\tikz@concept@color,draw=none]}
   \pgf@process{\pgfpointtransformed{\pgfpointanchor{\tikztotarget}{west}}}%
   \advance\pgf@xa by-\pgf@x%
   \pgfkeys{/pgf/decoration/end radius/.expanded=\the\pgf@xa}%
+  % now compute lengths of connection bar flares
+  \pgfpointdiff{\pgfpointanchor{\tikztostart}{center}}%
+               {\pgfpointanchor{\tikztotarget}{center}}%
+  \pgfmathveclen@{\pgf@sys@tonumber\pgf@x}{\pgf@sys@tonumber\pgf@y}%
+  \pgf@xa=\pgfmathresult pt\relax%
+  \pgf@process{%
+    \pgfmathsetlength\pgf@x{\pgfkeysvalueof{/pgf/decoration/start radius}}%
+    \pgfmathsetlength\pgf@y{\pgfkeysvalueof{/pgf/decoration/end radius}}%
+  }%
+  \advance\pgf@x by\pgf@y\relax% x = sum of radii = 2 * nominal sum of flare lengths
+  \advance\pgf@xa by-\pgf@x\relax% xa = distance between circles = room available for flares
+  \pgf@x=.5\pgf@x\relax% x = nominal sum of flare lengths
+  \ifdim\pgf@xa>\pgf@x\relax%
+    \pgf@xa=\pgf@x\relax%
+  \fi% xa = actual sum of flare lengths
+  \edef\tikz@lib@mm@numerator{\pgf@sys@tonumber\pgf@xa}%
+  \edef\tikz@lib@mm@denominator{\pgf@sys@tonumber\pgf@x}%
+  \pgfmathdivide@{\tikz@lib@mm@numerator}{\tikz@lib@mm@denominator}%
+  % math result = flare scale factor; 1.0 means flare length is half of abutting circle radius
+  \pgfmathmultiply@{\pgfmathresult}{.5}%
+  % math result = length of flare, measured in circle radii
+  \pgf@process{%
+    \pgfmathsetlength\pgf@x{\pgfkeysvalueof{/pgf/decoration/start radius}}%
+    \pgfmathsetlength\pgf@y{\pgfkeysvalueof{/pgf/decoration/end radius}}%
+  }%
+  \tikz@lib@mm@startflarelength=\pgfmathresult\pgf@x\relax%
+  \tikz@lib@mm@endflarelength=\pgfmathresult\pgf@y\relax%
 }%
 \def\tikz@compute@segmentamplitude{%
   \pgf@x=\pgfkeysvalueof{/pgf/decoration/start radius}\relax%


### PR DESCRIPTION
When the distance between two concepts is at least half the sum of the concepts' radii, the connection bar is constructed as expected with initial, bar, and final portions.  There is a visual glitch due to abutting filled path segments on certain anti-aliasing PDF rasterizers, including the one built into macOS, but that could be excused because the apparent gap is truly zero-width and a (sane) printer driver would not produce a white line.  However, there is a more serious visual glitch when the distance between two concepts is less than the sum of the concepts' radii.  In that case, the connection bar path becomes self-intersecting, and the even-odd inclusion test results in unfilled wedges.

This patch unifies the three path segments (initial, bar, and final) into a single continuous filled path segment.  It alters the logic which computes the length of the initial and final flares, proportionally reducing them from their nominal values (of one-half the abutted circle radius) in the case where the distance between concept circles would be too small to fit this shape.

Before:
<img width="457" alt="before" src="https://user-images.githubusercontent.com/552810/86262977-2c367680-bb86-11ea-8327-7ea30b0255d4.png">

After:
<img width="472" alt="after" src="https://user-images.githubusercontent.com/552810/86262985-2f316700-bb86-11ea-9518-bf24293f1217.png">

As an added bonus, this patch also eliminates the onscreen glitch on anti-aliasing rasterizers.