### PR TITLE
Minor change

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-math-algorithms.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-math-algorithms.tex
@@ -24,7 +24,7 @@ tricky business and is only recommended for adventurous users.
 
 To add a new function to the math engine the following command can be used:
 
-\begin{command}{\pgfmathdeclarefunction\opt{|*|}\marg{name}\marg{number of arguments}\marg{code}}
+\begin{command}{\pgfmathdeclarefunction\opt{|*|}\marg{function name}\marg{number of arguments}\marg{code}}
     This will set up the parser to recognize a function called \meta{name}. The
     name of the function can consist of, uppercase or lowercase letters,
     numbers or the underscore |_|. In line with many programming languages, a
@@ -120,9 +120,9 @@ To add a new function to the math engine the following command can be used:
 
 To redefine a function use the following command:
 
-\begin{command}{\pgfmathredeclarefunction\marg{function name}\marg{algorithm code}}
+\begin{command}{\pgfmathredeclarefunction\marg{function name}\marg{code}}
     This command redefines the |\pgfmath|\meta{function name}|@| macro with the
-    new \meta{algorithm code}. See the description of the
+    new \meta{code}. See the description of the
     |\pgfmathdeclarefunction| for details. You cannot change the number of
     arguments for an existing function.
     %

--- a/doc/generic/pgf/text-en/pgfmanual-en-math-parsing.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-math-parsing.tex
@@ -515,7 +515,7 @@ some notable exceptions.
 
 \begin{math-function}{subtract(\mvar{x},\mvar{y})}
 \mathcommand
-    Subtract $x$ from $y$.
+    Subtract $y$ from $x$.
     %
 \begin{codeexample}[]
 \pgfmathparse{subtract(75,6)} \pgfmathresult

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeysfiltered.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeysfiltered.tex
@@ -528,12 +528,12 @@ There are some more key filters which have nothing to do with family handling.
     is active or not.
 \end{command}
 
-\begin{command}{\pgfkeysgetfamily\marg{key}\marg{resultmacro}}
-    Returns the family associated to a full key \meta{key} into macro
+\begin{command}{\pgfkeysgetfamily\marg{full key}\marg{resultmacro}}
+    Returns the family associated to a \meta{full key} into macro
     \meta{resultmacro}.
 \end{command}
 
-\begin{command}{\pgfkeyssetfamily\marg{key}\marg{family}}
+\begin{command}{\pgfkeyssetfamily\marg{full key}\marg{family}}
     The command |\pgfkeyssetfamily|\marg{full key}\marg{family} has the same
     effect as |\pgfkeys{|\meta{full key}|/.belongs to family=|\marg{family}|}|.
 \end{command}

--- a/tex/generic/pgf/math/pgfmathcalc.code.tex
+++ b/tex/generic/pgf/math/pgfmathcalc.code.tex
@@ -339,7 +339,7 @@
 
 % \pgfmathpointreflectalongaxis
 %
-% Reflects point #2 around an axis centered on #2 at an angle #3.
+% Reflects point #1 around an axis centered on #2 at an angle #3.
 %
 \def\pgfmathreflectpointalongaxis#1#2#3{%
   \pgf@process{%

--- a/tex/generic/pgf/utilities/pgfutil-common-lists.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common-lists.tex
@@ -104,7 +104,7 @@
     \expandafter\def\csname pgfpPRP@#1@bigbuf@c\endcsname{0}%
 }%
 
-% #1: the item to append
+% #1: the item to prepend
 % #2: the list as macro name
 \long\def\pgfprependlistpushfront#1\to#2{%
     \begingroup


### PR DESCRIPTION
Changes to code:
 - Fixed two typos in code comment.
 - <strike>Commented useless `\tikz@lib@spy@parse@opt` in `spy` library.</strike> Reverted

Changes to doc:
 - Fixed wrong description of `pgfmath` operator `subtract(x, y)`/`\pgfmathsubtract{x}{y}` to "subtract y from x".
 - Enhanced consistency of argument names.
    - Now `pgfmath` macros `\pgfmathdeclarefunction` and `\pgfmathredeclarefunction` use arg-name `<function name>` and `<code>` consistently.
    - Now `pgfkeys` macros `\pgfkeysgetfamily` and `\pgfmathsetfamily` use arg-name `<full key>`, just like similar macros documented in the same subsection.