### PR TITLE
3d text along path

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
@@ -1570,6 +1570,66 @@ shapes. This library is included mostly for historical reasons, using the
     \end{key}
 \end{decoration}
 
+\begin{decoration}{3d text along path}
+    This decoration is almost the same to the |text along path| decoration
+    except that each character is placed on different coordinate plane
+    specified by two unit vectors. The $x$-direction is the tangent direction
+    of the point where the character locates on the path. The $y$-direction is
+    a fixed direction or the direction from the point where the character
+    locates to a fixed point.
+    %
+\begin{codeexample}[preamble={\usetikzlibrary{decorations.text}}]
+\begin{tikzpicture}[decoration={3d text along path,
+  text={|\large\color{red}|3d|| text along path!},
+  text align=center, 3d raise=1cm-.5ex, yvec=60}]
+
+  \draw [fill=gray!30]
+    (0, 2) arc (120:0:2cm) -- ++(60:2cm) arc (0:120:2cm) -- cycle;
+  \path [postaction={decorate}] (0,2) arc (120:0:2cm);
+\end{tikzpicture}
+\end{codeexample}
+\end{decoration}
+
+    \begin{key}{/pgf/decoration/yvec=\marg{number or point} (initially 90)}
+        Set the $y$-direction of every character coordinate plane. If a number
+        is provided, the $y$-direction is the \meta{number}. If a point is
+        provided, the $y$-direction is the direction from the point where the
+        character locates to this \meta{point}.
+        %
+\begin{codeexample}[preamble={\usetikzlibrary{decorations.text}}]
+\begin{tikzpicture}[decoration={3d text along path,
+    text={|\large\color{red}|3d|| text along path!},
+    text align=center, 3d raise=.8ex, yvec={([shift={(60:4cm)}]1.5,1)}}]
+
+  \draw [fill=gray!30]
+    (0, 2) arc (120:0:2cm) -- ([shift={(60:4cm)}]1.5,1) -- cycle;
+  \path [postaction={decorate}] (0,2) arc (120:0:2cm);
+\end{tikzpicture}
+\end{codeexample}
+    \end{key}
+
+    \begin{key}{/pgf/decoration/3d raise=\marg{number or dimension} (initially
+      0pt)}
+        The characters are raised in the $y$-direction of every charater
+        coordinate plane.
+        %
+\begin{codeexample}[preamble={\usetikzlibrary{decorations.text}}]
+\begin{tikzpicture}[decoration={3d text along path,
+    text={|\large\color{red}|3d|| text along path!},
+    text align=center, 3d raise=.8ex, yvec=90}]
+
+  \draw [fill=gray!30]
+    (0,0) arc (180:360:2cm and 1cm) --
+    ++(0,3) arc (360:180:2cm and 1cm) -- cycle;
+  \path [postaction={decorate}] (0,0) arc (180:360:2cm and 1cm);
+  \path [postaction={decorate}, decoration={text={3d raise=1cm}, 3d raise=1cm}]
+    (0,0) arc (180:360:2cm and 1cm);
+  \path [postaction={decorate}, decoration={text={3d raise=2}, 3d raise=2}]
+    (0,0) arc (180:360:2cm and 1cm);
+\end{tikzpicture}
+\end{codeexample}
+    \end{key}
+
 \begin{decoration}{text effects along path}
     This decoration is similar to the |text along path| decoration except that
     each character is inserted into the picture as a \tikzname\ node, and node

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.text.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.text.code.tex
@@ -20,6 +20,8 @@
 \def\tikz@lib@dec@align@right@text{right}%
 \def\tikz@lib@dec@align@center@text{center}%
 \def\tikz@lib@dec@te@none@text{none}%
+\def\tikz@lib@dec@te@yvecangle{90}
+\def\tikz@lib@dec@te@threedimraise{0pt}
 
 % Some ifs
 \newif\iftikz@lib@dec@te@pathfromtext%
@@ -28,6 +30,7 @@
 \newif\iftikz@lib@dec@te@fittexttopath%
 \newif\iftikz@lib@dec@te@wordsep%
 \newif\iftikz@lib@dec@te@finalletter%
+\newif\iftikz@lib@dec@te@yvecispoint
 
 
 % Utility macros
@@ -81,8 +84,6 @@
 \let\tikz@lib@dec@te@wordctotalvar=\pgfutil@empty
 \let\tikz@lib@dec@te@transformtext=\pgfutil@empty%
 \let\tikz@lib@dec@te@yvecendpoint=\pgfutil@empty
-\let\tikz@lib@dec@te@yvecangle=\pgfutil@empty
-\let\tikz@lib@dec@te@threedimraisevar=\pgfutil@empty
 
 
 % Keys... lots of them...
@@ -161,18 +162,23 @@
 % keys for 3d text
 \pgfkeys{%
   /pgf/decoration/.cd,
-  3d raise/.store in=\tikz@lib@dec@te@threedimraisevar,
+  3d raise/.store in=\tikz@lib@dec@te@threedimraise,
   3d raise=0pt,
   yvec/.code={\tikz@handle@vec{\tikz@lib@dec@te@yvec@point}{\tikz@lib@dec@te@yvec@angle}#1\relax}
-  yvec/.initial=90,
 }
 
 % Parse yvec
 % If #1 is an angle, save the angle as the direction of yvec
 % If #1 is a point, parse the point and save it in
 % `\tikz@lib@dec@te@yvecendpoint'
-\def\tikz@lib@dec@te@yvec@angle#1{\def\tikz@lib@dec@te@yvecanglebeforecorrection{#1}}
-\def\tikz@lib@dec@te@yvec@point#1{\def\tikz@lib@dec@te@yvecendpoint{#1}}%
+\def\tikz@lib@dec@te@yvec@angle#1{%
+  \tikz@lib@dec@te@yvecispointfalse%
+  \def\tikz@lib@dec@te@yvecangle{#1}%
+}%
+\def\tikz@lib@dec@te@yvec@point#1{%
+  \tikz@lib@dec@te@yvecispointtrue%
+  \def\tikz@lib@dec@te@yvecendpoint{#1}%
+}%
 
 
 % Prepare the decoration text
@@ -764,10 +770,12 @@
 %
 \state{typeset}[width=+0pt, next state=after typeset,
   persistent precomputation={
-    \pgfmathanglebetweenpoints%
-    {\pgfpointlineatdistance{\pgfdecoratedinputsegmentcompleteddistance}{\pgf@decorate@inputsegment@first}{\pgf@decorate@inputsegment@last}}%
-    {\tikz@lib@dec@te@yvecendpoint}%
-    \xdef\tikz@lib@dec@te@yvecangle{\pgfmathresult}
+    \iftikz@lib@dec@te@yvecispoint
+      \pgfmathanglebetweenpoints%
+      {\pgfpointlineatdistance{\pgfdecoratedinputsegmentcompleteddistance}{\pgf@decorate@inputsegment@first}{\pgf@decorate@inputsegment@last}}%
+      {\tikz@lib@dec@te@yvecendpoint}%
+      \edef\tikz@lib@dec@te@yvecangle{\pgfmathresult}
+    \fi
   }
 ]
 {%
@@ -776,12 +784,17 @@
   \pgftransformtriangle%
   {\pgfpointxy{0}{0}}%
   {\pgfpointxy{1}{0}}%
-  {\pgfpointpolar{\tikz@lib@dec@te@yvecangle-\pgfdecoratedangle}{1cm}}%
+  {\pgfpointpolarxy{\tikz@lib@dec@te@yvecangle-\pgfdecoratedangle}{1}}%
   \pgftransformscale{0.035146}%
   \pgfsetxvec{\pgfpointxy{1}{0}}%
   \pgfsetyvec{\pgfpointxy{0}{1}}%
   \pgfsetzvec{\pgfpointxy{0}{0}}%
-  \pgftransformshift{\pgfpoint{0pt}{\tikz@lib@dec@te@threedimraisevar}}
+  \tikz@checkunit{\tikz@lib@dec@te@threedimraise}%
+  \iftikz@isdimension%
+    \pgftransformshift{\pgfpoint{0pt}{\tikz@lib@dec@te@threedimraise}}%
+  \else%
+    \pgftransformshift{\pgfpointxy{0}{\tikz@lib@dec@te@threedimraise}}%
+  \fi%
   \pgfqboxsynced\pgf@hbox%
 }%
 \state{after typeset}[width=+.5\wd\pgf@lib@dec@text@box, next state=shift,

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.text.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.text.code.tex
@@ -80,6 +80,9 @@
 \let\tikz@lib@dec@te@wordcountvar=\pgfutil@empty
 \let\tikz@lib@dec@te@wordctotalvar=\pgfutil@empty
 \let\tikz@lib@dec@te@transformtext=\pgfutil@empty%
+\let\tikz@lib@dec@te@yvecendpoint=\pgfutil@empty
+\let\tikz@lib@dec@te@yvecangle=\pgfutil@empty
+\let\tikz@lib@dec@te@threedimraisevar=\pgfutil@empty
 
 
 % Keys... lots of them...
@@ -155,9 +158,21 @@
   text effects/.code={\pgfkeysalso{/pgf/decoration/text effects/.cd,#1}},
 }%
 
+% keys for 3d text
+\pgfkeys{%
+  /pgf/decoration/.cd,
+  3d raise/.store in=\tikz@lib@dec@te@threedimraisevar,
+  3d raise=0pt,
+  yvec/.code={\tikz@handle@vec{\tikz@lib@dec@te@yvec@point}{\tikz@lib@dec@te@yvec@angle}#1\relax}
+  yvec/.initial=90,
+}
 
-
-
+% Parse yvec
+% If #1 is an angle, save the angle as the direction of yvec
+% If #1 is a point, parse the point and save it in
+% `\tikz@lib@dec@te@yvecendpoint'
+\def\tikz@lib@dec@te@yvec@angle#1{\def\tikz@lib@dec@te@yvecanglebeforecorrection{#1}}
+\def\tikz@lib@dec@te@yvec@point#1{\def\tikz@lib@dec@te@yvecendpoint{#1}}%
 
 
 % Prepare the decoration text
@@ -676,6 +691,117 @@
   \tikz@lib@dec@te@drawcharacter%
 }%
 \state{post token}[width=+\tikz@lib@dec@te@characterpostwidth, next state=scan]{}%
+}%
+
+
+% 3d text along path
+\pgfdeclaredecoration{3d text along path}{initial}{%
+    \state{initial}[
+        width=+0pt, next state=left indent,
+        persistent precomputation={%
+            \edef\pgf@lib@dec@text@indent@left{\pgfkeysvalueof{/pgf/decoration/text align/left indent}}%
+            \edef\pgf@lib@dec@text@indent@right{\pgfkeysvalueof{/pgf/decoration/text align/right indent}}%
+            \edef\pgf@lib@dec@text@align{\pgfkeysvalueof{/pgf/decoration/text align/align}}%
+            \pgfdecoratedremainingdistance=\pgfdecoratedpathlength%
+        \advance\pgfdecoratedremainingdistance by-\pgf@lib@dec@text@indent@right\relax%
+        \edef\pgfdecoratedpathlength{\the\pgfdecoratedremainingdistance}%
+        \pgf@lib@dec@text@getwidth%
+        \pgf@x=\pgf@lib@dec@text@width\relax%
+        \pgf@y=\pgfdecoratedremainingdistance%
+        \ifpgf@lib@dec@text@fit%
+            \advance\pgf@y by-\pgf@lib@dec@text@indent@left\relax%
+            \advance\pgf@y by-\pgf@x%
+            \ifpgf@lib@dec@text@stretch@spaces%
+                \def\pgf@lib@dec@text@character@shift{0pt}%
+                \divide\pgf@y by\pgf@lib@dec@space@count\relax%
+                \edef\pgf@lib@dec@text@space@shift{\the\pgf@y}%
+            \else%
+                \c@pgf@counta=\pgf@lib@dec@character@count\relax%
+                \advance\c@pgf@counta by-1\relax%
+                \divide\pgf@y by\c@pgf@counta\relax%
+                \edef\pgf@lib@dec@text@character@shift{\the\pgf@y}%
+                \def\pgf@lib@dec@text@space@shift{0pt}%
+            \fi%
+            \ifdim\pgf@y<0pt\relax%
+                \pgf@lib@dec@text@fitfalse%
+                \pgf@lib@dec@text@stretch@spacesfalse%
+                \def\pgf@lib@dec@text@character@shift{0pt}%
+                \def\pgf@lib@dec@text@space@shift{0pt}%
+            \fi%
+        \else%
+            \def\pgf@lib@dec@text@character@shift{0pt}%
+            \def\pgf@lib@dec@text@space@shift{0pt}%
+                \ifx\pgf@lib@dec@text@align\pgf@lib@dec@text@left@text%
+                \else%
+                    \ifx\pgf@lib@dec@text@align\pgf@lib@dec@text@right@text%
+                        \advance\pgf@y by-\pgf@x%
+                        \edef\pgf@lib@dec@text@indent@left{\the\pgf@y}%
+                    \else%
+                        \advance\pgf@y by-\pgf@x%
+                        \advance\pgf@y by-\pgf@lib@dec@text@indent@left\relax%
+                        \pgf@y=0.5\pgf@y%
+                        \advance\pgf@y by\pgf@lib@dec@text@indent@left\relax%
+                        \edef\pgf@lib@dec@text@indent@left{\the\pgf@y}%
+                    \fi%
+                \fi%
+        \fi%
+        \let\pgfdecorationrestoftext=\pgfdecorationtext%
+    }]{}%
+\state{left indent}[width=+\pgf@lib@dec@text@indent@left, next state=scan]{}%
+%
+\state{scan}[
+    width=+0pt,
+    next state=before typeset,
+    persistent precomputation={
+        \pgf@lib@dec@text@scanchar%
+        \ifvoid\pgf@lib@dec@text@box%
+            \setbox\pgf@lib@dec@text@box\hbox{}%
+            \wd\pgf@lib@dec@text@box16383pt\relax%
+        \fi%
+}]{}%
+%
+\state{before typeset}[width=+.5\wd\pgf@lib@dec@text@box, next state=typeset]{}%
+%
+\state{typeset}[width=+0pt, next state=after typeset,
+  persistent precomputation={
+    \pgfmathanglebetweenpoints%
+    {\pgfpointlineatdistance{\pgfdecoratedinputsegmentcompleteddistance}{\pgf@decorate@inputsegment@first}{\pgf@decorate@inputsegment@last}}%
+    {\tikz@lib@dec@te@yvecendpoint}%
+    \xdef\tikz@lib@dec@te@yvecangle{\pgfmathresult}
+  }
+]
+{%
+  \pgftransformxshift{+-.5\wd\pgf@lib@dec@text@box}%
+  \setbox\pgf@hbox\hbox{\copy\pgf@lib@dec@text@box}%
+  \pgftransformtriangle%
+  {\pgfpointxy{0}{0}}%
+  {\pgfpointxy{1}{0}}%
+  {\pgfpointpolar{\tikz@lib@dec@te@yvecangle-\pgfdecoratedangle}{1cm}}%
+  \pgftransformscale{0.035146}%
+  \pgfsetxvec{\pgfpointxy{1}{0}}%
+  \pgfsetyvec{\pgfpointxy{0}{1}}%
+  \pgfsetzvec{\pgfpointxy{0}{0}}%
+  \pgftransformshift{\pgfpoint{0pt}{\tikz@lib@dec@te@threedimraisevar}}
+  \pgfqboxsynced\pgf@hbox%
+}%
+\state{after typeset}[width=+.5\wd\pgf@lib@dec@text@box, next state=shift,
+    persistent precomputation={%
+    \ifpgf@lib@dec@text@fit%
+        \ifpgf@lib@dec@text@stretch@spaces%
+            \ifpgf@lib@dec@text@scan@space%
+                \let\pgf@lib@dec@text@shift=\pgf@lib@dec@text@space@shift%
+            \else%
+                \def\pgf@lib@dec@text@shift{0pt}%
+            \fi%
+        \else%
+            \let\pgf@lib@dec@text@shift=\pgf@lib@dec@text@character@shift%
+          \fi%
+        \else%
+            \def\pgf@lib@dec@text@shift{0pt}%
+      \fi%
+  }]{}%
+\state{shift}[width=+\pgf@lib@dec@text@shift, next state=scan]{}%
+\state{final}{}%
 }%
 
 

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.text.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.text.code.tex
@@ -80,9 +80,6 @@
 \let\tikz@lib@dec@te@wordcountvar=\pgfutil@empty
 \let\tikz@lib@dec@te@wordctotalvar=\pgfutil@empty
 \let\tikz@lib@dec@te@transformtext=\pgfutil@empty%
-\let\tikz@lib@dec@te@yvecendpoint=\pgfutil@empty
-\let\tikz@lib@dec@te@yvecangle=\pgfutil@empty
-\let\tikz@lib@dec@te@threedimraisevar=\pgfutil@empty
 
 
 % Keys... lots of them...
@@ -158,21 +155,9 @@
   text effects/.code={\pgfkeysalso{/pgf/decoration/text effects/.cd,#1}},
 }%
 
-% keys for 3d text
-\pgfkeys{%
-  /pgf/decoration/.cd,
-  3d raise/.store in=\tikz@lib@dec@te@threedimraisevar,
-  3d raise=0pt,
-  yvec/.code={\tikz@handle@vec{\tikz@lib@dec@te@yvec@point}{\tikz@lib@dec@te@yvec@angle}#1\relax}
-  yvec/.initial=90,
-}
 
-% Parse yvec
-% If #1 is an angle, save the angle as the direction of yvec
-% If #1 is a point, parse the point and save it in
-% `\tikz@lib@dec@te@yvecendpoint'
-\def\tikz@lib@dec@te@yvec@angle#1{\def\tikz@lib@dec@te@yvecanglebeforecorrection{#1}}
-\def\tikz@lib@dec@te@yvec@point#1{\def\tikz@lib@dec@te@yvecendpoint{#1}}%
+
+
 
 
 % Prepare the decoration text
@@ -691,117 +676,6 @@
   \tikz@lib@dec@te@drawcharacter%
 }%
 \state{post token}[width=+\tikz@lib@dec@te@characterpostwidth, next state=scan]{}%
-}%
-
-
-% 3d text along path
-\pgfdeclaredecoration{3d text along path}{initial}{%
-    \state{initial}[
-        width=+0pt, next state=left indent,
-        persistent precomputation={%
-            \edef\pgf@lib@dec@text@indent@left{\pgfkeysvalueof{/pgf/decoration/text align/left indent}}%
-            \edef\pgf@lib@dec@text@indent@right{\pgfkeysvalueof{/pgf/decoration/text align/right indent}}%
-            \edef\pgf@lib@dec@text@align{\pgfkeysvalueof{/pgf/decoration/text align/align}}%
-            \pgfdecoratedremainingdistance=\pgfdecoratedpathlength%
-        \advance\pgfdecoratedremainingdistance by-\pgf@lib@dec@text@indent@right\relax%
-        \edef\pgfdecoratedpathlength{\the\pgfdecoratedremainingdistance}%
-        \pgf@lib@dec@text@getwidth%
-        \pgf@x=\pgf@lib@dec@text@width\relax%
-        \pgf@y=\pgfdecoratedremainingdistance%
-        \ifpgf@lib@dec@text@fit%
-            \advance\pgf@y by-\pgf@lib@dec@text@indent@left\relax%
-            \advance\pgf@y by-\pgf@x%
-            \ifpgf@lib@dec@text@stretch@spaces%
-                \def\pgf@lib@dec@text@character@shift{0pt}%
-                \divide\pgf@y by\pgf@lib@dec@space@count\relax%
-                \edef\pgf@lib@dec@text@space@shift{\the\pgf@y}%
-            \else%
-                \c@pgf@counta=\pgf@lib@dec@character@count\relax%
-                \advance\c@pgf@counta by-1\relax%
-                \divide\pgf@y by\c@pgf@counta\relax%
-                \edef\pgf@lib@dec@text@character@shift{\the\pgf@y}%
-                \def\pgf@lib@dec@text@space@shift{0pt}%
-            \fi%
-            \ifdim\pgf@y<0pt\relax%
-                \pgf@lib@dec@text@fitfalse%
-                \pgf@lib@dec@text@stretch@spacesfalse%
-                \def\pgf@lib@dec@text@character@shift{0pt}%
-                \def\pgf@lib@dec@text@space@shift{0pt}%
-            \fi%
-        \else%
-            \def\pgf@lib@dec@text@character@shift{0pt}%
-            \def\pgf@lib@dec@text@space@shift{0pt}%
-                \ifx\pgf@lib@dec@text@align\pgf@lib@dec@text@left@text%
-                \else%
-                    \ifx\pgf@lib@dec@text@align\pgf@lib@dec@text@right@text%
-                        \advance\pgf@y by-\pgf@x%
-                        \edef\pgf@lib@dec@text@indent@left{\the\pgf@y}%
-                    \else%
-                        \advance\pgf@y by-\pgf@x%
-                        \advance\pgf@y by-\pgf@lib@dec@text@indent@left\relax%
-                        \pgf@y=0.5\pgf@y%
-                        \advance\pgf@y by\pgf@lib@dec@text@indent@left\relax%
-                        \edef\pgf@lib@dec@text@indent@left{\the\pgf@y}%
-                    \fi%
-                \fi%
-        \fi%
-        \let\pgfdecorationrestoftext=\pgfdecorationtext%
-    }]{}%
-\state{left indent}[width=+\pgf@lib@dec@text@indent@left, next state=scan]{}%
-%
-\state{scan}[
-    width=+0pt,
-    next state=before typeset,
-    persistent precomputation={
-        \pgf@lib@dec@text@scanchar%
-        \ifvoid\pgf@lib@dec@text@box%
-            \setbox\pgf@lib@dec@text@box\hbox{}%
-            \wd\pgf@lib@dec@text@box16383pt\relax%
-        \fi%
-}]{}%
-%
-\state{before typeset}[width=+.5\wd\pgf@lib@dec@text@box, next state=typeset]{}%
-%
-\state{typeset}[width=+0pt, next state=after typeset,
-  persistent precomputation={
-    \pgfmathanglebetweenpoints%
-    {\pgfpointlineatdistance{\pgfdecoratedinputsegmentcompleteddistance}{\pgf@decorate@inputsegment@first}{\pgf@decorate@inputsegment@last}}%
-    {\tikz@lib@dec@te@yvecendpoint}%
-    \xdef\tikz@lib@dec@te@yvecangle{\pgfmathresult}
-  }
-]
-{%
-  \pgftransformxshift{+-.5\wd\pgf@lib@dec@text@box}%
-  \setbox\pgf@hbox\hbox{\copy\pgf@lib@dec@text@box}%
-  \pgftransformtriangle%
-  {\pgfpointxy{0}{0}}%
-  {\pgfpointxy{1}{0}}%
-  {\pgfpointpolar{\tikz@lib@dec@te@yvecangle-\pgfdecoratedangle}{1cm}}%
-  \pgftransformscale{0.035146}%
-  \pgfsetxvec{\pgfpointxy{1}{0}}%
-  \pgfsetyvec{\pgfpointxy{0}{1}}%
-  \pgfsetzvec{\pgfpointxy{0}{0}}%
-  \pgftransformshift{\pgfpoint{0pt}{\tikz@lib@dec@te@threedimraisevar}}
-  \pgfqboxsynced\pgf@hbox%
-}%
-\state{after typeset}[width=+.5\wd\pgf@lib@dec@text@box, next state=shift,
-    persistent precomputation={%
-    \ifpgf@lib@dec@text@fit%
-        \ifpgf@lib@dec@text@stretch@spaces%
-            \ifpgf@lib@dec@text@scan@space%
-                \let\pgf@lib@dec@text@shift=\pgf@lib@dec@text@space@shift%
-            \else%
-                \def\pgf@lib@dec@text@shift{0pt}%
-            \fi%
-        \else%
-            \let\pgf@lib@dec@text@shift=\pgf@lib@dec@text@character@shift%
-          \fi%
-        \else%
-            \def\pgf@lib@dec@text@shift{0pt}%
-      \fi%
-  }]{}%
-\state{shift}[width=+\pgf@lib@dec@text@shift, next state=scan]{}%
-\state{final}{}%
 }%
 
 


### PR DESCRIPTION
Declare a new decoration: `3d text along path`

Use this decoration to put text on curved surface.

Only two keys are added:
- `3d raise`: apply correct y shift
- `yvec`: specify the direction of y unit vector by an angle or end point(start point is the origin point of the segment)
