### PR TITLE
[doc] Replace \diameter representing radius with \r

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-pgffor.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgffor.tex
@@ -251,12 +251,12 @@ This section describes the package |pgffor|, which is loaded automatically by
 \begin{codeexample}[]
 \begin{tikzpicture}
   % Let's draw circles at interesting points:
-  \foreach \x / \y / \diameter in {0 / 0 / 2mm, 1 / 1 / 3mm, 2 / 0 / 1mm}
-    \draw (\x,\y) circle (\diameter);
+  \foreach \x / \y / \r in {0 / 0 / 2mm, 1 / 1 / 3mm, 2 / 0 / 1mm}
+    \draw (\x,\y) circle (\r);
 
   % Same effect
-  \foreach \center/\diameter in {{(0,0)/2mm}, {(1,1)/3mm}, {(2,0)/1mm}}
-    \draw[yshift=2.5cm] \center circle (\diameter);
+  \foreach \center/\r in {{(0,0)/2mm}, {(1,1)/3mm}, {(2,0)/1mm}}
+    \draw[yshift=2.5cm] \center circle (\r);
 \end{tikzpicture}
 \end{codeexample}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -1929,7 +1929,7 @@ explicitly by using the |pos| option or implicitly by placing the node
 
 \begin{key}{/tikz/auto=\opt{\meta{direction}} (default \normalfont is scope's setting)}
     This option causes an anchor positions to be calculated automatically
-    according to the following rule. Consider a line between to points. If the
+    according to the following rule. Consider a line between two points. If the
     \meta{direction} is |left|, then the anchor is chosen such that the node is
     to the left of this line. If the \meta{direction} is |right|, then the node
     is to the right of this line. Leaving out \meta{direction} causes automatic


### PR DESCRIPTION
1. Replace `-to` with `-To` in Section 3. _Tutorial: A Petri-Net for Hagen_
<strike>Arrow tip `to` is from deprecated library `arrows`, which is not
documented in latest pgfmanual anymore. Use undocumented setting
in tutorial sections will confuse careful new users, see #903. 
Hence I replace `-to` with `->`.</strike>

2. Replace `\diameter` used in `... circle (\diameter)` with `\r`.
_Note:_ Although `... circle (<radius>)` is an old syntax (mentioned
in the last two paragraphs of pgfmanual 3.1.5b, sec. 14.6), I didn't
replace it with `... circle[radius=<radius>]`. 
A simple `grep` shows there are ~200 usages of `... circle (<radius>)`
throughout the pgfmanual, and since this syntax is more convenient, 
I don't have a strong opinion to replace all of them.