### PR TITLE
".search also" is silent with unknown full key, fix #671

### DIFF
--- a/tex/generic/pgf/utilities/pgfkeys.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeys.code.tex
@@ -903,7 +903,10 @@
   \pgfkeys@searchalso@parse#1,\pgfkeys@mainstop
   {%
     \toks0=\expandafter{\pgfkeys@global@temp##1\pgfeov}%
-  \toks1={\pgfkeysalso{/handlers/.unknown/.expand once=\pgfkeys@searchalso@temp@value}}%
+  \toks1={%
+    \pgfkeysgetvalue{/handlers/.unknown/.@cmd}{\pgfkeys@code}%
+    \expandafter\pgfkeys@code\pgfkeys@searchalso@temp@value\pgfeov
+  }%
   \xdef\pgfkeys@global@temp{%
     \noexpand\def\noexpand\pgfkeys@searchalso@temp@value{####1}%
     \noexpand\ifpgfkeysaddeddefaultpath


### PR DESCRIPTION
Currently in `pgfkeys`, if `/key/.search also` is set, unknown full key `\pgfkeys{/key/subkey}` which should call `/key/.unknown` triggers nothing but redefines `/handlers/.unknown/.@cmd`. This PR fixes the problem.

The problem was introduced by commit 96e02db761, as suggested by https://sourceforge.net/p/pgf/patches/19/.

Closes #671