### PR TITLE
pgfsys-xetex: sync with upstream, #909

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-xetex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-xetex.def
@@ -62,7 +62,11 @@
   \pgf@marshal%
 }
 
-\def\pgf@sys@pdf@mark@pos@pgfpageorigin{\pgfqpoint{2\hoffset}{0pt}}
+\ifnum\the\XeTeXversion\expandafter\pgfutil@gobble\XeTeXrevision>0999991\relax
+  \def\pgf@sys@pdf@mark@pos@pgfpageorigin{\pgfqpoint{\hoffset}{\voffset}}
+\else
+  \def\pgf@sys@pdf@mark@pos@pgfpageorigin{\pgfqpoint{2\hoffset}{0pt}}
+\fi
 
 \ifx\paperheight\@undefined
 \else


### PR DESCRIPTION


**Motivation for this change**

There was a [`\pdfsavepos` bug in XeTeX](https://sourceforge.net/p/xetex/bugs/56/) which caused the asymmetric workaround `\pgfqpoint{2\hoffset}{0pt}` in defining node `current page`. XeTeX has fixed the bug in 0.999992 hence now pgf can use a normal symmetric `\pgfqpoint{\hoffset}{\voffset}`.

Compared to the proposed patch given in https://github.com/pgf-tikz/pgf/issues/909#issuecomment-675827488,
```tex
\ifnum\the\XeTeXversion\expandafter\pgfutil@gobble\XeTeXrevision>0999991\relax
```
is used in order to live with possible xetex 1.0+ version numbers.

Fixed #909

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
