### PR TITLE
Fix math lib

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarymath.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarymath.code.tex
@@ -25,9 +25,21 @@
     \if#1u% undefined
         \let\tikz@math@meaning=\tikz@math@meaning@macro%
     \else%
-        \if#1m%
+        \if#1m% "macro:->[...]"
             \let\tikz@math@meaning=\tikz@math@meaning@macro%
         \else%
+            \if#1s% "select font [...]", treat like a macro
+                \let\tikz@math@meaning=\tikz@math@meaning@macro
+            \else
+                \if#2l% "\long [...]macro:->[...]"
+                    \let\tikz@math@meaning=\tikz@math@meaning@macro
+                \else
+                    \if#2o% "\outer [...]macro:->[...]"
+                        \let\tikz@math@meaning=\tikz@math@meaning@macro
+                    \else
+                        \if#2p% "\protected [...]macro:->[...]"
+                            \let\tikz@math@meaning=\tikz@math@meaning@macro
+                        \else
             \if#2d%
                 \let\tikz@math@meaning=\tikz@math@meaning@dimen%
             \else%
@@ -41,6 +53,10 @@
                     \fi%
                 \fi%
             \fi%
+                        \fi% end of \if#2p
+                    \fi% end of \if#2o
+                \fi% end of \if#2l
+            \fi% end of \if#1s
         \fi%
     \fi%
 }%

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarymath.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarymath.code.tex
@@ -21,44 +21,53 @@
 
 \def\tikz@math@getmeaning#1{\expandafter\tikz@math@@getmeaning\meaning#1\tikz@math@getmeaning@stop}%
 
+% a backslash character ("\") with catcode 12 ("other")
+\edef\tikz@math@backslash@token{\expandafter\pgfutil@gobble\string\\}
+
 \def\tikz@math@@getmeaning#1#2#3#4#5\tikz@math@getmeaning@stop{%
-    \if#1u% undefined
-        \let\tikz@math@meaning=\tikz@math@meaning@macro%
-    \else%
-        \if#1m% "macro:->[...]"
-            \let\tikz@math@meaning=\tikz@math@meaning@macro%
-        \else%
-            \if#1s% "select font [...]", treat like a macro
+    \if#1\tikz@math@backslash@token
+        % first token is backslash, test following tokens
+        \if#2l% "\long [...]macro:->[...]"
+            \let\tikz@math@meaning=\tikz@math@meaning@macro
+        \else
+            \if#2o% "\outer [...]macro:->[...]"
                 \let\tikz@math@meaning=\tikz@math@meaning@macro
             \else
-                \if#2l% "\long [...]macro:->[...]"
+                \if#2p% "\protected [...]macro:->[...]"
                     \let\tikz@math@meaning=\tikz@math@meaning@macro
                 \else
-                    \if#2o% "\outer [...]macro:->[...]"
-                        \let\tikz@math@meaning=\tikz@math@meaning@macro
-                    \else
-                        \if#2p% "\protected [...]macro:->[...]"
-                            \let\tikz@math@meaning=\tikz@math@meaning@macro
-                        \else
-            \if#2d%
-                \let\tikz@math@meaning=\tikz@math@meaning@dimen%
-            \else%
-                \if#2c%
-                    \let\tikz@math@meaning=\tikz@math@meaning@count%
-                \else%
-                    \if#3k% A skip. Treat like a dimen.
+                    \if#2d% "\dimen<num>"
                         \let\tikz@math@meaning=\tikz@math@meaning@dimen%
                     \else%
-                        \let\tikz@math@meaning=\tikz@math@meaning@null%
-                    \fi%
-                \fi%
-            \fi%
-                        \fi% end of \if#2p
-                    \fi% end of \if#2o
-                \fi% end of \if#2l
-            \fi% end of \if#1s
-        \fi%
-    \fi%
+                        \if#2c% "\count<num>"
+                            \let\tikz@math@meaning=\tikz@math@meaning@count%
+                        \else%
+                            \if#3k% A skip ("\skip<num>"). Treat like a dimen.
+                                \let\tikz@math@meaning=\tikz@math@meaning@dimen%
+                            \else%
+                                \let\tikz@math@meaning=\tikz@math@meaning@null%
+                            \fi%
+                        \fi%
+                    \fi
+                \fi
+            \fi
+        \fi
+    \else
+        % first token is not backslash, continue to test the first one
+        \if#1u% "undefined"
+            \let\tikz@math@meaning=\tikz@math@meaning@macro%
+        \else%
+            \if#1m% "macro:->[...]"
+                \let\tikz@math@meaning=\tikz@math@meaning@macro%
+            \else%
+                \if#1s% "select font [...]", treat like a macro
+                    \let\tikz@math@meaning=\tikz@math@meaning@macro
+                \else
+                    \let\tikz@math@meaning=\tikz@math@meaning@null
+                \fi
+            \fi
+        \fi
+    \fi
 }%
 
 \def\tikz@math@firstoftwo#1#2{#1}%


### PR DESCRIPTION
**Motivation for this change**

In TikZ's `math` lib, if `\x` is
 - a macro with prefix(ex) in its `\meaning` output, for example defined by `\long\def\x{}` or
 - a font declaration e.g., defined by `\font\x=cmr10`,

then using `\x` as variable name raises errors. This PR fixes the problem. As mentioned in https://github.com/pgf-tikz/pgf/issues/847#issuecomment-688018512, there are more corner cases like font declarations that currently `math` lib won't handle.

Test case:
```tex
\documentclass{article}
\usepackage{tikz}
\usetikzlibrary{math}

\begin{document}
\long\def\x{blub}
\font\y=cmr10 at 10pt\selectfont

% expected output: "1, 2, 3"
\tikzmath{
  \x = 1;
  \y = 2;
  function f(\x, \y) {return \x + \y;};
  int \z;
  \z = f(\x,\y);
  print {\x, \y, \z};
}
\end{document}
```

Fixes #847 

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
