### PR TITLE
fixed typo notes -> nodes

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
@@ -2804,7 +2804,7 @@ The following keys place nodes in a $N\times M$ grid.
 Options like |grow up| or |branch right| do not take the sizes of the
 to-be-positioned nodes into account -- all nodes are placed quite ``dumbly'' at
 grid positions. It turns out that the |Cartesian placement| can also be used to
-place notes in such a way that their height and/or width is taken into account.
+place nodes in such a way that their height and/or width is taken into account.
 Note, however, that while the following options may yield an adequate placement
 in many situations, when you need advanced alignments you should use a |matrix|
 or advanced offline strategies to place the nodes.


### PR DESCRIPTION
Fixed a typo in manual for graphs library.