### PR TITLE
pgfmath wrongly using \pgf@sys@tonumber

### DIFF
--- a/tex/generic/pgf/libraries/luamath/pgflibraryluamath.code.tex
+++ b/tex/generic/pgf/libraries/luamath/pgflibraryluamath.code.tex
@@ -221,7 +221,7 @@
       \pgfluamath@makeparserinactive
     \else
       \pgfmath@error{Sorry, you need the luaTeX engine to use the
-        luamath library}%
+        luamath library}{}%
     \fi},
   luamath/parser and computation/.code={%
     \pgfutil@ifluatex
@@ -229,7 +229,7 @@
       \pgfluamath@makeparseractive
     \else
       \pgfmath@error{Sorry, you need the luaTeX engine to use the
-        luamath library}%
+        luamath library}{}%
     \fi},
   luamath/off/.code={%
     \pgfluamath@makecomputationinactive
@@ -245,7 +245,7 @@
       \pgfluamath@makeparseractive
     \else
       \pgfmath@error{Sorry, you need the luaTeX engine to use the
-        luamath library}%
+        luamath library}{}%
     \fi
   },
     luamath/output format/.is choice,

--- a/tex/generic/pgf/math/pgfmathfloat.code.tex
+++ b/tex/generic/pgf/math/pgfmathfloat.code.tex
@@ -1435,7 +1435,7 @@
                 \pgfmathfloattofixed\pgfmathresult
                 \pgf@xa=\pgfmathresult pt
                 \multiply\pgf@xa by\pgfmathresultdenom
-                \edef\pgfmathfloat@scaled@numerator{\pgf@sys@tonumber\pgf@xa}%
+                \edef\pgfmathfloat@scaled@numerator{\pgfmath@tonumber\pgf@xa}%
                 \expandafter\pgfmathfloat@loc@@to@int\pgfmathfloat@scaled@numerator\relax{\pgfmathresultnumerator}%
             \fi
             \ifpgfmathprintnumber@frac@whole

--- a/tex/generic/pgf/math/pgfmathfloat.code.tex
+++ b/tex/generic/pgf/math/pgfmathfloat.code.tex
@@ -1214,7 +1214,7 @@
             fixed zerofill=false,% useless here!
             sci zerofill=false}%
         \ifx\pgfmathprintnumber@issci\pgfmathprintnumber@RELATIVE@issci
-            \pgfmath@error{The '/pgf/number format/every relative' style should set a valid display style}%
+            \pgfmath@error{The '/pgf/number format/every relative' style should set a valid display style}{}%
         \fi
         \let\pgfmathfloat@round@precision@orig=\pgfmathfloat@round@precision
         \def\pgfmathfloat@round@precision{9999}%
@@ -1312,7 +1312,7 @@
 % The numerator and denominator is always a number (not empty)
 \def\pgfmathfloatgetfrac#1{%
     \pgfutil@ifundefined{pgfmathfloatmultiply@}{%
-        \pgfmath@error{Sorry, the number format 'frac' requires '\string\usetikzlibrary{fpu}' (and, optionally, \string\usepackage{fp}) in order to work correctly}%
+        \pgfmath@error{Sorry, the number format 'frac' requires '\string\usetikzlibrary{fpu}' (and, optionally, \string\usepackage{fp}) in order to work correctly}{}%
         \edef\pgfmathresult{{#1}{0}{1}}%
     }{%
         \pgfmathfloatgetfrac@{#1}%

--- a/tex/generic/pgf/math/pgfmathfloat.code.tex
+++ b/tex/generic/pgf/math/pgfmathfloat.code.tex
@@ -1312,7 +1312,7 @@
 % The numerator and denominator is always a number (not empty)
 \def\pgfmathfloatgetfrac#1{%
     \pgfutil@ifundefined{pgfmathfloatmultiply@}{%
-        \pgfmath@PackageError{Sorry, the number format 'frac' requires '\string\usetikzlibrary{fpu}' (and, optionally, \string\usepackage{fp}) in order to work correctly}%
+        \pgfmath@error{Sorry, the number format 'frac' requires '\string\usetikzlibrary{fpu}' (and, optionally, \string\usepackage{fp}) in order to work correctly}%
         \edef\pgfmathresult{{#1}{0}{1}}%
     }{%
         \pgfmathfloatgetfrac@{#1}%

--- a/tex/generic/pgf/math/pgfmathfunctions.base.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.base.code.tex
@@ -109,7 +109,7 @@
             \divide\c@pgfmath@counta by\pgfmath@base\relax%
             \let\pgfmath@next\pgfmathbasetodec@@@%
         \else
-            \pgfmath@error{Digit `#1' invalid for base \pgfmath@base}%
+            \pgfmath@error{Digit `#1' invalid for base \pgfmath@base}{}%
             \let\pgfmath@next=\relax%
         \fi%
     \fi%
@@ -245,10 +245,10 @@
 
 \def\pgfmath@checkbase#1{%
     \ifnum#1<2\relax%
-        \pgfmath@error{Cannot process numbers in base `#1'.}%
+        \pgfmath@error{Cannot process numbers in base `#1'.}{}%
     \else%
         \ifnum#1>36\relax%
-            \pgfmath@error{Cannot process numbers in base `#1'.}%
+            \pgfmath@error{Cannot process numbers in base `#1'.}{}%
         \fi%
     \fi}
 
@@ -256,7 +256,7 @@
     \expandafter\pgfmath@checknumber@#1\pgfmath@}
 \def\pgfmath@checknumber@#1#2\pgfmath@{%
     \ifx#1-%
-        \pgfmath@error{Cannot process negative numbers.}%
+        \pgfmath@error{Cannot process negative numbers.}{}%
     \fi}
 
 % \pgfmath@ensurenumberlength

--- a/tex/generic/pgf/math/pgfmathfunctions.basic.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.basic.code.tex
@@ -70,7 +70,7 @@
         \let\pgfmath@sign=\pgfmath@empty%
         \ifdim0pt=\pgfmath@y%
             \pgfmath@error{You've asked me to divide `#1' by `#2', %
-                but I cannot divide any number by `#2'}%
+                but I cannot divide any number by `#2'}{}%
         \fi%
         \afterassignment\pgfmath@xa%
         \c@pgfmath@counta\the\pgfmath@y\relax%

--- a/tex/generic/pgf/math/pgfmathfunctions.random.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.random.code.tex
@@ -239,7 +239,7 @@
 % #2 - the name of the list.
 %
 \def\pgfmathrandomitem#1#2{%
-    \pgfmath@ifundefined{pgfmath@randomlist@#2}{\pgfmath@error{Unknown random list `#2'}}{%
+    \pgfmath@ifundefined{pgfmath@randomlist@#2}{\pgfmath@error{Unknown random list `#2'}{}}{%
         \edef\pgfmath@randomlistlength{\csname pgfmath@randomlist@#2\endcsname}%
         \pgfmathrandominteger{\pgfmath@randomtemp}{1}{\pgfmath@randomlistlength}%
         \def#1{\csname pgfmath@randomlist@#2@\pgfmath@randomtemp\endcsname}}}

--- a/tex/generic/pgf/math/pgfmathfunctions.trigonometric.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.trigonometric.code.tex
@@ -249,7 +249,7 @@
   \begingroup%
     \pgfmath@x=#1pt %
     \pgfmath@xa\pgfmath@x%
-    \edef\pgf@temp{\pgf@sys@tonumber\pgfmath@x}%
+    \edef\pgf@temp{\pgfmath@tonumber\pgfmath@x}%
     % compute lossless '*1000' operation:
     \expandafter\pgfmath@multiply@thousand\pgf@temp 000\relax
     \pgfmath@x=\pgfmathresult pt %
@@ -306,7 +306,7 @@
   \begingroup%
     \pgfmath@x#1pt\relax%
     \pgfmath@xa\pgfmath@x%
-    \edef\pgf@temp{\pgf@sys@tonumber\pgfmath@x}%
+    \edef\pgf@temp{\pgfmath@tonumber\pgfmath@x}%
     % compute lossless '*1000' operation:
     \expandafter\pgfmath@multiply@thousand\pgf@temp 000\relax
     \pgfmath@x=\pgfmathresult pt %
@@ -340,7 +340,7 @@
       \pgfmath@x\pgfmathresult pt\relax%
     \fi%
     % compute lossless '*1000' operation:
-    \edef\pgf@temp{\pgf@sys@tonumber\pgfmath@x}%
+    \edef\pgf@temp{\pgfmath@tonumber\pgfmath@x}%
     \expandafter\pgfmath@multiply@thousand\pgf@temp 000\relax
     \pgfmath@x=\pgfmathresult pt %
     \pgfmath@table@lookup{\pgfmath@x}{pgfmath@atan@}{1001}%xxx


### PR DESCRIPTION
**Motivation for this change**

With only `pgfmath.sty` loaded, `asin`, `acos`, and `atan` break for using the wrong macro (Fixes #924).

adb0049 also replaces `\pgfmath@PackageError` by `\pgfmath@error` (the former takes three arguments, but only one exists).

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [X] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [X] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
