### PR TITLE
improved functional shading (dvips); \pgfsys@definemask fixed

### DIFF
--- a/tex/generic/pgf/basiclayer/pgfcoreimage.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcoreimage.code.tex
@@ -146,7 +146,7 @@
     {File "#3" not found when defining mask "#2".
       Tried all extensions in "\pgfsys@imagesuffixlist"}%
   \else%
-    \pgfsys@definemask{#2}%
+    \pgfsys@definemask%
   \fi%
   \expandafter\global\expandafter\let\csname pgf@mask@#2\endcsname=\pgf@mask%
 }

--- a/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
@@ -314,7 +314,7 @@
   \ifx\pgf@imagemask\pgfutil@empty\else\xdef\pgf@imagemask{ /SMask @\pgf@imagemask}\fi%
   \edef\pgf@image{\noexpand\hbox to \pgf@imagewidth{\vbox to \pgf@imageheight{\vfil\special{pdf:image width \pgf@imagewidth\space height \pgf@imageheight\space\pgf@imagepage\space(\pgf@filename) <<\pgf@imageinterpolate\pgf@imagemask\space>>}}\hfil}}%
 }
-\def\pgfsys@definemask#1{%
+\def\pgfsys@definemask{%
   \ifx\pgf@maskmatte\pgfutil@empty%
   \else%
     \edef\pgf@maskmatte{/Matte [\pgf@maskmatte]}%

--- a/tex/generic/pgf/systemlayer/pgfsys-dvips.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvips.def
@@ -335,31 +335,33 @@
             % shading patch width and height
             /pgfpatchX \pgf@sys@tonumber{\pgf@xb} pgfpatchllx sub def
             /pgfpatchY \pgf@sys@tonumber{\pgf@yb} pgfpatchlly sub def
-            % number of samples in each direction
-            pgfpatchX pgfpatchY pgfnumsamples\pgf@shading@model /pgfsamplesy exch def /pgfsamplesx exch def
-            % sample distance in each direction, in bp
-            /pgfpatchdx pgfpatchX pgfsamplesx 1 sub div def /pgfpatchdy pgfpatchY pgfsamplesy 1 sub div def
-            % allocate DataSource string
-            /pgfdatasource pgfsamplesx pgfsamplesy mul pgfsamplesize\pgf@shading@model\space mul string def
+            % number of samples in each direction (with samples spaced by approx. 1bp)
+            /pgfsamplesx pgfpatchX round cvi 1 add def
+            /pgfsamplesy pgfpatchY round cvi 1 add def
+            % exact sample distance in each direction, in bp
+            /pgfpatchdx pgfpatchX pgfsamplesx 1 sub div def
+            /pgfpatchdy pgfpatchY pgfsamplesy 1 sub div def
             %
             pgfpatchllx neg pgfpatchlly neg translate
             /pgfproc {#4} bind def
             %
-            %fill `pgfdatasource' string with colour samples
-            0 1 pgfsamplesy 1 sub
-            {                                % j
-              dup pgfsamplesx mul exch       % samplesdone j
-              pgfpatchdy mul pgfpatchlly add % samplesdone y
-              0 1 pgfsamplesx 1 sub
-              {                                % samplesdone y i
-                dup 3 index add                % samplesdone y i sampleidx
-                pgfdatasource exch 3 -1 roll   % samplesdone y pgfdatasrc sampleidx i
-                pgfpatchdx mul pgfpatchllx add % samplesdone y pgfdatasrc sampleidx x
-                3 index pgfproc                % samplesdone y pgfdatasrc sampleidx <colour>
-                pgfputstring\pgf@shading@model % samplesdone y
-              } for
-              pop pop
-            } for
+            % sampling procedure; repeatedly called by /ReusableStreamDecode filter;
+            % on each call, /pgfsamplingproc puts one colour sample (rgb, cmyk or gray)
+            % on the operand stack which is then consumed by the filter
+            userdict /pgfsampleidx 0 put % internal index; updated on each call 
+            /pgfsamplingproc {
+              pgfsampleidx pgfsamplesx pgfsamplesy mul eq {
+                () % push empty string on the stack to signal end-of-data
+              } {
+                pgfcolorsample\pgf@shading@model\space  % -str-
+                pgfsampleidx pgfsamplesx mod pgfpatchdx mul pgfpatchllx add   % -str- x
+                pgfsampleidx pgfsamplesx idiv pgfpatchdy mul pgfpatchlly add  % -str- x y
+                pgfproc                                 % -str- <colour>
+                pgfwritesample\pgf@shading@model\space  % -str-
+                /pgfsampleidx pgfsampleidx 1 add store  % (update index)
+              } ifelse
+            } bind def
+            %
             pgfpatchY pgfpatchX pgfpatchllx pgfpatchlly pgfe <<
               /PatternType 2
               /Shading <<
@@ -369,12 +371,12 @@
                 /ColorSpace \pgf@shading@device\space
                 /Function <<
                   /FunctionType 0
-                  /Order 1 % splines
+                  /Order 1
                   /Domain [0 1 0 1]
                   /Range pgfrange\pgf@shading@model
                   /BitsPerSample pgfchanneldepth\pgf@shading@model % bits per channel, actually
                   /Size [pgfsamplesx pgfsamplesy]
-                  /DataSource pgfdatasource
+                  /DataSource /pgfsamplingproc load /ReusableStreamDecode filter
                 >>
               >>
             >> matrix makepattern setpattern fill
@@ -389,85 +391,53 @@
 % helpers for converting FunctionType-4 to FunctionType-0, i. e. sampled, functions;
 % FunctionType-4 functions are not defined in PostScript-3
 %
-% Colours in the rectangular shading patch are sampled and stored in a
-% string which is passed as value to the /DataSource key in the /FunctionType 0
-% dictionary. However, PostScript imposes a limit of 65535 characters (bytes) per
-% string. To meet this requirement, we calculate the number of samples in x and y,
-% taking into account the patch dimensions and the colour depth of the colour
-% channels. Also, the distance between colour samples should not be less than 1bp
-% in x and y.
-%
-% The table summarizes the different colour models we are going to use:
-% ------+-------------------+-----------+------------------+----------------------
-% model | channel depth/bit | max value | sample size/byte | max number of samples
-% ------+-------------------+-----------+------------------+----------------------
-%  cmyk |                 8 |       255 |                4 |                 16383
-%   rgb |                 8 |       255 |                3 |                 21845
-%  gray |                24 |  16777215 |                3 |                 21845
-% ------+-------------------+-----------+------------------+----------------------
+% These are the different colour models we are going to use:
+% +-------+-------------------+-----------+------------------+
+% | model | channel depth/bit | max value | sample size/byte |
+% +-------+-------------------+-----------+------------------+
+% |  cmyk |                 8 |       255 |                4 |
+% |   rgb |                 8 |       255 |                3 |
+% |  gray |                24 |  16777215 |                3 |
+% +-------+-------------------+-----------+------------------+
 \expandafter\gdef\expandafter\pgfsys@atbegindocument\expandafter{\pgfsys@atbegindocument%
   \pgf@sys@postscript@header{
     %
-    % X Y pgfnumsamples(cmyk|rgb|gray) ==> nx ny
-    % patch dimensions X, Y in bp; number of samples nx, ny;
-    %
-    /pgfnumsamplescmyk {
-      2 copy div 16383 mul sqrt round cvi                              % X Y nx
-      % sample distance no less than 1bp
-      dup 1 sub 3 index gt {pop exch cvi 1 add} {3 -1 roll pop} ifelse % Y nx
-      dup 16383 exch div cvi                                           % Y nx ny
-      % sample distance no less than 1bp
-      dup 1 sub 3 index gt {pop exch cvi 1 add} {3 -1 roll pop} ifelse % nx ny
-    } bind def
-    %
-    /pgfnumsamplesrgb {
-      2 copy div 21845 mul sqrt round cvi
-      dup 1 sub 3 index gt {pop exch cvi 1 add} {3 -1 roll pop} ifelse
-      dup 21845 exch div cvi
-      dup 1 sub 3 index gt {pop exch cvi 1 add} {3 -1 roll pop} ifelse
-    } bind def
-    %
-    /pgfnumsamplesgray /pgfnumsamplesrgb load def
-    %
-    % -str- sampleindex c m y k pgfputstringcmyk ==> (nothing pushed)
-    % -str- sampleindex r g b   pgfputstringrgb  ==>
-    % -str- sampleindex gray    pgfputstringgray ==>
-    % put colour sample at given sample index into the /DataSource string;
+    % -str- c m y k pgfwritesamplecmyk ==> -str-
+    % -str- r g b   pgfwritesamplergb  ==> -str-
+    % -str- gray    pgfwritesamplegray ==> -str-
+    % writes a single colour sample into the /pgfcolorsample* string;
     % colour components (c,m,y,k; r,g,b; gray) between 0.0 to 1.0
     %
-    /pgfputstringcmyk {
-      5 -1 roll pgfsamplesizecmyk mul 5 1 roll % -str- samplestart c m y k
-      5 index 5 index       5 index pgfcheckcolorrange 255 mul round cvi put
-      5 index 5 index 1 add 4 index pgfcheckcolorrange 255 mul round cvi put
-      5 index 5 index 2 add 3 index pgfcheckcolorrange 255 mul round cvi put
-      5 index 5 index 3 add 2 index pgfcheckcolorrange 255 mul round cvi put
-      pop pop pop pop pop pop
+    /pgfwritesamplecmyk {
+      4 index 0 5 index pgfcheckcolorrange 255 mul round cvi put
+      4 index 1 4 index pgfcheckcolorrange 255 mul round cvi put
+      4 index 2 3 index pgfcheckcolorrange 255 mul round cvi put
+      4 index 3 2 index pgfcheckcolorrange 255 mul round cvi put
+      pop pop pop pop
     } bind def
     %
-    /pgfputstringrgb {
-      4 -1 roll pgfsamplesizergb mul 4 1 roll
-      4 index 4 index       4 index pgfcheckcolorrange 255 mul round cvi put
-      4 index 4 index 1 add 3 index pgfcheckcolorrange 255 mul round cvi put
-      4 index 4 index 2 add 2 index pgfcheckcolorrange 255 mul round cvi put
-      pop pop pop pop pop
-    } bind def
-    %
-    /pgfputstringgray {
-      % grayvalue between 0 and 16777215 (24 bit)
-      pgfcheckcolorrange 16777215 mul round cvi % -str- sampleindex gray24
-      exch pgfsamplesizegray mul exch
-      2 index 2 index       2 index           -16 bitshift put % high byte
-      2 index 2 index 1 add 2 index 65535 and  -8 bitshift put % middle byte
-      2 index 2 index 2 add 2 index   255 and              put % low byte
+    /pgfwritesamplergb {
+      3 index 0 4 index pgfcheckcolorrange 255 mul round cvi put
+      3 index 1 3 index pgfcheckcolorrange 255 mul round cvi put
+      3 index 2 2 index pgfcheckcolorrange 255 mul round cvi put
       pop pop pop
+    } bind def
+    %
+    /pgfwritesamplegray {
+      % grayvalue between 0 and 16777215 (24 bit)
+      pgfcheckcolorrange 16777215 mul round cvi % -str- gray24
+      1 index 0 2 index           -16 bitshift put % high byte
+      1 index 1 2 index 65535 and  -8 bitshift put % middle byte
+      1 index 2 2 index   255 and              put % low byte
+      pop
     } bind def
     %
     % <colour component> pgfcheckcolorrange ==> <something between 0.0 and 1.0>
     % truncates value to the allowed range (user-defined Type-4 functions may
     % happen to provide values outside this range)
     /pgfcheckcolorrange {
-      dup 0.0 ge not {pop 0.0} if
-      dup 1.0 le not {pop 1.0} if
+      dup 0.0 lt {pop 0.0} if
+      dup 1.0 gt {pop 1.0} if
     } bind def
     %
     %colour depths per channel (bit)
@@ -475,10 +445,10 @@
     /pgfchanneldepthrgb 8 def
     /pgfchanneldepthgray 24 def
     %
-    %colour sample size (byte)
-    /pgfsamplesizecmyk 4 def
-    /pgfsamplesizergb 3 def
-    /pgfsamplesizegray 3 def
+    % allocate strings as buffers for storing a single colour sample
+    /pgfcolorsamplecmyk 4 string def
+    /pgfcolorsamplergb 3 string def
+    /pgfcolorsamplegray 3 string def
     %
     %/Range array in the FunctionType 0 dictionary
     /pgfrangecmyk [0 1 0 1 0 1 0 1] def
@@ -637,7 +607,7 @@
 % Image masks
 %
 
-\def\pgfsys@definemask#1{%
+\def\pgfsys@definemask{%
   \global\advance\pgf@objectcount\@ne%
   \ifx\pgf@maskmatte\pgfutil@empty%
   \else%

--- a/tex/generic/pgf/systemlayer/pgfsys-luatex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-luatex.def
@@ -71,7 +71,7 @@
     \edef\pgf@image{\noexpand\useimageresource\the\lastsavedimageresourceindex}%
   \fi
 }%
-\def\pgfsys@definemask#1{%
+\def\pgfsys@definemask{%
   \ifx\pgf@maskmatte\pgfutil@empty%
   \else%
     \edef\pgf@maskmatte{/Matte [\pgf@maskmatte]}%

--- a/tex/generic/pgf/systemlayer/pgfsys-pdftex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-pdftex.def
@@ -68,7 +68,7 @@
     \edef\pgf@image{\noexpand\pdfrefximage\the\pdflastximage}%
   \fi
 }%
-\def\pgfsys@definemask#1{%
+\def\pgfsys@definemask{%
   \ifx\pgf@maskmatte\pgfutil@empty%
   \else%
     \edef\pgf@maskmatte{/Matte [\pgf@maskmatte]}%


### PR DESCRIPTION
**Motivation for this change**
1. Improving implementation of Functional Shadings for the `dvips` driver

The method of converting user-provided code for functional shadings (provided as `/FunctionType 4` function) to PostScript-3 compatible `/FunctionType 0` , i. e. sampled, functions does no more depend on the maximum size (64K)  
of the PS `string` data type. This allows the user to define functional shadings at arbitrary resolution by sizing the shading patch appropriately. This is demonstrated by the Mandelbrot set example in the attached test file [functionalShading.pdf](https://github.com/pgf-tikz/pgf/files/5282276/functionalShading.pdf)  (source listed below; use the Chromium/Chrome-builtin PDF viewer or Acrobat Reader for correct rendering of functional shadings).

2. Removing the unused and un-documented argument from `\pgfsys@definemask` in the driver files of the system layer and in `pgfcoreimage.code.tex` of the basic layer.


**Checklist** 

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html


`functionalShading.tex`:
````latex
\documentclass{article}
\usepackage[a4paper]{geometry}
\usepackage{tikz}
\usetikzlibrary{shadings}
\makeatletter
\usepackage{parskip}
\begin{document}
\pgfdeclarefunctionalshading[black]{portabletwospots}{\pgfpointorigin}{\pgfpoint{3.5cm}{3.5cm}}{}{
2 copy
45 sub dup mul exch
40 sub dup mul 0.5 mul add sqrt
dup mul neg 1.0005 exch exp 1.0 exch sub
3 1 roll
70 sub dup mul .5 mul exch
70 sub dup mul add sqrt
dup mul neg 1.002 exch exp 1.0 exch sub
1.0 3 1 roll
\ifpgfshadingmodelcmyk
\pgffuncshadingrgbtocmyk
\fi
\ifpgfshadingmodelgray
\pgffuncshadingrgbtogray
\fi
}

\selectcolormodel{cmyk}%
\mbox{\pgfuseshading{portabletwospots}}
\selectcolormodel{rgb}%
\mbox{\pgfuseshading{portabletwospots}}
\selectcolormodel{gray}%
\mbox{\pgfuseshading{portabletwospots}}

\pgfdeclarefunctionalshading[mycol]{sweep}{\pgfpoint{-1cm}{-1cm}}
{\pgfpoint{1cm}{1cm}}{\pgfshadecolortorgb{mycol}{\myrgb}}{
2 copy
% whirl
% Calculate "safe" atan of position
2 copy abs exch abs add 0.0001 ge { atan } { pop } ifelse
3 1 roll
dup mul exch
dup mul add sqrt
30 mul
add
sin
1 add 2 div
dup
\myrgb
% push mycol
5 4 roll
% multiply all components by calculated value
mul
3 1 roll
3 index
mul
3 1 roll
4 3 roll
mul
3 1 roll
\ifpgfshadingmodelcmyk
\pgffuncshadingrgbtocmyk
\fi
\ifpgfshadingmodelgray
\pgffuncshadingrgbtogray
\fi
}
\colorlet{mycol}{white}%
\mbox{\pgfuseshading{sweep}}%
\selectcolormodel{rgb}
\colorlet{mycol}{red}%
\mbox{\pgfuseshading{sweep}}
\tikz \shade[upper left=red,upper right=green, lower left=blue,lower right=yellow] (0,0) rectangle (3,2);

\tikz \shade[shading=color wheel] (0,0) circle (1.5);
\tikz \shade[shading=color wheel] [even odd rule] (0,0) circle (1.5) (0,0) circle (1);
\tikz \shade[shading=color wheel black center] (0,0) circle (1.5);
\tikz \shade[shading=color wheel white center] (0,0) circle (1.5);

% original (100bp x 100bp, sampled to 101 x 101)
\tikz \shade[shading=Mandelbrot set] (0,0) rectangle (2,2);
%
% Mandelbrot refined; 800bp x 800bp patch size, 801 x 801 samples
\pgfdeclarefunctionalshading[black]{Mandelbrot set 2}
{\pgfpoint{-400bp}{-400bp}} % original: {-50bp}{-50bp}
{\pgfpoint{400bp}{400bp}}{} % original: {50bp}{50bp}
{
  8 div exch 8 div exch  % <-- added; maps x,y-coords of [(-400bp,-400bp),(400bp,400bp)] domain
  12.5 div exch 12.5 div exch                  % to original [(-50bp,-50bp),(50bp,50bp)] domain
  1 index 1 index
  % Stack: c_r c_i z_r z_i
  % Formula: z' = z^2 + c = (z_r + i z_i)^2 + c_r + i c_i
  %             = (z_r^2 - z_i^2 + c_r) + i (2 z_r z_i + c_i)
  %
  % First iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Second iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Third iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Fourth iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Check for break (to avoid too large numbers)
  1 index dup mul 1 index dup mul add
  4 lt {
  % Fifth iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Sixth iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Seventh iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Check for break (to avoid too large numbers)
  1 index dup mul 1 index dup mul add
  4 lt {
  % Eighth iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Ninth iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  % Tenth iteration
  % 1. Compute z_r^2 -z_i^2 + c_r
  1 index dup mul % z_r^2
  1 index dup mul % z_i^2
  sub             % z_r^2 - z_i^2
  4 index add     % z_r^2 -z_i^2 + c_r
  % 2. Compute 2 z_r z_i + c_i
  3 1 roll
  mul 2 mul       % 2 z_r z_i
  2 index add     % 2 z_r z_i + c_i
  } { pop pop 1000.0 1000.0 } ifelse
  } { pop pop 1000.0 1000.0 } ifelse
  % Compute distance
  dup mul exch
  dup mul
  add sqrt
  dup 4 1 roll
  2 gt { pop pop 2.0 exch div 1.0 exch sub dup dup} {pop pop pop 0.0 0.0 0.0} ifelse
  \ifpgfshadingmodelcmyk
    \pgffuncshadingrgbtocmyk
  \fi
  \ifpgfshadingmodelgray
    \pgffuncshadingrgbtogray
  \fi
}%
\tikz {
  % scale shading patch to the standard 100bp x 100bp size
  \pgfsetadditionalshadetransform{\pgftransformxscale{0.125}\pgftransformyscale{0.125}}
  \shade[shading=Mandelbrot set 2] (0,0) rectangle (2,2);
}

\pgfdeclarefunctionalshading[col1,col2,col3,col4]{bilinear interpolation}
{\pgfpointorigin}{\pgfpoint{100bp}{100bp}}
{%
\pgfshadecolortorgb{col1}{\first}\pgfshadecolortorgb{col2}{\second}%
\pgfshadecolortorgb{col3}{\third}\pgfshadecolortorgb{col4}{\fourth}%
}{
100 div exch 100 div 2 copy
% Calculate y/100 x/100.
neg 1 add exch neg 1 add
% Calculate 1-y/100 1-x/100.
3 1 roll 2 copy exch 5 2 roll 6 copy 6 copy
% Set up stack.
\firstred mul exch \secondred mul add mul
% Process red component.
4 1 roll
\thirdred mul exch \fourthred mul add mul
add
13 1 roll
\firstgreen mul exch \secondgreen mul add mul % Process green component.
4 1 roll
\thirdgreen mul exch \fourthgreen mul add mul
add
7 1 roll
\firstblue mul exch \secondblue mul add mul
% Process blue component.
4 1 roll
\thirdblue mul exch \fourthblue mul add mul
add
\ifpgfshadingmodelcmyk
\pgffuncshadingrgbtocmyk
\fi
\ifpgfshadingmodelgray
\pgffuncshadingrgbtogray
\fi
}%
\colorlet{col1}{blue}%
\colorlet{col2}{yellow}%
\colorlet{col3}{red}%
\colorlet{col4}{green}%
\selectcolormodel{cmyk}%
\mbox{\pgfuseshading{bilinear interpolation}}
\selectcolormodel{rgb}%
\mbox{\pgfuseshading{bilinear interpolation}}
\selectcolormodel{gray}%
\mbox{\pgfuseshading{bilinear interpolation}}

\end{document}
````
