### PR TITLE
Fix doc

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-arrows.tex
@@ -142,7 +142,7 @@ We will use the following terminology:
     \item There is also a \emph{visual tip end}, the counterpart of the visual
         back end for the front. In our case, the visual tip end and the tip end
         obviously coincide, but if we were to reverse the arrow tip, the visual
-        tip end would be different form the tip end (while the visual back end
+        tip end would be different from the tip end (while the visual back end
         would then coincide with the new back end).
     \item There are four points that make up the \emph{convex hull} of the
         arrow tip: $(1,0)$, $(-3,2)$, and $(-3,-2)$.
@@ -258,7 +258,7 @@ fast arrow tip management.
             This defines the name of the arrow tip. It is legal to define an
             arrow tip a second time, in this case the previous definition will
             be overwritten in the current \TeX\ scope. It is customary to use a
-            name with an uppercase fist letter for a ``complete'' arrow tip
+            name with an uppercase first letter for a ``complete'' arrow tip
             kind. Short names and lower case names should be used for
             shorthands that change their meaning inside a document, while arrow
             tips with uppercase first letters should not be redefined.
@@ -917,7 +917,7 @@ you need to make \pgfname\ ``aware'' of this using the following key:
 \end{command}
 
 \begin{command}{\pgfarrowslinewidthdependent\marg{dimension}\marg{line width factor}\marg{outer factor}}
-    This command take three parameters and does the ``line width dependent
+    This command takes three parameters and does the ``line width dependent
     computation'' described on page~\pageref{length-arrow-key} for the |length|
     key. The result is returned in |\pgf@x|.
 
@@ -937,7 +937,7 @@ you need to make \pgfname\ ``aware'' of this using the following key:
 \end{command}
 
 \begin{command}{\pgfarrowslengthdependent\marg{dimension}\marg{length factor}\marg{dummy}}
-    This command take three parameters, of which the last one is ignored, and
+    This command takes three parameters, of which the last one is ignored, and
     does the ``length dependent computation'' described for the |width'| and
     |inset'| keys. The result is returned in |\pgf@x|.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
@@ -171,7 +171,7 @@ must set up the box |\pgfnodepartXYZbox|. The box will be placed at the anchor
     As can be seen, all coordinate transformations are also applied to the text
     of the shape. Sometimes, it is desirable that the transformations are
     applied to the point where the shape will be anchored, but you do not wish
-    the shape itself to the transformed. In this case, you should call
+    the shape itself to be transformed. In this case, you should call
     |\pgftransformresetnontranslations| prior to calling the |\pgfnode|
     command.
     %

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-formats.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-formats.tex
@@ -71,7 +71,7 @@ point may span several lines, but deviating from this ``one data point per
 line'' rule makes parsers harder to program.
 
 
-\subsection{Reference: Build-In Formats}
+\subsection{Reference: Built-In Formats}
 
 The following format is the default format, when no |format=...| is specified.
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-dv-stylesheets.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-dv-stylesheets.tex
@@ -781,7 +781,7 @@ data group {sin functions};
     visualizer.
 \end{stylesheet}
 
-\begin{stylesheet}{vary dashing and thickness}
+\begin{stylesheet}{vary thickness and dashing}
     This style alternates between varying the thickness and the dashing of
     lines. The difference to just using both the |vary thickness| and
     |vary dashing| is that too thick lines are avoided. Instead, this style

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -402,7 +402,7 @@ In order to setup a special syntax handling for \meta{strings} that begin with
 a certain character, two things need to be done:
 %
 \begin{enumerate}
-    \item First, the whole first char syntax detection must be ``switched on'',
+    \item First, the whole |first char syntax| detection must be ``switched on'',
         since, by default, it is turned off for efficiency reasons (the
         overhead is rather small, however). This is done by setting the
         following key:
@@ -1264,7 +1264,7 @@ directly stored in a key.
 \end{handler}
 
 \begin{handler}{{.add}|=|\marg{prefix value}\marg{append value}}
-    Adds the \meta{prefix value} and the beginning and the \meta{append value}
+    Adds the \meta{prefix value} at the beginning and the \meta{append value}
     at the end of the value stored in \meta{key}.
 \end{handler}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
@@ -398,7 +398,7 @@ context:
             to select this), the size of the arrow should still be the same
             as in the first case (that is, as if a miter join were used).
             This creates some ``visual consistency'' if the two modes are
-            mixed or if you later one change the mode.
+            mixed or if you later want to change the mode.
             %
 \begin{codeexample}[preamble={\usetikzlibrary{arrows.meta}}]
 \tikz{
@@ -417,7 +417,7 @@ context:
 
 \begin{key}{/pgf/arrow keys/width=\meta{dimension}| |\opt{\meta{line width factor}}%
         | |\opt{\meta{outer factor}}}
-    This key works line the |length| key, only it specifies the ``width'' of
+    This key works like the |length| key, only it specifies the ``width'' of
     the arrow tip; so if width and length are identical, the arrow will just
     touch the borders of a square. (An exception to this rule are ``halved''
     arrow tips, see Section~\ref{section-arrow-key-harpoon}.) The meaning of

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
@@ -160,7 +160,7 @@ the following example:
   \graph { foo -> bar -> blub };
 \end{codeexample}
 
-As can be seen, the text |foo -> bar -> my node| creates three nodes, one with
+As can be seen, the text |foo -> bar -> blub| creates three nodes, one with
 the text |foo|, one with |bar| and one with the text |blub|. These nodes are
 connected by arrows, which are caused by the |->| between the node texts. Such
 a sequence of node texts and arrows between them is called a \emph{chain} in
@@ -296,7 +296,7 @@ going from |b| to |c| and the edge going from |b| to |d|. To achieve this
 effect, we can no longer specify the label as part of the options of |--|.
 Rather, we must pass the desired label to the nodes |c| and |d|, but we must
 somehow also indicate that these options actually ``belong'' to the edge
-``leading to'' to nodes. This is achieved by preceding the options with a
+``leading'' to nodes. This is achieved by preceding the options with a
 greater-than sign:
 %
 \begin{codeexample}[preamble={\usetikzlibrary{graphs,quotes}}]

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
@@ -69,8 +69,8 @@ which is described in the subsections of the present section.
             %
 \begin{codeexample}[]
 \tikz{\draw (0,0) -- (1,1);
-      \draw [color=red] (2,0) -- (3,1);
-      \draw [color=blue] (3,0) -- (2,1);}
+      \draw [color=red] (1,1) -- (2,0) -- (3,1);
+      \draw [color=blue] (3,1) -- (3,0) -- (2,1);}
 \end{codeexample}
     \end{enumerate}
 
@@ -1134,6 +1134,7 @@ for a reference.
 
 The \emph{let operation} is the first of a number of path operations that do
 not actually extend that path, but have different, mostly local, effects.
+It requires the |calc| library, see Section~\ref{tikz-lib-calc}.
 
 \begin{pathoperation}{let}{\meta{assignment}
         \opt{|,|\meta{assignment}}%
@@ -1178,7 +1179,7 @@ not actually extend that path, but have different, mostly local, effects.
     The second kind of \meta{assignments} have the following form:
     %
     \begin{quote}
-        |\p|\meta{point register}|={|\meta{formula}|}|
+        |\p|\meta{point register}|=|\meta{coordinate}
     \end{quote}
     %
     Point position registers store a single point, consisting of an $x$-part

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-plots.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-plots.tex
@@ -198,7 +198,7 @@ namely whenever you use an expression involving a parenthesis.
 The following options influence how the \meta{coordinate expression} is
 evaluated:
 %
-\begin{key}{/tikz/variable=\meta{macro} (initially x)}
+\begin{key}{/tikz/variable=\meta{macro} (initially \string\x)}
     Sets the macro whose value is set to the different values when
     \meta{coordinate expression} is evaluated.
 \end{key}

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -3033,7 +3033,7 @@ The following macro may be useful there:
     Expands to the last node on the path.
 \end{command}
 
-Instead of the |node also| syntax, you can also the following option:
+Instead of the |node also| syntax, you can also use the following option:
 
 \begin{key}{/tikz/late options=\meta{options}}
     This option can be given on a path (but not as an argument to a |node| path

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-transformations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-transformations.tex
@@ -97,7 +97,7 @@ To change the $x$-, $y$-, and $z$-vectors, you can use the following options:
     corner of the grid.
 
     If \meta{value} is a coordinate, the $x$-vector of \pgfname's
-    $xyz$-coordinate system to the specified coordinate. If \meta{value}
+    $xyz$-coordinate system is set to the specified coordinate. If \meta{value}
     contains a comma, it must be put in braces.
     %
 \begin{codeexample}[]


### PR DESCRIPTION
**Motivation for this change**

Fix various minor typo found in pgfmanual.

One notable change: https://github.com/pgf-tikz/pgf/compare/master...muzimuzhi:fix-doc?expand=1#diff-4397e74bc0ccbad7ba99c8b9c118c68f

* before (pgfmanual v3.1.6a, page 153) 
   ![image](https://user-images.githubusercontent.com/6376638/94991322-f8b81d80-05b4-11eb-987f-ab42d2c1cb2b.png)

* after
   ![image](https://user-images.githubusercontent.com/6376638/94991332-05d50c80-05b5-11eb-9c5f-40793f3c09ff.png)


Fixes #930

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
