### PR TITLE
Consistently define `.@cmd` long and fix spurious spaces

### DIFF
--- a/tex/generic/pgf/utilities/pgfkeys.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeys.code.tex
@@ -1035,50 +1035,50 @@
 
 \pgfkeys{
   /errors/boolean expected/.code 2 args=%
-  {
-    \toks1={#1}
-    \toks2={#2}
+  {%
+    \toks1={#1}%
+    \toks2={#2}%
     \pgfkeys@error{%
       Boolean parameter of key '\the\toks1' must be 'true' or 'false', not
       '\the\toks2'. I am going to ignore it%
-    }
+    }%
   },
   /errors/value required/.code 2 args=%
-  {
-    \toks1={#1}
+  {%
+    \toks1={#1}%
     \pgfkeys@error{%
       The key '\the\toks1' requires a value. I am going to ignore this
       key%
-    }
+    }%
   },
   /errors/value forbidden/.code 2 args=%
-  {
-    \toks1={#1}
-    \toks2={#2}
+  {%
+    \toks1={#1}%
+    \toks2={#2}%
     \pgfkeys@error{%
       You may not specify a value for the key '\the\toks1'. I am going to ignore
       the value '\the\toks2' that you provided%
-    }
+    }%
   },
   /errors/unknown choice value/.code 2 args=%
-  {
-    \toks1={#1}
-    \toks2={#2}
+  {%
+    \toks1={#1}%
+    \toks2={#2}%
     \pgfkeys@error{%
       Choice '\the\toks2' unknown in choice key '\the\toks1'. I am
       going to ignore this key%
-    }
+    }%
   },
   /errors/unknown key/.code 2 args=%
-  {
-    \toks1={#1}
-    \toks2={#2}
+  {%
+    \toks1={#1}%
+    \toks2={#2}%
     \def\pgf@temp{#2}%
     \pgfkeys@error{%
       I do not know the key '\the\toks1'\ifx\pgf@temp\pgfkeysnovalue@text\space\else, to which you passed
       '\the\toks2', \fi and I am going to ignore it. Perhaps you
       misspelled it%
-    }
+    }%
   }
 }
 

--- a/tex/generic/pgf/utilities/pgfkeys.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeys.code.tex
@@ -749,7 +749,7 @@
   {%
     \pgfkeysgetvalue{\pgfkeyscurrentpath/.@args}{\pgfkeys@tempargs}%
     \pgfkeysgetvalue{\pgfkeyscurrentpath/.@body}{\pgfkeys@tempbody}%
-    \def\pgfkeys@marshal{\expandafter\gdef\expandafter\pgfkeys@global@temp\pgfkeys@tempargs}%
+    \def\pgfkeys@marshal{\expandafter\long\expandafter\gdef\expandafter\pgfkeys@global@temp\pgfkeys@tempargs}%
     \expandafter\pgfkeys@marshal\expandafter{\pgfkeys@tempbody}%
   }%
     \pgfkeysifdefined{\pgfkeyscurrentpath/.@@body}{%


### PR DESCRIPTION
**Motivation for this change**

This PR fixes two minor problems I found when reading `pgfkeys.code.tex`.
 1. In definition of `/.add code`, branch that subkey `/.@args` is defined, the subkey `/.@cmd` is redefined short (without prefix `\long`), which is inconsistent with all other codes that (re)define `/.@cmd`.
 1. Some spurious spaces found in defining five `/errors/...` keys. 

PS: With `\unexpanded` from eTeX, the code for `/errors/...` keys can be simplified so that the use of `\toks` is avoidable.

PS2: To avoid "at" github user cmd, `` `/.@cmd` `` is used instead of `"/.@cmd"` in commit message.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
