### PR TITLE
Pluralization typo fix in docs

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-actions.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-actions.tex
@@ -620,7 +620,7 @@ For this to happen, a number of different things need to be specified:
         Section~\ref{section-tikz-arrows}, to setup which kinds of arrow tips
         you would like.
     \item The path may not be closed (like a circle or a rectangle) and, if
-        it consists of several subpath, further restrictions apply as
+        it consists of several subpaths, further restrictions apply as
         explained in Section~\ref{section-tikz-arrows}.
     \item The |tips| key must be set to an appropriate value, see
         Section~\ref{section-tikz-arrows} once more.


### PR DESCRIPTION
**Motivation for this change**

I came across a trivial pluralization typo in the docs. Since this was the first typo I've found in 7 years of Ti*k*Z use, I figured I won't wait until I find some other ones to open a PR :)

**Checklist**

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
