### PR TITLE
hiding smask in the PS viewer (dvips driver)

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-dvips.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvips.def
@@ -474,15 +474,27 @@
     \expandafter\xdef\csname pgfsmasktrans@#1\endcsname{%
       \noexpand\pgftransformcm{1}{0}{0}{1}{\noexpand\pgfqpoint{\the\pgf@x}{\the\pgf@y}}}%
     \edef\@tempa{\noexpand\pgfutil@insertatbegincurrentpagefrombox{%
-      % box coordinates (reference point and top) needed for distilling
+      % box coordinates (reference point and top) needed for ps2pdf
       \pgfsys@outerinvoke{currentpoint /pgf@refy exch def /pgf@refx exch def}%
       \hbox to 0pt {\hbox to \ifdim\ht#2>\ht\strutbox\ht#2\else\ht\strutbox\fi{\hss\pgfsys@outerinvoke{%
         /pgf@top pgf@refy currentpoint pop pgf@refx sub VResolution Resolution div mul sub def%
       }}\hss}%
+      % lower-right box corner coordinates for viewing
+      \hbox to 0pt {\hbox to \wd#2{\hss\pgfsys@outerinvoke{/pgf@right currentpoint pop def}}\hss}%
+      \hbox to 0pt {\hbox to \ifdim\dp#2>\dp\strutbox\dp#2\else\dp\strutbox\fi{\hss\pgfsys@outerinvoke{%
+        /pgf@bot pgf@refy currentpoint pop pgf@refx sub VResolution Resolution div mul add def%
+      }}\hss}%
       \pgfsys@outerinvoke{gsave
-        % translate box to upper left page corner, so we have the whole clipping path (i. e.
-        % page area) available for distilling, as outlying parts get clipped
-        clippath pathbbox newpath pop pop translate pgf@refx neg pgf@top neg translate
+        clippath pathbbox newpath pop pop translate
+        systemdict /pdfmark known {%
+          % for ps2pdf, translate box to upper-left page corner, so we have the whole clipping
+          % path (i. e. page area) available, as outlying parts get clipped
+          pgf@refx neg pgf@top neg translate%
+        } {%
+          % for viewing, however, we want to hide the box by moving it off-page; we do so by aligning
+          % the lower-right box corner with the upper-left page corner
+          pgf@right neg pgf@bot neg translate%
+        } ifelse
         % translate origin (0,0) to the reference point
         gsave pgf@refx pgf@refy translate
         mark /_objdef {pgfsmaskxform@\the\pgf@objectcount}


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

When creating a fading, as a first step, a PDF XObject needs to be created from the underlying shading. Later, it serves as a soft mask for adding opacity gradients to graphical objects. In the `dvips` driver, XObject generation is done using `/BP` and `/EP` pdfmarks, and the shading is translated to the upper left page corner during the process. Although not suitable for distribution or printing (transparency is a PDF feature), the intermediate PostScript displays the shading when opened in a PostScript viewer or when sent to a printer. This might be disturbing, as the issue was brought up in https://tex.stackexchange.com/q/568560 .

This PR simply translates the shading off-page for viewing purposes in order to hide it from display.

This is a small test file. The effect of the PR is to be seen in the `dvips` output, when opened in Evince or Gv:

````latex
\documentclass{article}

\usepackage[a6paper,landscape]{geometry}
\usepackage{tikz}
\usetikzlibrary{patterns}

\begin{document}

% define soft mask
\pgfdeclarefading{myFading}{%
  \tikz\shade [left color=pgftransparent!0, right color=pgftransparent!100] (0,0) rectangle (2,2);%
}%
%
\begin{tikzpicture}
  % checkerboard background
  \pattern [pattern=checkerboard, pattern color=black!30] (0,0) rectangle (9,4);
  % blue rect with transparency gradient
  \fill [color=blue, path fading=myFading] (1,1) rectangle (3,3);
  % red rect with transparency gradient
  \fill [color=red, path fading=myFading] (4,1) rectangle (8,3);
\end{tikzpicture}

\end{document}
````

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
