### PR TITLE
Fix typos in the manual

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-arrows.tex
@@ -329,7 +329,7 @@ context:
     As an example, when you write |length=0pt 5|, the length of the arrow will
     be exactly five times the current line width. As another example, the
     default length of a |Latex| arrow is |length=3pt 4.5 0.8|. Let us ignore
-    the 0.8 for a moment; the |4pt 4.5| then means that for the standard line
+    the 0.8 for a moment; the |3pt 4.5| then means that for the standard line
     width of |0.4pt|, the length of a |Latex| arrow will be exactly 4.8pt (3pt
     plus 4.5 times |0.4pt|).
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-paths.tex
@@ -599,7 +599,7 @@ You can add a grid to the current path using the |grid| path operation.
     This operations adds a grid filling a rectangle whose two corners are given
     by \meta{corner} and by the previous coordinate. (Instead of a coordinate
     you can also say |cycle| to use the position of the last move-to as the
-    corner coordinate, but it not very natural to do so.) corner Thus, the
+    corner coordinate, but it not very natural to do so.) Thus, the
     typical way in which a grid is drawn is |\draw (1,1) grid (3,3);|, which
     yields a grid filling the rectangle whose corners are at $(1,1)$ and
     $(3,3)$. All coordinate transformations apply to the grid.

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-pics.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-pics.tex
@@ -613,7 +613,7 @@ handler that allows us to write even simpler code, namely:
 \end{codeexample}
 
 \begin{handler}{{.pic}|=|\meta{some code}}
-    This handler can only be used with a key with the prefix |/tikz/|, so just
+    This handler can only be used with a key with the prefix |/tikz/|, so you
     should normally use it only as an option to a \tikzname\ command or to the
     |\tikzset| command. It takes the \meta{key}'s path and, inside that path,
     it replaces |/tikz/| by |/tikz/pics/| (so, basically, it adds the

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -313,7 +313,7 @@ The syntax for specifying nodes is the following:
 \end{codeexample}
     %
     As the example shows, a \meta{list} can contain ellipses (three dots) to
-    indicated that a larger number of numbers is meant. Indeed, you can use the
+    indicate that a larger number of numbers is meant. Indeed, you can use the
     full power of the |\foreach| command here, including multiple parameters
     and options, see Section~\ref{section-foreach}.
 
@@ -1853,7 +1853,7 @@ force:
 \subsection{Placing Nodes on a Line or Curve Explicitly}
 \label{section-nodes-placing-1}
 
-Until now, we always placed node on a coordinate that is mentioned in the path.
+Until now, we always placed nodes on a coordinate that is mentioned in the path.
 Often, however, we wish to place nodes on ``the middle'' of a line and we do
 not wish to compute these coordinates ``by hand''. To facilitate such
 placements, \tikzname\ allows you to specify that a certain node should be
@@ -1928,7 +1928,7 @@ explicitly by using the |pos| option or implicitly by placing the node
 \end{key}
 
 \begin{key}{/tikz/auto=\opt{\meta{direction}} (default \normalfont is scope's setting)}
-    This option causes an anchor positions to be calculated automatically
+    This option causes an anchor position to be calculated automatically
     according to the following rule. Consider a line between two points. If the
     \meta{direction} is |left|, then the anchor is chosen such that the node is
     to the left of this line. If the \meta{direction} is |right|, then the node
@@ -2387,7 +2387,7 @@ following library, you get access to an even more concise syntax:
 
 Let us start with the basics of what this library does: Once loaded, inside the
 options of a |node| command, instead of the usual \meta{key}|=|\meta{value}
-pairs, you may also provide strings of the following form (the actual syntax
+pairs, you may also provide strings of the following form (the actual syntax is
 slightly more general, see the detailed descriptions later on):
 %
 \begin{quote}
@@ -2435,7 +2435,7 @@ options in curly braces:
 \end{tikzpicture}
 \end{codeexample}
 
-Let us now have a more detailed look at what which commands this library
+Let us now have a more detailed look at what commands this library
 provides:
 
 \begin{key}{/tikz/quotes mean label}


### PR DESCRIPTION
Sometimes there were multiple ways to fix a typo. I then chose what I believe was the intended version of that sentence.
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
