### PR TITLE
Improve doc and code comments for \pgfmathdeclarerandomlist

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-math-commands.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-math-commands.tex
@@ -74,7 +74,7 @@ Section~\ref{pgfmath-functions-random}, the following commands are provided:
     %
 \end{command}
 
-\begin{command}{\pgfmathdeclarerandomlist\marg{list name}\{\marg{item-1}\marg{item 2}...\}}
+\begin{command}{\pgfmathdeclarerandomlist\marg{list name}{\ttfamily\{}\marg{item-1}\marg{item-2}...{\ttfamily\}}}
     This creates a list of items with the name \meta{list name}.
 \end{command}
 

--- a/tex/generic/pgf/math/pgfmathfunctions.random.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.random.code.tex
@@ -210,7 +210,7 @@
 % Create a list to be used with \pgfmathrandomelement.
 %
 % #1 - the name of the list
-% #2 - a list of comma separated elements.
+% #2 - a list of elements (e.g., {item-1}{item-2}...{item-n}).
 %
 \def\pgfmathdeclarerandomlist#1#2{%
     \def\pgfmath@randomlistname{#1}%


### PR DESCRIPTION
**Motivation for this change**

<strike>Following https://github.com/pgf-tikz/pgf/commit/8a997bbc1b41c5d47f202a735d25efd4d6944d81, this PR improves doc and code comment for `\pgfmathrandominteger`, and additionally for `\pgfmathdeclarerandomlist`.</strike>

Being a by-product of reading #954 and its fix https://github.com/pgf-tikz/pgf/commit/8a997bbc1b41c5d47f202a735d25efd4d6944d81, this PR slightly improves the doc and code comments for `\pgfmathdeclarerandomlist`.

PS: the syntax of random lists were changed from comma-separated lists to token/balanced text lists by https://github.com/pgf-tikz/pgf/commit/7ee4c13e888d3e0201945603e07ec61bea4690e8, committed on Apr 26, 2007.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
