### PR TITLE
doc: clarify path or full key start with slash #904

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -185,6 +185,11 @@ partial key or a full key: If it starts with a slash, then it is a full key and
 it is not modified; if it does not start with a slash, then the default path is
 automatically prefixed.
 
+\emph{Remark:} The above rule is actually a definition, hence the corresponding
+sufficiency conditions hold. That is, if it is a full key, then it starts with
+a slash; if it is a partial key, then it does not start with a slash. Moreover,
+a path always starts with a slash.
+
 Note that the default path is not the same as a search path. In particular, the
 default path is just a single path. When a partial key is given, only this
 single default path is prefixed; |pgfkeys| does not try to look up the key in


### PR DESCRIPTION
**Motivation for this change**

Adds clarification that a path or full key in `pgfkeys` must start with slash.

Fixes #904

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
