### PR TITLE
Document \pgfpointtransformed and the relation of /.code and /.initial

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-transformations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-transformations.tex
@@ -522,6 +522,16 @@ matrices.
 \end{command}
 
 
+\subsubsection{Applying Coordinate Transformation to Points}
+
+\begin{command}{\pgfpointtransformed\marg{point}}
+    Applies current transformation matrix to \marg{point} $(x,y)$ and returns a
+    transformed point $(ax+cy+s,bx+dy+t)$. Normally, this is done automatically
+    by commands like |\pgfpathlineto| or |\pgfpathmoveto|, but sometimes you
+    may wish to access a transformed point yourself.
+\end{command}
+
+
 \subsubsection{Computing Adjustments for Coordinate Transformations}
 \label{section-adjustment-transformations}
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -1253,6 +1253,22 @@ directly stored in a key.
     and, thus, |\pgfkeysnovalue| will be stored in |/my key|.
 
     To retrieve the value stored in a key, the handler |/.get| is used.
+    
+    \medskip
+    \emph{Remark:} A key can both store a value and execute commands. If so,
+    using \meta{key} will \emph{always} execute commands with the passed
+    value, or the default value |\pgfkeysnovalue| if no value is provided.
+    Note that the stored value is never used. To update the stored value, the
+    handler |/.initial| or command |\pgfkeyssetvalue| is used.
+    %
+\begin{codeexample}[]
+\pgfkeys{/my key/.initial=red}
+\pgfkeys{/my key/.code=#1}
+% "/my key" now both stores the value "red" and executes commands
+\pgfkeys{/my key=blue}
+% "/my key" now still stores the value "red"
+\end{codeexample}
+    %
 \end{handler}
 
 \begin{handler}{{.get}|=|\meta{macro}}

--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -1255,8 +1255,11 @@ directly stored in a key.
     To retrieve the value stored in a key, the handler |/.get| is used.
     
     \medskip
-    \emph{Remark:} A key can both store a value and execute commands. If so,
-    using \meta{key} will \emph{always} execute commands with the passed
+    \emph{Remark:} A key can both store a value and execute commands%
+    \footnote{This behavior was partially changed in \pgfname{} 3.1.6 and then
+    restored in 3.1.7.  For compatibility reasons, this behavior will not be
+    changed in future releases anymore.}.
+    If so, using \meta{key} will \emph{always} execute commands with the passed
     value, or the default value |\pgfkeysnovalue| if no value is provided.
     Note that the stored value is never used. To update the stored value, the
     handler |/.initial| or command |\pgfkeyssetvalue| is used.


### PR DESCRIPTION
**Motivation for this change**

Two documentary changes:
 - added doc for `\pgfpointtransformed` which is adapted from its [code comments](https://github.com/pgf-tikz/pgf/blob/c3fb4153410ebc1a0491df7c0189050d43c8ba7a/tex/generic/pgf/basiclayer/pgfcorepoints.code.tex#L90-L100)
 - clarify that a `pgfkeys` key can be defined to both store a value and execute commands, and if so `<key>=<value>` always execute commands.

To reduce the number of merging commits, I combined them into a single PR.

Fixes #844
Fixes #654

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
