### PR TITLE
Handle \relax and frozen \relax in tikz path

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
@@ -393,7 +393,7 @@ execute before day scope={\ifdate{day of month=1}{%
   \pgfutil@next%
 }
 \def\tikz@lib@cal@expand{%
-  \advance\tikz@expandcount by -1%
+  \advance\tikz@expandcount by -1
   \ifnum\tikz@expandcount<0\relax%
     \tikzerror{Giving up on this calendar}%
     \let\pgfutil@next=\tikz@lib@cal@end%

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2587,7 +2587,7 @@
 
 \def\tikz@skip#1{\tikz@scan@next@command#1}%
 \def\tikz@expand{%
-  \advance\tikz@expandcount by -1%
+  \advance\tikz@expandcount by -1
   \ifnum\tikz@expandcount<0\relax%
     \tikzerror{Giving up on this path. Did you forget a semicolon?}%
     \let\pgfutil@next=\tikz@finish%
@@ -2960,7 +2960,7 @@
 % -| <point>
 
 \def\tikz@hv@lineto{%
-  \pgfutil@ifnextchar n{\tikz@collect@label@onpath\tikz@hv@lineto}{
+  \pgfutil@ifnextchar n{\tikz@collect@label@onpath\tikz@hv@lineto}{%
   \pgfutil@ifnextchar p{\tikz@collect@pic@onpath\tikz@hv@lineto}%
   {\pgfutil@ifnextchar c{\tikz@collect@coordinate@onpath\tikz@hv@lineto}%
     {\tikz@scan@one@point{\tikz@@hv@lineto}}}}}%
@@ -3225,13 +3225,13 @@
     \let\tikz@collected@onpath=\pgfutil@empty%
     \tikz@edgetoparentcollect%
 }%
-\def\tikz@edgetoparentcollect{
+\def\tikz@edgetoparentcollect{%
   \pgfutil@ifnextchar n{\tikz@collect@label@onpath\tikz@edgetoparentcollect}%
   {%
       \expandafter%
     \endgroup%
     \expandafter\tikz@edgetoparent@rollout\expandafter{\tikz@collected@onpath}%
-  }
+  }%
 }%
 
 \def\tikz@edgetoparent@rollout#1{%
@@ -3861,7 +3861,7 @@
 % A label text always ``ends'' the node.
 %
 \def\tikz@fig ode{%
-  \pgfutil@ifnextchar a\tikz@test@also{
+  \pgfutil@ifnextchar a\tikz@test@also{%
     \pgfutil@ifnextchar f{\tikz@nodes@start}\tikz@normal@fig}}%
 \def\tikz@test@also a{\pgfutil@ifnextchar l\tikz@node@also{\tikz@normal@fig a}}%
 \def\tikz@normal@fig{%
@@ -5261,7 +5261,7 @@
 \def\tikz@scan@absolute#1{%
   \pgfutil@ifnextchar({\tikz@scan@@absolute#1}%)
   {%
-    \advance\tikz@expandcount by -1%
+    \advance\tikz@expandcount by -1
     \ifnum\tikz@expandcount<0\relax%
       \let\pgfutil@next=\tikz@@scangiveup%
     \else%

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2120,10 +2120,15 @@
   \else%
     \tikz@invoke@collected@onpath%
   \fi%
-  \afterassignment\tikz@handle\let\pgf@let@token=%
+  \tikz@scan@@next@command
 }%
+\def\tikz@scan@@next@command{%
+  \afterassignment\tikz@handle\let\pgf@let@token=%
+}
+
 \newcount\tikz@expandcount
 \let\tikz@collected@onpath=\pgfutil@empty%
+\edef\tikz@frozen@relax@token{\ifnum0=0\fi}
 
 % Central dispatcher for commands
 \def\tikz@handle{%
@@ -2224,7 +2229,7 @@
                               \ifx\pgf@let@token:%
                                 \let\pgfutil@next=\tikz@colon@char%
                               \else%
-                                \let\pgfutil@next=\tikz@expand%
+                                \let\pgfutil@next=\tikz@handle@evenmore
                               \fi%
                             \fi%
                           \fi%
@@ -2240,9 +2245,25 @@
       \fi%
     \fi%
   \fi%
-  \ifx\pgfutil@next\tikz@expand\else\tikz@expandcount=100\relax\fi%
   \pgfutil@next%
 }%
+
+% Continued...
+\def\tikz@handle@evenmore{%
+  % if \pgf@let@token is \relax or frozen \relax, skip it and
+  % scan from the next token
+  \ifx\pgf@let@token\relax
+    \let\pgfutil@next=\tikz@scan@@next@command
+  \else
+    \ifx\pgf@let@token\tikz@frozen@relax@token
+      \let\pgfutil@next=\tikz@scan@@next@command
+    \else
+      \let\pgfutil@next=\tikz@expand
+    \fi
+  \fi
+  \ifx\pgfutil@next\tikz@expand\else\tikz@expandcount=100\relax\fi
+  \pgfutil@next
+}
 
 \def\tikz@l@char{%
   \pgfutil@ifnextchar e{\tikz@let@command}{%


### PR DESCRIPTION
**Motivation for this change**

As suggested in https://github.com/pgf-tikz/pgf/issues/966#issuecomment-749154057, this PR makes `\relax` and the frozen `\relax` handled in tikz path parsing. An intro to frozen `\relax` can be found in [this TeX-SX answer](https://tex.stackexchange.com/a/57417) and [`texdoc interface3`, sec. XVI.7](https://github.com/latex3/latex3/blob/c297e780ff706dab7b30f9ad5153f2f58f542de9/l3kernel/l3token.dtx#L1162-L1164).

PS: Perhaps `\tikz@frozen@relax@token` could be put in `pgfutil-common.tex`.

Fixes #966 (or, implements)

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
