### PR TITLE
tikz: reset \tikz@expandcount more frequent #969

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
@@ -370,28 +370,13 @@ execute before day scope={\ifdate{day of month=1}{%
 }
 
 \def\tikz@lib@cal@handle{%
-  \let\pgfutil@next=\tikz@lib@cal@expand%
-  \ifx\pgf@let@token;%
-    \let\pgfutil@next=\tikz@lib@cal@stop%
-  \else%
-    \ifx\pgf@let@token(%)
-      \let\pgfutil@next=\tikz@lib@cal@name%
-    \else%
-      \ifx\pgf@let@token a%
-        \let\pgfutil@next=\tikz@lib@cal@at%
-      \else%
-        \ifx\pgf@let@token[%
-          \let\pgfutil@next=\tikz@lib@cal@option%
-        \else%
-          \ifx\pgf@let@token i%
-            \let\pgfutil@next=\tikz@lib@cal@if%
-          \fi%
-        \fi%
-      \fi%
-    \fi%
-  \fi%
-  \pgfutil@ifx\pgfutil@next\tikz@lib@cal@expand{}{\tikz@resetexpandcount}%
-  \pgfutil@next%
+  \pgfutil@switch\pgfutil@ifx\pgf@let@token{%
+    {;}{\tikz@lib@cal@stop}%
+    {(}{\tikz@lib@cal@name}%)
+    {a}{\tikz@lib@cal@at}%
+    {[}{\tikz@lib@cal@option}%]
+    {i}{\tikz@lib@cal@if}%
+  }{}{\tikz@resetexpandcount\tikz@lib@cal@expand}%
 }
 \def\tikz@lib@cal@expand{%
   \advance\tikz@expandcount by -1

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
@@ -358,7 +358,7 @@ execute before day scope={\ifdate{day of month=1}{%
 \def\tikz@lib@cal@calendar{%
   \begingroup%
     \let\tikz@lib@cal@ifs=\pgfutil@empty%
-    \tikz@expandcount=1000\relax%
+    \tikz@resetexpandcount
     \tikzset{name=,at={(0,0)}}%
     \let\%=\pgfcalendarshorthand%
     \tikzset{every calendar/.try}%
@@ -390,6 +390,7 @@ execute before day scope={\ifdate{day of month=1}{%
       \fi%
     \fi%
   \fi%
+  \pgfutil@ifx\pgfutil@next\tikz@lib@cal@expand{}{\tikz@resetexpandcount}%
   \pgfutil@next%
 }
 \def\tikz@lib@cal@expand{%

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryspy.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryspy.code.tex
@@ -97,7 +97,7 @@
         \pgftransformcm{\pgf@lib@svg@a}{\pgf@lib@svg@b}{\pgf@lib@svg@c}{\pgf@lib@svg@d}{\pgfpointorigin}%
       }
     }]{};
-    \expandafter\pgfutil@switch\expandafter{\tikz@anchor}{%
+    \expandafter\pgfutil@switch\expandafter\pgfutil@ifstrequal\expandafter{\tikz@anchor}{%
       {north}     {\def\tikz@spy@anchor{south}}%
       {north east}{\def\tikz@spy@anchor{south west}}%
       {east}      {\def\tikz@spy@anchor{west}}%
@@ -106,9 +106,7 @@
       {south west}{\def\tikz@spy@anchor{north east}}%
       {west}      {\def\tikz@spy@anchor{east}}%
       {north west}{\def\tikz@spy@anchor{south east}}%
-      % default to center
-      {default}   {\def\tikz@spy@anchor{center}}%
-    }
+    }{}{\def\tikz@spy@anchor{center}}%
     \node [alias=tikzspyinnode,inner sep=0pt,outer sep=0pt,at={#2},every spy in node/.try,
     path picture={\node[anchor=\tikz@spy@anchor,tikz@lib@reset@gs]{\nullfont%
         \pgfpicture\relax\pgfsetbaseline{default}\pgfsettrimleft{default}\pgfsettrimright{default}%

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2173,6 +2173,7 @@
       \fi%
     \fi%
   \fi%
+  \ifx\pgfutil@next\tikz@handle@more\else\tikz@expandcount=100\relax\fi
   \pgfutil@next%
 }%
 

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2105,7 +2105,7 @@
     \tikz@snakedfalse%
     \tikz@decoratepathfalse%
     \tikz@node@is@a@labelfalse%
-    \tikz@expandcount=100\relax%
+    \tikz@resetexpandcount
     \pgf@path@lastx=0pt%
     \pgf@path@lasty=0pt%
     \tikz@lastx=0pt%
@@ -2123,6 +2123,7 @@
   \afterassignment\tikz@handle\let\pgf@let@token=%
 }%
 \newcount\tikz@expandcount
+\def\tikz@resetexpandcount{\tikz@expandcount=100\relax}
 \let\tikz@collected@onpath=\pgfutil@empty%
 
 % Central dispatcher for commands
@@ -2173,7 +2174,7 @@
       \fi%
     \fi%
   \fi%
-  \ifx\pgfutil@next\tikz@handle@more\else\tikz@expandcount=100\relax\fi
+  \pgfutil@ifx\pgfutil@next\tikz@handle@more{}{\tikz@resetexpandcount}%
   \pgfutil@next%
 }%
 
@@ -2241,7 +2242,7 @@
       \fi%
     \fi%
   \fi%
-  \ifx\pgfutil@next\tikz@expand\else\tikz@expandcount=100\relax\fi%
+  \pgfutil@ifx\pgfutil@next\tikz@expand{}{\tikz@resetexpandcount}%
   \pgfutil@next%
 }%
 
@@ -4755,8 +4756,8 @@
     \expandafter\expandafter\expandafter\tikz@parse@child@node%
   \fi%
 }%
-\def\tikz@parse@child@node@rest#1\pgf@stop{\tikz@expandcount=100\relax\def\tikz@child@node@rest{#1}}%
-\def\tikz@parse@child@node@c c{\tikz@expandcount=100\pgfutil@ifnextchar o{\tikz@parse@child@node@co}{\tikz@parse@child@node@rest c}}%
+\def\tikz@parse@child@node@rest#1\pgf@stop{\tikz@resetexpandcount\def\tikz@child@node@rest{#1}}%
+\def\tikz@parse@child@node@c c{\tikz@resetexpandcount\pgfutil@ifnextchar o{\tikz@parse@child@node@co}{\tikz@parse@child@node@rest c}}%
 \def\tikz@parse@child@node@co o{\pgfutil@ifnextchar o{\tikz@parse@child@node@coordinate}{\tikz@parse@child@node@rest co}}%
 \def\tikz@parse@child@node@coordinate ordinate{%
   \pgfutil@ifnextchar ({\tikz@@parse@child@node@coordinate}{%
@@ -4778,7 +4779,7 @@
   \expandafter\expandafter\expandafter{\expandafter\tikz@child@node@text@pre\tikz@marshal}%
   \tikz@parse@child@node@rest%
 }%
-\def\tikz@parse@child@node@n node{\tikz@expandcount=100%
+\def\tikz@parse@child@node@n node{\tikz@resetexpandcount%
   \let\tikz@child@node@text=\pgfutil@empty%
   \tikz@p@c@s}%
 \def\tikz@p@c@s{%

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2126,6 +2126,8 @@
 \def\tikz@resetexpandcount{\tikz@expandcount=100\relax}
 \let\tikz@collected@onpath=\pgfutil@empty%
 
+\edef\tikz@frozen@relax@token{\ifnum0=0\fi}
+
 % Central dispatcher for commands
 \def\tikz@handle{%
   \pgfutil@switch\pgfutil@ifx\pgf@let@token{%
@@ -2155,6 +2157,7 @@
     {d}{\tikz@decoration}%
     {l}{\tikz@l@char}%
     {:}{\tikz@colon@char}%
+    {\relax}{\relax\tikz@scan@next@command}%
   }{}{\tikz@resetexpandcount\tikz@expand}%
 }%
 

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2128,122 +2128,34 @@
 
 % Central dispatcher for commands
 \def\tikz@handle{%
-  \let\pgfutil@next=\tikz@expand%
-  \ifx\pgf@let@token(%)
-    \let\pgfutil@next=\tikz@movetoabs%
-  \else%
-    \ifx\pgf@let@token+%
-      \let\pgfutil@next=\tikz@movetorel%
-    \else%
-      \ifx\pgf@let@token-%
-        \let\pgfutil@next=\tikz@lineto%
-      \else%
-        \ifx\pgf@let@token.%
-          \let\pgfutil@next=\tikz@dot%
-        \else%
-          \ifx\pgf@let@token r%
-            \let\pgfutil@next=\tikz@rect%
-          \else%
-            \ifx\pgf@let@token n%
-              \let\pgfutil@next=\tikz@fig%
-            \else%
-              \ifx\pgf@let@token[%]
-                \let\pgfutil@next=\tikz@parse@options%
-              \else%
-                \ifx\pgf@let@token c%
-                  \let\pgfutil@next=\tikz@cchar%
-                \else%
-                  \ifx\pgf@let@token\bgroup%
-                    \let\pgfutil@next=\tikz@beginscope%
-                  \else%
-                    \ifx\pgf@let@token\egroup%
-                      \let\pgfutil@next=\tikz@endscope%
-                    \else%
-                      \ifx\pgf@let@token;%
-                        \let\pgfutil@next=\tikz@finish%
-                      \else%
-                        \let\pgfutil@next=\tikz@handle@more%
-                      \fi%
-                    \fi%
-                  \fi%
-                \fi%
-              \fi%
-            \fi%
-          \fi%
-        \fi%
-      \fi%
-    \fi%
-  \fi%
-  \pgfutil@ifx\pgfutil@next\tikz@handle@more{}{\tikz@resetexpandcount}%
-  \pgfutil@next%
-}%
-
-% Continued...
-\def\tikz@handle@more{%
-  \ifx\pgf@let@token a%
-    \let\pgfutil@next=\tikz@a@char%
-  \else%
-    \ifx\pgf@let@token e%
-      \let\pgfutil@next=\tikz@e@char%
-    \else%
-      \ifx\pgf@let@token g%
-        \let\pgfutil@next=\tikz@g@char%
-      \else%
-        \ifx\pgf@let@token s%
-           \let\pgfutil@next=\tikz@schar%
-        \else%
-          \ifx\pgf@let@token |%
-             \let\pgfutil@next=\tikz@vh@lineto%
-          \else%
-            \ifx\pgf@let@token p%
-              \let\pgfutil@next=\tikz@pchar%
-              \pgfsetmovetofirstplotpoint%
-            \else%
-              \ifx\pgf@let@token t%
-                \let\pgfutil@next=\tikz@to%
-              \else%
-                \ifx\pgf@let@token\pgfextra%
-                  \let\pgfutil@next=\tikz@extra%
-                \else%
-                  \ifx\pgf@let@token\foreach%
-                    \let\pgfutil@next=\tikz@foreach%
-                  \else%
-                    \ifx\pgf@let@token f%
-                      \let\pgfutil@next=\tikz@fchar%
-                    \else%
-                      \ifx\pgf@let@token\pgf@stop%
-                        \let\pgfutil@next=\relax%
-                      \else%
-                        \ifx\pgf@let@token\par%
-                          \let\pgfutil@next=\tikz@scan@next@command%
-                        \else%
-                          \ifx\pgf@let@token d%
-                            \let\pgfutil@next=\tikz@decoration%
-                          \else%
-                            \ifx\pgf@let@token l%
-                              \let\pgfutil@next=\tikz@l@char%
-                            \else%
-                              \ifx\pgf@let@token:%
-                                \let\pgfutil@next=\tikz@colon@char%
-                              \else%
-                                \let\pgfutil@next=\tikz@expand%
-                              \fi%
-                            \fi%
-                          \fi%
-                        \fi%
-                      \fi%
-                    \fi%
-                  \fi%
-                \fi%
-              \fi%
-            \fi%
-          \fi%
-        \fi%
-      \fi%
-    \fi%
-  \fi%
-  \pgfutil@ifx\pgfutil@next\tikz@expand{}{\tikz@resetexpandcount}%
-  \pgfutil@next%
+  \pgfutil@switch\pgfutil@ifx\pgf@let@token{%
+    {(}{\tikz@movetoabs}%)
+    {+}{\tikz@movetorel}%
+    {-}{\tikz@lineto}%
+    {.}{\tikz@dot}%
+    {r}{\tikz@rect}%
+    {n}{\tikz@fig}%
+    {[}{\tikz@parse@options}%]
+    {c}{\tikz@cchar}%
+    {\bgroup}{\tikz@beginscope}%
+    {\egroup}{\tikz@endscope}%
+    {;}{\tikz@finish}%
+    {a}{\tikz@a@char}%
+    {e}{\tikz@e@char}%
+    {g}{\tikz@g@char}%
+    {s}{\tikz@schar}%
+    {|}{\tikz@vh@lineto}%
+    {p}{\pgfsetmovetofirstplotpoint\tikz@pchar}%
+    {t}{\tikz@to}%
+    {\pgfextra}{\tikz@extra}%
+    {\foreach}{\tikz@foreach}%
+    {f}{\tikz@fchar}%
+    {\pgf@stop}{\relax}%
+    {\par}{\tikz@scan@next@command}%
+    {d}{\tikz@decoration}%
+    {l}{\tikz@l@char}%
+    {:}{\tikz@colon@char}%
+  }{}{\tikz@resetexpandcount\tikz@expand}%
 }%
 
 \def\tikz@l@char{%

--- a/tex/generic/pgf/systemlayer/pgfsys.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsys.code.tex
@@ -1715,7 +1715,30 @@
 % inserted into the resulting .pdf/.ps/.xxx file.
 
 
-
+% String comparison
+\ifdefined\pdfstrcmp
+  \let\pgfsys@strcmp\pdfstrcmp
+\else\ifdefined\strcmp
+  \let\pgfsys@strcmp\strcmp
+\else\ifdefined\directlua
+  \directlua{
+  local lft = lua.get_functions_table()
+  lft[\string#lft+1] = function()
+      local lhs = token.scan_string()
+      local rhs = token.scan_string()
+      if lhs < rhs then
+          tex.sprint(-2, "-1")
+      elseif lhs == rhs then
+          tex.sprint(-2, "0")
+      else
+          tex.sprint(-2, "1")
+      end
+  end
+  token.set_lua("pgfsys@strcmp", \string#lft, "global")
+  }
+\else
+  \def\pgfsys@strcmp#1#2{\pgf@sys@fail{string comparison}}%
+\fi\fi\fi
 
 
 % Discern the driver:

--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -32,6 +32,10 @@
 \newif\ifpgfutil@format@is@plain
 \newif\ifpgfutil@format@is@context
 
+% Aliases
+
+\let\pgfutil@exp\romannumeral
+\chardef\pgfutil@exp@end=0
 
 % Simple stuff
 
@@ -48,7 +52,7 @@
 % \pgfutil@ifx{<token 1>}{<token 2>}{<true code>}{<false code>}
 %
 % This macro is expandable.
-\def\pgfutil@ifx#1#2{%
+\long\def\pgfutil@ifx#1#2{%
   \ifx#1#2%
     \expandafter\pgfutil@firstoftwo
   \else
@@ -60,7 +64,20 @@
 % Check if <cs> is equal to \pgfutil@empty
 %
 % This macro is expandable.
-\def\pgfutil@ifempty#1{\pgfutil@ifx#1\pgfutil@empty}
+\long\def\pgfutil@ifempty#1{\pgfutil@ifx#1\pgfutil@empty}
+
+% \pgfutil@ifstrequal{<lhs>}{<rhs>}{<true code>}{<false code>}
+%
+% Check if <lhs> and <rhs> are equal by string comparison
+%
+% This macro is expandable.
+\long\def\pgfutil@ifstrequal#1#2{%
+  \ifnum\pgfsys@strcmp{\pgfutil@unexpanded{#1}}{\pgfutil@unexpanded{#2}}=0
+    \expandafter\pgfutil@firstoftwo
+  \else
+    \expandafter\pgfutil@secondoftwo
+  \fi
+}
 
 % \pgfutil@ifundefined{<macro name with backslash>}
 %  {<is undefined code>}{<is defined code>}
@@ -224,45 +241,42 @@
 \def\pgfutil@iterate{\pgfutil@body \let\pgfutil@next\pgfutil@iterate \else\let\pgfutil@next\relax\fi \pgfutil@next}
 \let\pgfutil@repeat=\fi % this makes \loop...\if...\repeat skippable
 
-
 % \pgfutil@switch
 %
-% #1: string to switch on
-% #2: sequence of label-value pairs
+% #1: comparison function of the form
+%     \comp{<lhs>}{<rhs>}{<true code>}{<false code>}
+%     Has to be expandable!
+% #2: lhs
+% #3: sequence of rhs-value pairs
+% #4: default statement in case of match
+% #5: default statement in case of no match
 %
 % Example:
 %
-% \pgfutil@switch{foo}{%
-%   {foo}{1}%
-%   {bar}{2}%
-%   {default}{X}%
-% }
-%
-% If a statement with the label `default' exists it will be executed
-% if no other label matches.
+% \pgfutil@switch\pgfutil@ifx\pgf@let@token{%
+%   {(}{\tikz@movetoabs}%)
+%   {+}{\tikz@movetorel}%
+%   {-}{\tikz@lineto}%
+% }{}{\tikz@expand}
 
-\long\def\pgfutil@switch#1#2{%
-  \begingroup
-    \def\pgfutil@switch@selected{}%
-    \pgfutil@switch@collect@statements#2{}{}%
-    \ifcsname pgfutil@switch@choice@\detokenize{#1}\endcsname
-      \expandafter\let\expandafter\pgfutil@switch@selected\csname pgfutil@switch@choice@\detokenize{#1}\endcsname
-    \else
-      \ifdefined\pgfutil@switch@choice@default
-        \let\pgfutil@switch@selected\pgfutil@switch@choice@default
-      \fi
-    \fi
-  \expandafter\endgroup\pgfutil@switch@selected
+\let\pgfutil@scan@mark\relax
+\let\pgfutil@scan@stop\relax
+
+\long\def\pgfutil@switch#1#2#3#4#5{%
+  \pgfutil@exp
+  \pgfutil@switch@@{#1}%
+  {#2}#3% user-defined cases
+  {#2}{}% default case
+  \pgfutil@scan@mark{#4}% true code
+  \pgfutil@scan@mark{#5}% false code
+  \pgfutil@scan@stop
 }
-
-\long\def\pgfutil@switch@collect@statements#1{%
-  \if\relax\detokenize{#1}\relax
-  \else
-    \afterassignment\pgfutil@switch@collect@statements
-    \expandafter\def\csname pgfutil@switch@choice@\detokenize{#1}\expandafter\endcsname
-  \fi
+\long\def\pgfutil@switch@@#1#2#3#4{%
+  #1{#2}{#3}%
+    {\pgfutil@switch@end{#4}}%
+    {\pgfutil@switch@@{#1}{#2}}%
 }
-
+\long\def\pgfutil@switch@end#1#2#3\pgfutil@scan@mark#4#5\pgfutil@scan@stop{\pgfutil@exp@end#1#4}
 
 % aux-read-hook
 

--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -45,17 +45,22 @@
 \def\pgfutil@trimspaces@@#1Q#2{#1}
 \catcode`\Q=11
 
+% \pgfutil@ifx{<token 1>}{<token 2>}{<true code>}{<false code>}
+%
+% This macro is expandable.
+\def\pgfutil@ifx#1#2{%
+  \ifx#1#2%
+    \expandafter\pgfutil@firstoftwo
+  \else
+    \expandafter\pgfutil@secondoftwo
+  \fi}
+
 % \pgfutil@ifempty{<cs>}{<true code>}{<false code>}
 %
 % Check if <cs> is equal to \pgfutil@empty
 %
 % This macro is expandable.
-\def\pgfutil@ifempty#1{%
-  \ifx#1\pgfutil@empty
-    \expandafter\pgfutil@firstoftwo
-  \else
-    \expandafter\pgfutil@secondoftwo
-  \fi}
+\def\pgfutil@ifempty#1{\pgfutil@ifx#1\pgfutil@empty}
 
 % \pgfutil@ifundefined{<macro name with backslash>}
 %  {<is undefined code>}{<is defined code>}
@@ -64,11 +69,7 @@
 %
 % This macro is expandable.
 \def\pgfutil@ifundefined#1{%
-  \expandafter\ifx\csname#1\endcsname\relax
-    \expandafter\pgfutil@firstoftwo
-  \else
-    \expandafter\pgfutil@secondoftwo
-  \fi}
+  \expandafter\pgfutil@ifx\csname#1\endcsname\relax}
 
 % A variant of \pgfutil@ifundefined which will NOT let #1 to \relax it
 % is undefined.
@@ -79,6 +80,7 @@
     \expandafter\pgfutil@firstoftwo
   \fi
 }
+
 \long\def\pgfutil@firstofone#1{#1}
 \long\def\pgfutil@firstoftwo#1#2{#1}
 \long\def\pgfutil@secondoftwo#1#2{#2}

--- a/tex/generic/pgf/utilities/pgfutil-context.def
+++ b/tex/generic/pgf/utilities/pgfutil-context.def
@@ -367,10 +367,7 @@
 
 % e-TeX primitives
 
-\pgfutil@IfUndefined{normalprotected}{%
-  \def\pgfutil@protected{}%
-}{%
-  \let\pgfutil@protected\normalprotected
-}
+\let\pgfutil@protected\normalprotected
+\let\pgfutil@unexpanded\normalunexpanded
 
 \endinput

--- a/tex/generic/pgf/utilities/pgfutil-latex.def
+++ b/tex/generic/pgf/utilities/pgfutil-latex.def
@@ -208,10 +208,7 @@
 
 % e-TeX primitives
 
-\pgfutil@IfUndefined{protected}{%
-  \def\pgfutil@protected{}%
-}{%
-  \let\pgfutil@protected\protected
-}
+\let\pgfutil@protected\protected
+\let\pgfutil@unexpanded\unexpanded
 
 \endinput

--- a/tex/generic/pgf/utilities/pgfutil-plain.def
+++ b/tex/generic/pgf/utilities/pgfutil-plain.def
@@ -337,10 +337,7 @@
 
 % e-TeX primitives
 
-\pgfutil@IfUndefined{protected}{
-  \def\pgfutil@protected{}%
-}{%
-  \let\pgfutil@protected\protected
-}
+\let\pgfutil@protected\protected
+\let\pgfutil@unexpanded\unexpanded
 
 \endinput


### PR DESCRIPTION
This makes `\tikz@expandcount` get reset every time a token is handled
in tikz path scanning.

**Motivation for this change**

Fixes #969

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
