### PR TITLE
Remove a spurious \show

### DIFF
--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -789,7 +789,6 @@
 }
 
 \pgfkeys{/pgf/calendar/Easter/.cd,.default=0,.code={%
-  \show\pgfcalendarifdateyear
   \pgfcalendareastersunday{\pgfcalendarifdateyear}{\pgf@cal@easter@julianday}%
   \ifnum\pgfcalendarifdatejulian=\pgfinteval{\pgf@cal@easter@julianday+#1}
     \expandafter\pgfcalendarmatchestrue


### PR DESCRIPTION
**Motivation for this change**
There was an unnecessary `\show` in the code, presumably from debugging, that lead to unhelpfully large log files and confused IDEs like TeXstudio.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
