### PR TITLE
tikz/math: gobble spaces between for list and loop body

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-math.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-math.tex
@@ -68,7 +68,7 @@ following command:
     };
   };
   int \f, \i;
-  for \i in {0,1,...,20}{
+  for \i in {0,1,...,20} {
     \f = fibonacci(\i);
     print {\f, };
   };
@@ -86,8 +86,8 @@ In addition to this command the following key is provided:
 \tikz[x=0.25cm,y=0.25cm,
   evaluate={
     int \i, \j;
-    for \i in {0,...,10}{
-      for \j in {0,...,10}{
+    for \i in {0,...,10} {
+      for \j in {0,...,10} {
         \a{\i,\j} = (\i+\j)*5;
       };
     };
@@ -295,7 +295,7 @@ following keyword.
 
 \subsection{Repeating Things}
 
-\begin{math-keyword}{{for} \meta{variable} \texttt{in \{}\meta{list}\texttt{\}\{}\meta{expressions}\texttt{\};}}
+\begin{math-keyword}{{for} \meta{variable} \texttt{in \{}\meta{list} \texttt{\}\{}\meta{expressions}\texttt{\};}}
     This is a ``trimmed down'' version of the |\foreach| command available as
     part of \pgfname\ and \tikzname, but cannot currently be used outside of
     the |\tikzmath| command. It is important to note the following:
@@ -310,7 +310,7 @@ following keyword.
 \tikzmath{
   int \x, \v;
   \v=1;
-  for \x in {1,...,{random(3,10)}}{
+  for \x in {1,...,{random(3,10)}} {
      \v=\v*2;
   };
   print {$x=\x, v=\v$};
@@ -333,8 +333,8 @@ following keyword.
 \tikzmath{
   int \x, \y;
   \y = 0;
-  for \x1 in {1,...,5}{
-    for \x2 in {10,20,...,50}{
+  for \x1 in {1,...,5} {
+    for \x2 in {10,20,...,50} {
       \y = \y+\x1*\x2;
     };
   };
@@ -365,7 +365,7 @@ of an expression. In this case the following keyword can be used:
   \begin{tikzpicture}
   \tikzmath{
     int \x;
-    for \k in {0,10,...,350}{
+    for \k in {0,10,...,350} {
       if \k>260 then { let \c = orange; } else {
         if \k>170 then { let \c = blue; } else {
           if \k>80 then { let \c = red; } else {
@@ -441,7 +441,7 @@ options. Firstly, the following keyword can be used:
 \tikzmath{
   int \x, \y, \z;
   \x = random(2, 5);
-  for \y in {0,...,6}{
+  for \y in {0,...,6} {
     \z = \x^\y;
     print {$\x^\y=\z$, };
   };
@@ -462,7 +462,7 @@ executed inside a |tikzpicture|.
 \draw [help lines] grid (3,2);
 \tikzmath{
   coordinate \c;
-  for \x in {0,10,...,360}{
+  for \x in {0,10,...,360} {
     \c = (1.5cm, 1cm) + (\x:1cm and 0.5cm);
     { \fill (\c) circle [radius=1pt]; };
   };

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarymath.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarymath.code.tex
@@ -532,7 +532,8 @@
 
 \long\def\tikz@math@for@parselist#1{%
     \edef\tikz@math@for@list{#1}%
-    \tikz@math@collecttosemicolon{\tikz@math@for@parseaction}}%
+    \tikz@math@gobblespaces{%
+      \tikz@math@collecttosemicolon{\tikz@math@for@parseaction}}}%
 
 \def\tikz@math@for@parseaction{%
     \tikz@math@for@namedef{prevvalue}{}%


### PR DESCRIPTION
**Motivation for this change**

This PR makes the usage
```tex
\tikzmath{
  for \x in {1,...,100} {};
}
```
valid and updates the corresponding docs. Before, only `for \x in {1,...,100}{}` is valid and `for \x in {1,...,100}␣{}` (note the `␣` before loop body) triggers an endless loop.

PS: Thanks to the example given in https://github.com/pgf-tikz/pgf/issues/974#issuecomment-754085505.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
