### PR TITLE
pgf/shapes: improve \pgfpointshapeborder, #908

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
@@ -602,7 +602,8 @@ commands:
 \end{codeexample}
     %
     \emph{Remark:} If the given \meta{point} is almost identical to the center
-    of \meta{node}, the node center is returned.
+    of \meta{node}, the node center is returned and a warning message will be
+    printed.
 \end{command}
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-nodes.tex
@@ -601,6 +601,8 @@ commands:
 \end{pgfpicture}
 \end{codeexample}
     %
+    \emph{Remark:} If the given \meta{point} is almost identical to the center
+    of \meta{node}, the node center is returned.
 \end{command}
 
 

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -2627,9 +2627,9 @@ Section~\ref{section-node-coordinates}. Suppose you have said
         Likewise, |(1,1)--(x)| will also have the line end on the border in the
         direction coming from |(1,1)|.
 
-        If the specified coordinate is identical or too close to the node
-        center, for example |(x)--(0,0)|, no line will be drawn and a warning
-        message will be printed.
+        If the specified coordinate is almost identical to the node center, for
+        example |(x)--(0,0)|, no line will be drawn and a warning message will
+        be printed.
 
         In addition to |--|, the curve-to path operation |..| and the path
         operations \verb!-|! and \verb!|-! will also handle nodes without

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -2627,6 +2627,10 @@ Section~\ref{section-node-coordinates}. Suppose you have said
         Likewise, |(1,1)--(x)| will also have the line end on the border in the
         direction coming from |(1,1)|.
 
+        If the specified coordinate is identical or too close to the node
+        center, for example |(x)--(0,0)|, no line will be drawn and a warning
+        message will be printed.
+
         In addition to |--|, the curve-to path operation |..| and the path
         operations \verb!-|! and \verb!|-! will also handle nodes without
         anchors correctly. Here is an example, see also

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -618,16 +618,26 @@
         \advance\pgf@xa by-\pgf@x%
         \advance\pgf@ya by-\pgf@y%
         % Now (\pgf@xa, \pgf@ya) is a coord in shape's coord system, and
-        % relative to the anchor "center". If it is almost identical to
-        % "center", i.e. ~= (0pt, 0pt), just return coord of "center".
-        \pgf@xb=0.01pt % use tolerance 0.01pt
-        \pgfutil@tempswafalse
-        \ifdim\pgf@xa>-\pgf@xb\ifdim\pgf@xa<\pgf@xb
-          \ifdim\pgf@ya>-\pgf@xb\ifdim\pgf@ya<\pgf@xb
-            \pgfutil@tempswatrue
-          \fi\fi
+        % relative to the anchor "center". It (xa, ya) is almost identical to
+        % the node center, which is measured by sqrt(xa^2+ya^2) < 0.02pt, just
+        % return the node center.
+        %
+        % \pgf@xb = 10*\pgf@xa if -1pt<\pgf@xa<1pt else 10pt
+        %  - "10*\pgf@xa": reduce ruonding errors when \pgf@xa is small
+        %  - "-1pt<\pgf@xa<1pt": guard against error "Dimension too large"
+        \pgf@xb=10pt
+        \ifdim\pgf@xa<1pt\ifdim\pgf@xa>-1pt
+          \pgf@xb=10\pgf@xa
         \fi\fi
-        \ifpgfutil@tempswa
+        % \pgf@yb = 10*\pgf@ya if -1pt<\pgf@ya<1pt else 10pt
+        \pgf@yb=10pt
+        \ifdim\pgf@ya<1pt\ifdim\pgf@ya>-1pt
+          \pgf@yb=10\pgf@ya
+        \fi\fi
+        % if 100*(xa^2+ya^2) < 0.04pt, which means sqrt(xa^2+ya^2) < 0.02pt,
+        % return node center
+        \ifdim\dimexpr\expandafter\Pgf@geT\the\pgf@xb\pgf@xb
+                     +\expandafter\Pgf@geT\the\pgf@yb\pgf@yb\relax<0.04pt
           \expandafter\pgfutil@firstoftwo
         \else
           \expandafter\pgfutil@secondoftwo

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -636,7 +636,7 @@
           \pgfwarning
             {Returning node center instead of a point on node border. Did you
             specify a point identical to the center of node
-            ``\pgfreferencednodename"?}%
+            ``\pgfreferencednodename''?}%
           \pgf@sh@reanchor{\csname pgf@sh@ns@#1\endcsname}{center}%
         }
         {% this calls the corresponding \anchorborder in shape declaration

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -618,7 +618,7 @@
         \advance\pgf@xa by-\pgf@x%
         \advance\pgf@ya by-\pgf@y%
         % Now (\pgf@xa, \pgf@ya) is a coord in shape's coord system, and
-        % relative to the anchor "center". If it is almost identical to 
+        % relative to the anchor "center". If it is almost identical to
         % "center", i.e. ~= (0pt, 0pt), just return coord of "center".
         \pgf@xb=0.01pt % use tolerance 0.01pt
         \pgfutil@tempswafalse
@@ -633,6 +633,10 @@
           \expandafter\pgfutil@secondoftwo
         \fi
         {% return coord of "center"
+          \pgfwarning
+            {Returning node center instead of a point on node border. Did you
+            specify a point identical to the center of node
+            ``\pgfreferencednodename"?}%
           \pgf@sh@reanchor{\csname pgf@sh@ns@#1\endcsname}{center}%
         }
         {% this calls the corresponding \anchorborder in shape declaration

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -618,9 +618,9 @@
         \advance\pgf@xa by-\pgf@x%
         \advance\pgf@ya by-\pgf@y%
         % Now (\pgf@xa, \pgf@ya) is a coord in shape's coord system, and
-        % relative to the anchor "center". It (xa, ya) is almost identical to
-        % the node center, which is measured by sqrt(xa^2+ya^2) < 0.02pt, just
-        % return the node center.
+        % relative to the anchor "center". If (xa, ya) is almost identical to
+        % the node center, which is determined by sqrt(xa^2+ya^2) < 0.02pt,
+        % just return the node center.
         %
         % \pgf@xb = 10*\pgf@xa if -1pt<\pgf@xa<1pt else 10pt
         %  - "10*\pgf@xa": reduce ruonding errors when \pgf@xa is small
@@ -634,7 +634,7 @@
         \ifdim\pgf@ya<1pt\ifdim\pgf@ya>-1pt
           \pgf@yb=10\pgf@ya
         \fi\fi
-        % if 100*(xa^2+ya^2) < 0.04pt, which means sqrt(xa^2+ya^2) < 0.02pt,
+        % if xb^2+yb^2 < 0.04pt, which means sqrt(xa^2+ya^2) < 0.02pt,
         % return node center
         \ifdim\dimexpr\expandafter\Pgf@geT\the\pgf@xb\pgf@xb
                      +\expandafter\Pgf@geT\the\pgf@yb\pgf@yb\relax<0.04pt

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -617,7 +617,28 @@
         \pgf@process{\pgf@shape@interpictureshift{#1}}%%
         \advance\pgf@xa by-\pgf@x%
         \advance\pgf@ya by-\pgf@y%
-        \csname pgf@anchor@\csname pgf@sh@ns@#1\endcsname @border\endcsname{\pgfqpoint{\pgf@xa}{\pgf@ya}}%
+        % Now (\pgf@xa, \pgf@ya) is a coord in shape's coord system, and
+        % relative to the anchor "center". If it is almost identical to 
+        % "center", i.e. ~= (0pt, 0pt), just return coord of "center".
+        \pgf@xb=0.01pt % use tolerance 0.01pt
+        \pgfutil@tempswafalse
+        \ifdim\pgf@xa>-\pgf@xb\ifdim\pgf@xa<\pgf@xb
+          \ifdim\pgf@ya>-\pgf@xb\ifdim\pgf@ya<\pgf@xb
+            \pgfutil@tempswatrue
+          \fi\fi
+        \fi\fi
+        \ifpgfutil@tempswa
+          \expandafter\pgfutil@firstoftwo
+        \else
+          \expandafter\pgfutil@secondoftwo
+        \fi
+        {% return coord of "center"
+          \pgf@sh@reanchor{\csname pgf@sh@ns@#1\endcsname}{center}%
+        }
+        {% this calls the corresponding \anchorborder in shape declaration
+          \csname pgf@anchor@\csname pgf@sh@ns@#1\endcsname @border\endcsname
+            {\pgfqpoint{\pgf@xa}{\pgf@ya}}%
+        }%
         \pgfsettransform{\csname pgf@sh@nt@#1\endcsname}%
         \pgf@pos@transform@glob%
         \global\pgf@x=\pgf@x%


### PR DESCRIPTION
**Motivation for this change**

In `\pgfpointshapeborder{<node>}{<coord>}`, if the given coord is almost identical to the node center, it is nonsense to compute the intersection on node border. This PR changes `\pgfpointshapeborder` to just return the node center in such case, which will avoid errors raised by the intersection computation, see an example in #908.

Note that this PR implements a modified version of my proposal given in https://github.com/pgf-tikz/pgf/issues/908#issuecomment-687701614

> I think `\pgfpointshapeborder` should just return `<point>` if it is close enough (`< 0.0001pt`) to the `<node>` center (perhaps with a warning message saying "points XXX too close to the center of node XXX, result is not reliable").

Discussions:
 - Tolerance `0.01pt` is so large because under some transformations the rounding error will be bigger than `0.008pt`.
 - A meaningful warning message would be nice.

Fixes #908

------
Some tests:

```tex
\documentclass{article}
\usepackage{tikz}
\usetikzlibrary{shapes.misc, graphs}

\begin{document}
\def\nodeNameList{rectangle, circle, rounded rectangle}

pgf examples, node centers are at \verb|(1, 1)|\par
\foreach \i in \nodeNameList {
%\foreach \i in {rectangle} {
  \begin{pgfpicture}
    \pgfsetbaseline{0pt}
    % helper grid
    \begin{pgfscope}
      \color{gray}
      \pgfpathgrid{\pgfpoint{-1cm}{-1cm}}{\pgfpoint{2cm}{1cm}}
      \pgfusepath{stroke}
    \end{pgfscope}
    
    \pgfnode{\i}{center}{pgf example}{x}{\pgfusepath{stroke}}
    
    % <point> is different from center of <node>
    \pgfpathcircle{\pgfpointshapeborder{x}{\pgfpoint{2cm}{1cm}}}{2pt}
    \pgfpathcircle{\pgfpoint{2cm}{1cm}}{2pt}
    \pgfusepath{fill}
    
    % <point> is identical to center of <node>
    \color{blue}
    \pgfpathcircle{\pgfpointshapeborder{x}{\pgfpoint{0pt}{0pt}}}{2pt}
    \pgfpathcircle{\pgfpoint{0cm}{0cm}}{2pt}
    \pgfusepath{fill}
  \end{pgfpicture}\qquad
}

tikz examples, node centers are at \verb|(1+rnd, 1+rnd)|\par
\foreach \i in \nodeNameList {
  \begin{tikzpicture}[baseline=0pt]
    \draw (0,0) grid (3,2);
    \expandafter\node\expandafter[\i, draw] (x) at (rnd, rnd) {tikz example};
    \draw (x) -- (3,2);
    \fill[blue] (x.center) circle (2pt);
    \draw[blue, line width=1pt] (x) -- (x.center);
  \end{tikzpicture}\qquad
}

tikz examples, with some random transformation matrix applied (used to set appropriate tolerance)\par
\foreach \i in \nodeNameList {
  \begin{tikzpicture}[baseline=0pt, cm={.3+rnd, .4*rnd, .4*rnd, .3+rnd, (rnd, rnd)}]
    \draw (0,0) grid (3,2);
    \expandafter\node\expandafter[\i, draw, transform shape] (x) at (rnd, rnd) {tikz example};
    \draw (x) -- (3,2);
    \fill[blue] (x.center) circle (2pt);
    \draw[blue, line width=1pt] (x) -- (x.center);
  \end{tikzpicture}\qquad
}

original example in issue \verb|#908|\par
\begin{tikzpicture}[baseline=(c.base)]
    \node[draw,rounded rectangle] (c) {x};
    \draw (0,0) -- (c);
\end{tikzpicture}

\end{document}
```

![image](https://user-images.githubusercontent.com/6376638/104104154-4abdbd00-52e1-11eb-8cb4-7fc4712d3ae3.png)


**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
