### PR TITLE
doc/fpu: fpu: mark /pgf/fpu/install only as not experimental

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-fpu.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-fpu.tex
@@ -179,7 +179,8 @@ by \pgfname.
 \endgroup
 \end{codeexample}
     %
-    \emph{This key is experimental and can change or disappear at any time!}
+    This key is introduced in \pgfname v3.1.6 and marked stable since \pgfname
+    v3.1.8.
 \end{key}
 
 


### PR DESCRIPTION
**Motivation for this change**

Sync `pgfmanual` with commit https://github.com/pgf-tikz/pgf/commit/7da3ef4c80cba6e4b1213d211a4bee91170cb245, which marked `/pgf/fpu/install only` as non experimental.

To help myself (and possibly others) introduce this key to others, for example in [this TeX-SX answer](https://tex.stackexchange.com/a/578408/79060), I added its version info as well. Any wording suggestions are welcome.

To verify the mentioned versions, `/pgf/fpu/install only` is added in https://github.com/pgf-tikz/pgf/commit/494bd677709b9f2eb938d96eeb0c2ad29ae37aa3 and marked stable in https://github.com/pgf-tikz/pgf/commit/7da3ef4c80cba6e4b1213d211a4bee91170cb245.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
