### PR TITLE
added \graphicspath support to \pgfdeclareimage

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-images.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-images.tex
@@ -70,6 +70,9 @@ To speedup the compilation, you may wish to use the following class option:
     will automatically tried. For PostScript, the extensions |.eps|, |.epsi|,
     and |.ps| will be tried.
 
+    You may use |\graphicspath| to specify a list of directories in which to
+    search for graphics files.
+
     The following options are possible:
     %
     \begin{itemize}

--- a/tex/generic/pgf/basiclayer/pgfcoreimage.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcoreimage.code.tex
@@ -36,10 +36,10 @@
   % If page= parameter is not empty, try that file first:
   \ifx\pgf@imagepage\pgfutil@empty%
   \else%
-  \expandafter\pgf@findfile\pgfsys@imagesuffixlist:+{#3.page\pgf@imagepage}%
+  \expandafter\pgf@findimage\pgfsys@imagesuffixlist:+{#3.page\pgf@imagepage}%
   \fi%
   \ifx\pgf@filename\pgfutil@empty%
-    \expandafter\pgf@findfile\pgfsys@imagesuffixlist:+{#3}%
+    \expandafter\pgf@findimage\pgfsys@imagesuffixlist:+{#3}%
   \else%
     \pgfkeys{/pgf/images/page=}% make page empty
   \fi%
@@ -88,6 +88,35 @@
     \ifx\pgf@mightbeempty\pgfutil@empty\else%
     \pgf@findfile#2+{#3}%
     \fi}}
+
+% Similar to \pgf@findfile but for images.
+% Additionally loops over directories in \Ginput@path.
+\def\pgf@findimage#1:#2+#3{%
+  \ifx\Ginput@path\@undefined
+    \let\Ginput@path\@empty
+  \fi
+  \ifx\Ginput@path\@empty
+    % Graphics search path is empty.
+    % Pass the arguments to the base command as is.
+    \@pgf@findfile{#1}:{#2}+{#3}%
+  \else
+    \let\pgf@cur\@secondoftwo
+    \expandafter\@tfor\expandafter
+      \pgf@cur\expandafter:\expandafter=\Ginput@path\do{%
+      \def\pgf@curfilename{\pgf@cur/#3#1}%
+      \pgfutil@IfFileExists{\pgf@curfilename}%
+      {\xdef\pgf@filename{\pgf@curfilename}%
+        % Found the file. We're done searching.
+        \@break@tfor
+      }%
+      {\def\pgf@mightbeempty{#2}%
+        \ifx\pgf@mightbeempty\pgfutil@empty\else%
+          \pgf@findimage#2+{#3}%
+        \fi
+      }%
+    }%
+  \fi
+}%
 
 % #1: image name
 % #2: file name


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

This PR implements support for `\graphicspath` in `\pgfdeclareimage`.

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Fixes #565.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
