### PR TITLE
tikz: fix uses of \pgfutil@switch

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
@@ -371,12 +371,12 @@ execute before day scope={\ifdate{day of month=1}{%
 
 \def\tikz@lib@cal@handle{%
   \pgfutil@switch\pgfutil@ifx\pgf@let@token{%
-    {;}{\tikz@lib@cal@stop}%
-    {(}{\tikz@lib@cal@name}%)
-    {a}{\tikz@lib@cal@at}%
-    {[}{\tikz@lib@cal@option}%]
-    {i}{\tikz@lib@cal@if}%
-  }{}{\tikz@resetexpandcount\tikz@lib@cal@expand}%
+    {;}{\let\pgfutil@next\tikz@lib@cal@stop}%
+    {(}{\let\pgfutil@next\tikz@lib@cal@name}%)
+    {a}{\let\pgfutil@next\tikz@lib@cal@at}%
+    {[}{\let\pgfutil@next\tikz@lib@cal@option}%]
+    {i}{\let\pgfutil@next\tikz@lib@cal@if}%
+  }{\tikz@resetexpandcount\pgfutil@next}{\tikz@lib@cal@expand}%
 }
 \def\tikz@lib@cal@expand{%
   \advance\tikz@expandcount by -1

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2147,7 +2147,7 @@
     {g}{\let\pgfutil@next\tikz@g@char}%
     {s}{\let\pgfutil@next\tikz@schar}%
     {|}{\let\pgfutil@next\tikz@vh@lineto}%
-    {p}{\def\pgfutil@next{\pgfsetmovetofirstplotpoint\tikz@pchar}}%
+    {p}{\pgfsetmovetofirstplotpoint\let\pgfutil@next\tikz@pchar}%
     {t}{\let\pgfutil@next\tikz@to}%
     {\pgfextra}{\let\pgfutil@next\tikz@extra}%
     {\foreach}{\let\pgfutil@next\tikz@foreach}%
@@ -2157,7 +2157,7 @@
     {d}{\let\pgfutil@next\tikz@decoration}%
     {l}{\let\pgfutil@next\tikz@l@char}%
     {:}{\let\pgfutil@next\tikz@colon@char}%
-    {\relax}{\def\pgfutil@next{\relax\tikz@scan@next@command}}%
+    {\relax}{\relax\let\pgfutil@next\tikz@scan@next@command}%
   }{\tikz@resetexpandcount\pgfutil@next}{\tikz@expand}%
 }%
 

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2131,34 +2131,34 @@
 % Central dispatcher for commands
 \def\tikz@handle{%
   \pgfutil@switch\pgfutil@ifx\pgf@let@token{%
-    {(}{\tikz@movetoabs}%)
-    {+}{\tikz@movetorel}%
-    {-}{\tikz@lineto}%
-    {.}{\tikz@dot}%
-    {r}{\tikz@rect}%
-    {n}{\tikz@fig}%
-    {[}{\tikz@parse@options}%]
-    {c}{\tikz@cchar}%
-    {\bgroup}{\tikz@beginscope}%
-    {\egroup}{\tikz@endscope}%
-    {;}{\tikz@finish}%
-    {a}{\tikz@a@char}%
-    {e}{\tikz@e@char}%
-    {g}{\tikz@g@char}%
-    {s}{\tikz@schar}%
-    {|}{\tikz@vh@lineto}%
-    {p}{\pgfsetmovetofirstplotpoint\tikz@pchar}%
-    {t}{\tikz@to}%
-    {\pgfextra}{\tikz@extra}%
-    {\foreach}{\tikz@foreach}%
-    {f}{\tikz@fchar}%
-    {\pgf@stop}{\relax}%
-    {\par}{\tikz@scan@next@command}%
-    {d}{\tikz@decoration}%
-    {l}{\tikz@l@char}%
-    {:}{\tikz@colon@char}%
-    {\relax}{\relax\tikz@scan@next@command}%
-  }{}{\tikz@resetexpandcount\tikz@expand}%
+    {(}{\let\pgfutil@next\tikz@movetoabs}%)
+    {+}{\let\pgfutil@next\tikz@movetorel}%
+    {-}{\let\pgfutil@next\tikz@lineto}%
+    {.}{\let\pgfutil@next\tikz@dot}%
+    {r}{\let\pgfutil@next\tikz@rect}%
+    {n}{\let\pgfutil@next\tikz@fig}%
+    {[}{\let\pgfutil@next\tikz@parse@options}%]
+    {c}{\let\pgfutil@next\tikz@cchar}%
+    {\bgroup}{\let\pgfutil@next\tikz@beginscope}%
+    {\egroup}{\let\pgfutil@next\tikz@endscope}%
+    {;}{\let\pgfutil@next\tikz@finish}%
+    {a}{\let\pgfutil@next\tikz@a@char}%
+    {e}{\let\pgfutil@next\tikz@e@char}%
+    {g}{\let\pgfutil@next\tikz@g@char}%
+    {s}{\let\pgfutil@next\tikz@schar}%
+    {|}{\let\pgfutil@next\tikz@vh@lineto}%
+    {p}{\def\pgfutil@next{\pgfsetmovetofirstplotpoint\tikz@pchar}}%
+    {t}{\let\pgfutil@next\tikz@to}%
+    {\pgfextra}{\let\pgfutil@next\tikz@extra}%
+    {\foreach}{\let\pgfutil@next\tikz@foreach}%
+    {f}{\let\pgfutil@next\tikz@fchar}%
+    {\pgf@stop}{\let\pgfutil@next\relax}%
+    {\par}{\let\pgfutil@next\tikz@scan@next@command}%
+    {d}{\let\pgfutil@next\tikz@decoration}%
+    {l}{\let\pgfutil@next\tikz@l@char}%
+    {:}{\let\pgfutil@next\tikz@colon@char}%
+    {\relax}{\def\pgfutil@next{\relax\tikz@scan@next@command}}%
+  }{\tikz@resetexpandcount\pgfutil@next}{\tikz@expand}%
 }%
 
 \def\tikz@l@char{%


### PR DESCRIPTION
**Motivation for this change**

This PR fixes a problem introduced by https://github.com/pgf-tikz/pgf/commit/70f814b522b23328b5a4374cd0273d2d420cd8d0. See previous discussions in https://github.com/pgf-tikz/pgf/pull/970#discussion_r555940015.

Examples for testing:
```tex
\documentclass{article}
\usepackage{tikz}

\begin{document}
% test "\tikz@handle"
% current: infinite loop
% expected: throws error
%   ! Package tikz Error: Giving up on this path. Did you forget a semicolon?.
\tikz \path x;
\end{document}
```

```tex
\documentclass{article}
\usepackage{tikz}
\usetikzlibrary{calendar}

\begin{document}
% test "\tikz@lib@cal@handle"
% current: infinite loop
% expected: throws error
%   ! Package tikz Error: Giving up on this calendar.
\tikz \calendar x;
\end{document}
```

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
