### PR TITLE
Correct documentation for .code 2 args second arg

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-pgfkeys.tex
@@ -1025,9 +1025,6 @@ A number of handlers exist for defining the code of keys.
 \pgfkeys{/page size={30cm}{20cm}}
 \end{codeexample}
     %
-    The second argument is optional: if it is not provided, it will be the
-    empty string.
-
     Because of the special way the \meta{value} is parsed, if you set
     \meta{value} to, for instance, |first| (without any braces), then |#1| will
     be set to |f| and |#2| will be set to |irst|.


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

The current documentation states that the key handler `.code 2 args`
treats the second argument as optional, but the implementation
differs: if the second argument isn't provided, then the first letter
of the first argument is treated as the first argument, and the
remainder of the first argument is treated as the second argument.
Thus, this change removes the incorrect statement from the
documentation.

Fixes #991

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
