### PR TITLE
documentation fix in introduction: syntax is similar to METAPOST not METAFONT

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-introduction.tex
@@ -95,7 +95,7 @@ beginning a path at the first corner of the triangle, one for extending the
 path to the second corner, one for going to the third, one for closing the
 path, and one for actually painting the triangle (as opposed to filling it).
 With the \tikzname\ frontend all this boils down to a single simple
-\textsc{metafont}-like command:
+\textsc{metapost}-like command:
 %
 \begin{verbatim}
 \draw (0,0) -- (1,0) -- (1,1) -- cycle;
@@ -103,7 +103,7 @@ With the \tikzname\ frontend all this boils down to a single simple
 
 In practice, \tikzname\ is the only ``serious'' frontend for \pgfname. It gives
 you access to all features of \pgfname, but it is intended to be easy to use.
-The syntax is a mixture of \textsc{metafont} and \textsc{pstricks} and some
+The syntax is a mixture of \textsc{metapost} and \textsc{pstricks} and some
 ideas of myself. There are other frontends besides \tikzname, but they are intended
 more as ``technology studies'' and less as serious alternatives to
 \tikzname. In particular, the |pgfpict2e| frontend   reimplements the standard


### PR DESCRIPTION
**Motivation for this change**

corrected documentation

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [X] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [X] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
