### PR TITLE
build.lua: add README to tds.zip

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -271,6 +271,13 @@ end
 local function generate_TDSzip(filename)
     local files = generate_FILES()
 
+    -- copy over README
+    local readme_path = "doc/generic/pgf/README"
+    lfs.copy("README.md", readme_path)
+    -- it's safer to check if files already contains value readme_path
+    files[#files + 1] = readme_path
+    table.sort(files)
+
     -- write FILES
     local FILES = io.open("doc/generic/pgf/FILES", "w")
     for _, line in ipairs(files) do


### PR DESCRIPTION
**Motivation for this change**

The CTAN team complained to pgf-tikz mailing list about the [release v3.1.9](https://github.com/pgf-tikz/pgf/releases/tag/3.1.9) that

> Sadly, README is missing from pgf.tds.zip, where it should be
> placed in doc/generic/pgf/, next to ChangeLog.
> 
> (see the full email in https://tug.org/pipermail/pgf-tikz/2021q1/000056.html)

This PR tries to fix this. It's my first time to write logic in lua, so any comments are welcome.

------
Some words about the traced problem

 - In [v3.1.8](https://github.com/pgf-tikz/pgf/releases/tag/3.1.8) released on Dec 26, 2020, `doc/generic/pgf/README` was missing from `*.tds.zip` for the first time. (It's a pity that the CTAN Team members who handled 3.1.8, 3.1.8a, and 3.1.8b didn't find the issue.)
 - This file missing was caused by https://github.com/pgf-tikz/pgf/commit/759ccaee522ccf4af4c21034a093f3b6dea20c70, by which the outdated `doc/generic/pgf/README` was removed.
 - But the lua build system introduced by https://github.com/pgf-tikz/pgf/commit/fab019d286fe5095d5a7668f15e5cecfaa6788d0 and took effect from v3.1.5 only copied `README.md` for `*.ctan.flatdir.zip`. This not only co-authored the original problem, but also left two different `README` files in `*.ctan.flatdir.zip`. Don't know if anyone had spotted the latter problem.

CLI lines to verify some of the above words, tested on macOS only (sorry)
```bash
$ wget \
  https://github.com/pgf-tikz/pgf/releases/download/3.1.8/pgf_3.1.8.tds.zip \
  https://github.com/pgf-tikz/pgf/releases/download/3.1.8/pgf_3.1.8.ctan.flatdir.zip \
  https://github.com/pgf-tikz/pgf/releases/download/3.1.7a/pgf_3.1.7a.tds.zip \
  https://github.com/pgf-tikz/pgf/releases/download/3.1.7a/pgf_3.1.7a.ctan.flatdir.zip

$ unzip -l pgf_3.1.8.tds.zip | grep -i readme
<no output>
$ unzip -l pgf_3.1.8.ctan.flatdir.zip | grep -i readme
     2095  12-26-2020 02:00   pgf/README
$ unzip -l pgf_3.1.7a.tds.zip | grep -i readme
      470  12-01-2020 19:13   doc/generic/pgf/README
$ unzip -l pgf_3.1.7a.ctan.flatdir.zip | grep -i readme
     2095  12-01-2020 19:30   pgf/README
      470  12-01-2020 19:30   pgf/doc/README
```

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
