### PR TITLE
pgfkeys: enhance edef keys, #305

### DIFF
--- a/tex/generic/pgf/utilities/pgfkeys.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeys.code.tex
@@ -45,6 +45,17 @@
   \csname @@end\expandafter\endcsname\expandafter\end%
 \fi
 
+% e-TeX primitives and beyond
+
+\ifx\contextversion\undefined
+  \let\pgfkeys@expanded   \expanded
+  \let\pgfkeys@unexpanded \unexpanded
+\else
+  \let\pgfkeys@expanded   \normalexpanded
+  \let\pgfkeys@unexpanded \normalunexpanded
+\fi
+
+
 % Set a key to a value
 %
 % #1 = key
@@ -74,9 +85,8 @@
 }
 
 \long\def\pgfkeyssetevalue#1#2{%
-  \edef\pgfkeys@temp##1##2##3##4##5##6##7##8##9{#2}%
-  \pgfkeys@temptoks=\expandafter{\pgfkeys@temp{##1}{##2}{##3}{##4}{##5}{##6}{##7}{##8}{##9}}%
-  \expandafter\edef\csname pgfk@#1\endcsname{\the\pgfkeys@temptoks}%
+  \expandafter\edef\csname pgfk@#1\endcsname
+  {\pgfkeys@unexpanded\expandafter{\pgfkeys@expanded{#2}}}%
 }
 
 % Add text to a key at the end


### PR DESCRIPTION
**Motivation for this change**

Short recap: 

> There was a bug in old PGF versions that the body of \pgfkeysedef was not fully expanded #305. [...] We support macro definitions within edef bodies by doubling all the hashes followed by numbers. All other hashes have to be escaped manually. We assume that this is not a common use case.
> _(excerpted from [release note of v3.1.5](https://github.com/pgf-tikz/pgf/releases/tag/3.1.5))_

From discussions under #305, using newly introduced (since texlive 2019) primitive `\expanded` might be the "only proper solution". For compatibility issues, Henri [replied](https://github.com/pgf-tikz/pgf/issues/305#issuecomment-633794449) "Maybe I'll ship that for TeX Live 2021."

It's already 2021 but unfortunately texlive 2021 has just stopped updating from CTAN (since [22 Mar](https://www.tug.org/texlive/)). Maybe it's time to add dependence of `\expanded` to `pgfkeys`.

Please review if the ConTeXt compatibility is kept.

Question: Is a rollback definition of `\pgfkeyssetevalue` needed, when `\ifx\pgfkeys@expanded\undefined` is true?

------
A latex / context example for testing:
```tex
\ifx\contextversion\undefined
  \documentclass{article}
  \usepackage{pgfkeys}
  
  \begin{document}
\else
  \usemodule[pgfkey]
  \starttext
\fi

% define keys
\pgfkeys{
  key/.code=\def\test##1{<##1>},
  key/.add code={}{\test{#1}},
  ekey/.ecode=\def\noexpand\test##1{<##1>},
  ekey/.add code={}{\test{#1}}
}

% check key internals
\pgfkeysgetvalue{/key/.@cmd}\keyCmd
\pgfkeysgetvalue{/ekey/.@cmd}\ekeyCmd

\pgfkeysgetvalue{/key/.@body}\keyBody
\pgfkeysgetvalue{/ekey/.@body}\ekeyBody

% expected: typeset "True True"
% otherwise, throw error "Undefined control sequence \else\fail"
\let\fail\undefined
\ifx\keyCmd\ekeyCmd   True \else\fail \fi
\ifx\keyBody\ekeyBody True \else\fail \fi

\ifx\contextversion\undefined
  \def\temp{\end{document}}
\else
  \def\temp{\stoptext}
\fi
\temp
```

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
