### PR TITLE
Fixed typo in graphs docs

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-graphs.tex
@@ -270,7 +270,7 @@ preamble) results in the following somewhat more pleasing rendering:
 \subsubsection{Concept: Edge Labels and Styles}
 
 When connectors like |->| or |--| are used to connect nodes or whole chain
-groups, one or more edges will typically be created. These edges can be styles
+groups, one or more edges will typically be created. These edges can be styled
 easily by providing options in square brackets directly after these connectors:
 %
 \begin{codeexample}[preamble={\usetikzlibrary{graphs}}]


### PR DESCRIPTION
styles -> styled

<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

typo

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [ x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
