### PR TITLE
Update pgfsys-dvisvgm4ht.def

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-dvisvgm4ht.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvisvgm4ht.def
@@ -15,51 +15,68 @@
 %
 % Load common pdf commands:
 %
-  %\input pgfsys-dvisvgm.def
+
+% we load the dvips driver by default. it doesn't support patterns and some other stuff,
+% but it handles better nested images and some formatting. if you use patterns or if you
+% have other issues with the default method, pass the "tikz-dvisvgm" option to make4ht. 
+\ifdefined\ifOption
+\ifOption{tikz+}{\input pgfsys-dvisvgm.def}{\input pgfsys-dvips.def}
+\else
+% load the dvips driver by default
 \input pgfsys-dvips.def
+\fi
 
 
+\def\texfourht@tikz@begin{%
+  \bgroup%
+  \def\run@pict@cmd{}% insert the \Picture hooks only in the top nesting level
+  \def\end@pict@cmd{}%
+  \ifdefined\EndPicture\else% We are already inside command that uses \Picture
+  \ifdefined\inside@pict@cmd% handle nested uses
+  \else
+  % use different version of \Picture depending on the vertical mode
+  \ifvmode\def\run@pict@cmd{\Picture*}\else\def\run@pict@cmd{\Picture+}\fi%
+  \def\end@pict@cmd{\EndPicture}%
+  \fi\fi%
+  % command used to detect nesting
+  \def\inside@pict@cmd{}%
+  \csname a:tikzpicture\endcsname%
+}
+
+\def\texfourht@tikz@end{%
+  \csname b:tikzpicture\endcsname%
+  \egroup%
+}
 
 \AtBeginDocument{
-  % configure the output picture format to svg
+  \NewConfigure{tikzpicture}{2}
+  \catcode`\:=11
+  \Configure{tikzpicture}{%
+    \protect\csname nested:math\endcsname% support display math
+    \run@pict@cmd{}%
+  }{\end@pict@cmd}
+  % configure the output picture format to svg, as it will require dvisvgm
+  % post processing. 
   \Configure{Picture}{.svg}
-  % insert tex4ht hook to the code used at the start and end of each TikZ picture
-  \def\pgfsys@beginpicture{%
-    \bgroup%
-    \ifdefined\inside@pict@cmd% handle nested uses
-    \def\run@pict@cmd{}% insert the \Picture hooks only in the top nesting level
-    \def\end@pict@cmd{}%
-    \else
-    % use different version of \Picture depending on the vertical mode
-    \ifvmode\def\run@pict@cmd{\Picture*}\else\def\run@pict@cmd{\Picture+}\fi%
-    \def\end@pict@cmd{\EndPicture}%
-    \fi%
-    % command used to detect nesting
-    \def\inside@pict@cmd{}%
-    \csname a:tikzpicture\endcsname%
-    \orig@pgfsys@begin%
-  }%
-  \def\pgfsys@endpicture{%
-    \orig@pgfsys@end%
-      \csname b:tikzpicture\endcsname%
-      \egroup%
-      \par%
-  }%
+  % insert tex4ht hooks around TikZ picture box
+  \def\pgfsys@typesetpicturebox#1{%
+    \texfourht@tikz@begin%
+    \orig@pgfsys@typesetpicturebox{#1}%
+    \texfourht@tikz@end%
+  }
+  %
+  \ConfigureEnv{tikzpicture}{\ifvmode\Picture*{}\else\Picture+{}\fi\def\inside@pict@cmd{}}{\EndPicture}{}{}
+  \ConfigureEnv{pgfpicture}{\ifvmode\Picture*{}\else\Picture+{}\fi\def\inside@pict@cmd{}}{\EndPicture}{}{}
+  \catcode`\:=12
 }
 
 
 % Make the code inserted by tex4ht configurable
+% 
 
-\NewConfigure{tikzpicture}{2}
-\Configure{tikzpicture}{%
-  % \ifvmode\IgnorePar\fi\EndP%\HtmlParOff
-  \protect\csname nested:math\endcsname% support display math
-  \run@pict@cmd{}%
-}{\end@pict@cmd}
 
-\let\orig@pgfsys@begin\pgfsys@beginpicture
-\let\orig@pgfsys@end\pgfsys@endpicture
-\def\pgf@sys@postscript@header#1{{\special{! #1}}}
+\let\orig@pgfsys@typesetpicturebox\pgfsys@typesetpicturebox
+%\def\pgf@sys@postscript@header#1{{\special{! #1}}}
 
 
 \endinput


### PR DESCRIPTION
Here is updated version of the TeX4ht dvisvgm driver. It fixes some bugs and provides two modes. The default mode loads `dvips` specials. It works in most cases, but it fails sometimes. For example with [patterns](https://tex.stackexchange.com/q/590599/2891). The second mode loads `dvisvgm` specials. It fixes the pattern sample, but it fails for   [other examples](https://texample.net/tikz/examples/poincare/). All text labels are put at one place. This `dvisvgm` mode can be required using 

     make4ht filename.tex "tikz+"

<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**



<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
