### PR TITLE
Specify that relative coord is to end point

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-edges.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-edges.tex
@@ -253,7 +253,8 @@ this curve looks can be influenced via a number of options.
     %
     \begin{key}{/tikz/in control=\meta{coordinate}}
         This option causes the \meta{coordinate} to be used as the target
-        control point.
+        control point. You can use a coordinate like |+(1,0)| to specify
+        a point relative to the \emph{end} coordinate.
     \end{key}
     %
     \begin{key}{/tikz/controls=\meta{coordinate}| and |\meta{coordinate}}


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

When using a relative coordinate for the second control point of a Bezier curve, that coordinate is relative to the end point of the path. This is specified in the [section about relative coordinates](https://github.com/pgf-tikz/pgf/blob/master/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex#L948), but not here. And if you find an example using `.. controls`, the word `controls` is a link that takes you to this section, so perhaps a good idea to mention it here as well. 

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
