### PR TITLE
Ensure \tracinglostchars<3 in \pgf@picture

### DIFF
--- a/tex/generic/pgf/basiclayer/pgfcorescopes.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcorescopes.code.tex
@@ -242,6 +242,8 @@
           \let\addtolength=\pgf@addtolength%
           \let\selectfont=\pgf@selectfont%
           \nullfont\spaceskip0pt\xspaceskip0pt%
+          \tracinglostchars=%
+            \ifnum\tracinglostchars>2 2\else\tracinglostchars\fi
           \setbox\pgf@layerbox@main\hbox to0pt\bgroup%
             \begingroup%
   }


### PR DESCRIPTION
**Motivation for this change**

Setting `\tracinglostchars=3` (or 2 for the faint of heart) is a must-have when writing documents to avoid missing characters slipping by, but it may break TikZ because it allows more or less arbitrary things to be written with `\nullfont`.  This PR ensures that `\tracinglostchars` is at most 2 when a `\pgf@picture` starts.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
