### PR TITLE
Patterns in PDF: add empty Pattern dictionary to Resources dictionary

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
@@ -360,7 +360,7 @@
            /XStep \pgf@sys@tonumber\pgf@xc\space
            /YStep \pgf@sys@tonumber\pgf@yc\space
            /Matrix [#2\space#3\space#4\space#5\space\pgf@sys@tonumber\pgfutil@tempdima\space\pgf@sys@tonumber\pgfutil@tempdimb]
-           /Resources << >> %<<
+           /Resources <</Pattern<<>>>> %<<
       }%
   }%
   \pgfutil@addpdfresource@patterns{/pgfpat#1\space @pgfpatternobject#1}%

--- a/tex/generic/pgf/systemlayer/pgfsys-luatex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-luatex.def
@@ -220,7 +220,7 @@
     /XStep \pgf@sys@tonumber\pgf@xc\space
     /YStep \pgf@sys@tonumber\pgf@yc\space
     /Matrix [#2\space#3\space#4\space#5\space\pgf@sys@tonumber\pgfutil@tempdima\space\pgf@sys@tonumber\pgfutil@tempdimb]
-    /Resources << >> %<<
+    /Resources <</Pattern<<>>>> %<<
   }
   {#8}%
   \pgfutil@addpdfresource@patterns{/pgfpat#1\space \the\numexpr\pdffeedback lastobj\relax\space 0 R}%

--- a/tex/generic/pgf/systemlayer/pgfsys-pdftex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-pdftex.def
@@ -217,7 +217,7 @@
     /XStep \pgf@sys@tonumber\pgf@xc\space
     /YStep \pgf@sys@tonumber\pgf@yc\space
     /Matrix [#2\space#3\space#4\space#5\space\pgf@sys@tonumber\pgfutil@tempdima\space\pgf@sys@tonumber\pgfutil@tempdimb]
-    /Resources << >> %<<
+    /Resources <</Pattern<<>>>> %<<
   }
   {#8}%
   \pgfutil@addpdfresource@patterns{/pgfpat#1\space \the\pdflastobj\space 0 R}%


### PR DESCRIPTION
**Motivation for this change**

Minimal example:
```latex
\documentclass[tikz]{standalone}
\usetikzlibrary{patterns}
\begin{document}

\begin{tikzpicture}
    \fill[pattern=checkerboard] (0,0) circle (1);
\end{tikzpicture}

\end{document}
```

When opening the resulting PDF (from lualatex, pdflatex, or `\def\pgfsysdriver{pgfsys-dvipdfmx.def}`+latex+dvipdfmx) in Adobe Acrobat 2020 and running any Preflight analysis task (or performing certain other operations, but this is the easiest one), Acrobat silently corrects what it considers to be a syntax error. This is mostly evident by the prompt to save changes when closing the document, which does not appear on "good" documents. Comparison between the original and the automatically corrected PDF shows that Acrobat makes exactly the change that my patch makes. And with this patch, Acrobat no longer prompts for saving an automatically-changed document.

Curiously, this only affected filled patterns (dots, crosshatch dots, fivepointed stars, checkerboard), but not line patterns (horizontal/vertical/north east/north west lines, grid, bricks). My patch does not appear to do any harm to the latter though.

@hmenke said he reads the PDF standard as if this patch is not required for the PDF to be valid. It is thus only needed to make a specific PDF implementation happy. Assuming the standard does not forbid having an empty `/Pattern` dictionary inside the previously-empty `/Resources` dictionary, this patch will not affect the standards-compliance of Tikz's generated PDFs.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [X] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [X] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
