### PR TITLE
add rhombic polihedra

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-folding.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-folding.tex
@@ -188,6 +188,26 @@ The foldings are sorted by number of faces.
     %
 \end{pictype}
 
+\begin{pictype}{dodecahedron rhombic folding}{}
+    A rhombic dodecahedron, based on square-of-two rhombi.
+    %
+\begin{codeexample}[preamble={\usetikzlibrary{folding}}]
+\tikz \pic [folding line length=6mm, numbered faces, transform shape]
+  { dodecahedron rhombic folding };
+\end{codeexample}
+    %
+\end{pictype}
+
+\begin{pictype}{dodecahedron golden folding}{}
+    An alternative rhombic dodecahedron, flat laying, based on golden rhombi.
+    %
+\begin{codeexample}[preamble={\usetikzlibrary{folding}}]
+\tikz \pic [folding line length=6mm, numbered faces, transform shape]
+  { dodecahedron golden folding };
+\end{codeexample}
+    %
+\end{pictype}
+
 \begin{pictype}{cuboctahedron folding}{}
     A folding of a cuboctahedron.
     %

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
@@ -2217,19 +2217,19 @@
   \endgroup
 }%
 
-%golden rhombic dodecahedron
+%golden rhombic dodecahedron ("type 2" - flattened)
 \def\tikzfoldinggoldenrhombicdodecahedron#1[#2]#3;{%
   \begingroup%
     \tikzset{#2}%
     \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@A}
-    {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@B}
+    {\tikz@lib@fold@goldenrhombusl{\scope[rotate=180]\tikz@lib@fold@face@B\endscope}
       {\tikz@lib@fold@cut@path}
       {\tikz@lib@fold@ear@path}
       {\tikz@lib@fold@path}
       {\tikz@lib@fold@path}
     }
-    {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@C}
-      {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@I}
+    {\tikz@lib@fold@goldenrhombusr{\scope[rotate=180]\tikz@lib@fold@face@E\endscope}
+      {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@H}
         {\tikz@lib@fold@cut@path}
         {\tikz@lib@fold@cut@path}
         {\tikz@lib@fold@path}
@@ -2244,16 +2244,16 @@
         {\tikz@lib@fold@cut@path}
       }
     }
-    {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@D}
-      {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@E}
-        {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@J}
-          {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@L}
+    {\tikz@lib@fold@goldenrhombusl{\scope[rotate=180]\tikz@lib@fold@face@D\endscope}
+      {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@I}
+        {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@L}
+          {\tikz@lib@fold@goldenrhombusr{\scope[rotate=180]\tikz@lib@fold@face@K\endscope}
             {\tikz@lib@fold@ear@path}
             {\tikz@lib@fold@cut@path}
             {\tikz@lib@fold@path}
             {\tikz@lib@fold@ear@path}
           }
-          {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@K}
+          {\tikz@lib@fold@goldenrhombusl{\scope[rotate=180]\tikz@lib@fold@face@J\endscope}
             {\tikz@lib@fold@ear@path}
             {\tikz@lib@fold@cut@path}
             {\tikz@lib@fold@path}
@@ -2266,7 +2266,7 @@
         {\tikz@lib@fold@path}
         {\tikz@lib@fold@ear@path}
       }
-      {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@H}
+      {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@F}
         {\tikz@lib@fold@ear@path}
         {\tikz@lib@fold@ear@path}
         {\tikz@lib@fold@path}
@@ -2275,7 +2275,7 @@
       {\tikz@lib@fold@path}
       {\tikz@lib@fold@path}
     }
-    {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@F}
+    {\tikz@lib@fold@goldenrhombusr{\scope[rotate=180]\tikz@lib@fold@face@C\endscope}
       {\tikz@lib@fold@cut@path}
       {\tikz@lib@fold@cut@path}
       {\tikz@lib@fold@path}
@@ -2306,7 +2306,7 @@
           }
           {\tikz@lib@fold@ear@path}
           {\tikz@lib@fold@path}
-          {\tikz@lib@fold@ear@path}
+          {\tikz@lib@fold@path}
         }
         {\tikz@lib@fold@path}
         {\tikz@lib@fold@path}
@@ -2339,7 +2339,7 @@
         {\tikz@lib@fold@path}
       }
       {\tikz@lib@fold@path}
-      {\tikz@lib@fold@ear@path}
+      {\tikz@lib@fold@cut@path}
     }
     { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@C}
           { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@N}
@@ -2368,16 +2368,76 @@
           }
     }
     { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@D}
+      { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@D}
+        { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@D}
+          { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@D}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+          {\tikz@lib@fold@ear@path}
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+        }
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@path}
+        { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@D}
           {\tikz@lib@fold@path}
           {\tikz@lib@fold@ear@path}
           {\tikz@lib@fold@path}
           {\tikz@lib@fold@ear@path}
+        }
+      }
+      { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@D}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@ear@path}
+      }
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@ear@path}
     }
     { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@E}
+      { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@E}
+        { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@E}
+          { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@E}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@path}
+          }
+          {\tikz@lib@fold@ear@path}
           {\tikz@lib@fold@path}
+          { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@E}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@cut@path}
+          }
+        }
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@cut@path}
+      }
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@path}
+      { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@E}
+        { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@E}
+          { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@E}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@path}
+          }
           {\tikz@lib@fold@ear@path}
           {\tikz@lib@fold@path}
           {\tikz@lib@fold@ear@path}
+        }
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@path}
+      }
     }
   \endgroup
 }%

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
@@ -605,6 +605,8 @@
   pics/octahedron truncated folding/.style    = {code=\tikzfoldingtruncatedoctahedron[];},
   pics/dodecahedron folding/.style            = {code=\tikzfoldingdodecahedron[];},
   pics/dodecahedron' folding/.style           = {code=\tikzfoldingalternatedodecahedron[];},
+  pics/dodecahedron rhombic folding/.style    = {code=\tikzfoldingrhombicdodecahedron[];},
+  pics/dodecahedron golden folding/.style     = {code=\tikzfoldinggoldenrhombicdodecahedron[];},
   pics/cuboctahedron folding/.style           = {code=\tikzfoldingcuboctahedron[];},
   pics/cuboctahedron truncated folding/.style = {code=\tikzfoldingtruncatedcuboctahedron[];},
   pics/icosahedron folding/.style             = {code=\tikzfoldingicosahedron[];},
@@ -2153,15 +2155,15 @@
 \def\tikzfoldingrhombicdodecahedron#1[#2]#3;{%
   \begingroup%
     \tikzset{#2}%
-    \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@A}
-    {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@B}
+    \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@B}
+    {\tikz@lib@fold@squarerhombusl{\scope[rotate=90]\tikz@lib@fold@face@C\endscope}
       {\tikz@lib@fold@cut@path}
       {\tikz@lib@fold@ear@path}
       {\tikz@lib@fold@path}
       {\tikz@lib@fold@ear@path}
     }
-    {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@C}
-      {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@I}
+    {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@E}
+      {\tikz@lib@fold@squarerhombusl{\scope[rotate=90]\tikz@lib@fold@face@F\endscope}
         {\tikz@lib@fold@cut@path}
         {\tikz@lib@fold@cut@path}
         {\tikz@lib@fold@path}
@@ -2169,23 +2171,23 @@
       }
       {\tikz@lib@fold@cut@path}
       {\tikz@lib@fold@path}
-      {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@G}
+      {\tikz@lib@fold@squarerhombusr{\scope[rotate=180]\tikz@lib@fold@face@D\endscope}
         {\tikz@lib@fold@cut@path}
         {\tikz@lib@fold@cut@path}
         {\tikz@lib@fold@path}
         {\tikz@lib@fold@cut@path}
       }
     }
-    {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@D}
-      {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@E}
-        {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@J}
-          {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@L}
+    {\tikz@lib@fold@squarerhombusl{\scope[rotate=-90]\tikz@lib@fold@face@H\endscope}
+      {\tikz@lib@fold@squarerhombusr{\scope[rotate=180]\tikz@lib@fold@face@G\endscope}
+        {\tikz@lib@fold@squarerhombusl{\scope[rotate=-90]\tikz@lib@fold@face@L\endscope}
+          {\tikz@lib@fold@squarerhombusr{\scope[rotate=180]\tikz@lib@fold@face@K\endscope}
             {\tikz@lib@fold@ear@path}
             {\tikz@lib@fold@cut@path}
             {\tikz@lib@fold@path}
             {\tikz@lib@fold@ear@path}
           }
-          {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@K}
+          {\tikz@lib@fold@squarerhombusl{\scope[rotate=90]\tikz@lib@fold@face@J\endscope}
             {\tikz@lib@fold@ear@path}
             {\tikz@lib@fold@cut@path}
             {\tikz@lib@fold@path}

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
@@ -2149,8 +2149,7 @@
   \endgroup
 }%
 
-%rhombic (Catalan) dodecahedron
-
+%rhombic (Catalan) dodecahedron ("type 1" - spheric)
 \def\tikzfoldingrhombicdodecahedron#1[#2]#3;{%
   \begingroup%
     \tikzset{#2}%

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
@@ -2289,12 +2289,12 @@
 \def\tikzfoldingrhombictricontahedron#1[#2]#3;{%
   \begingroup%
     \tikzset{#2}%
-    \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@A}
-    { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@B}
-      { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@F}
-        { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@I}
-          { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@J}
-            { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@K}
+    \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@A}
+    { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@B}
+      { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@F}
+        { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@I}
+          { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@J}
+            { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@K}
               {\tikz@lib@fold@path}
               {\tikz@lib@fold@ear@path}
               {\tikz@lib@fold@path}
@@ -2310,16 +2310,16 @@
         }
         {\tikz@lib@fold@path}
         {\tikz@lib@fold@path}
-        { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@H}
+        { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@H}
           {\tikz@lib@fold@path}
           {\tikz@lib@fold@cut@path}
           {\tikz@lib@fold@path}
           {\tikz@lib@fold@ear@path}
         }
       }
-      { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@G}
-        { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@L}
-          { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@N}
+      { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@G}
+        { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@L}
+          { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@N}
             {\tikz@lib@fold@path}
             {\tikz@lib@fold@cut@path}
             {\tikz@lib@fold@path}
@@ -2327,7 +2327,7 @@
           }
           {\tikz@lib@fold@cut@path}
           {\tikz@lib@fold@path}
-          { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@M}
+          { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@M}
             {\tikz@lib@fold@path}
             {\tikz@lib@fold@cut@path}
             {\tikz@lib@fold@path}
@@ -2341,10 +2341,10 @@
       {\tikz@lib@fold@path}
       {\tikz@lib@fold@ear@path}
     }
-    { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@C}
-          { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@N}
-          { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@N}
-          { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@N}
+    { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@C}
+          { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@N}
+          { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@N}
+          { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@N}
             {\tikz@lib@fold@path}
             {\tikz@lib@fold@cut@path}
             {\tikz@lib@fold@path}
@@ -2360,20 +2360,20 @@
           }
           {\tikz@lib@fold@ear@path}
           {\tikz@lib@fold@path}
-          { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@N}
+          { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@N}
             {\tikz@lib@fold@path}
             {\tikz@lib@fold@cut@path}
             {\tikz@lib@fold@path}
             {\tikz@lib@fold@ear@path}
           }
     }
-    { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@D}
+    { \tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@D}
           {\tikz@lib@fold@path}
           {\tikz@lib@fold@ear@path}
           {\tikz@lib@fold@path}
           {\tikz@lib@fold@ear@path}
     }
-    { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@E}
+    { \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@E}
           {\tikz@lib@fold@path}
           {\tikz@lib@fold@ear@path}
           {\tikz@lib@fold@path}

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryfolding.code.tex
@@ -56,6 +56,78 @@
   \endscope
 }%
 
+\def\tikz@lib@fold@squarerhombusr#1#2#3#4#5{% right leaning "square-of-two" rhombus
+  \scope[xshift=.63\tikz@lib@fold@length,yshift=.4755\tikz@lib@fold@length,xslant=0.34]
+    #1
+  \endscope
+  \scope[shift={(70.529:\tikz@lib@fold@length)}]
+    #2
+  \endscope
+  \scope[shift={(35.264:1.63299\tikz@lib@fold@length)},rotate=-109.471]
+    #3
+  \endscope
+  \scope[xshift=\tikz@lib@fold@length,rotate=180]
+    #4
+  \endscope
+  \scope[rotate=70.529]
+    #5
+  \endscope
+}%
+
+\def\tikz@lib@fold@squarerhombusl#1#2#3#4#5{% left leaning "square-of-two" rhombus
+  \scope[xshift=.33\tikz@lib@fold@length,yshift=.4755\tikz@lib@fold@length,xslant=-0.34]
+    #1
+  \endscope
+  \scope[shift={(109.471:\tikz@lib@fold@length)}]
+    #2
+  \endscope
+  \scope[shift={(54.736:1.1547\tikz@lib@fold@length)},rotate=-70.529]
+    #3
+  \endscope
+  \scope[xshift=\tikz@lib@fold@length,rotate=180]
+    #4
+  \endscope
+  \scope[rotate=109.471]
+    #5
+  \endscope
+}%
+
+\def\tikz@lib@fold@goldenrhombusr#1#2#3#4#5{% right leaning golden rhombus
+  \scope[xshift=.724\tikz@lib@fold@length,yshift=.447\tikz@lib@fold@length, xslant=0.447]
+    #1
+  \endscope
+  \scope[shift={(63.435:\tikz@lib@fold@length)}]
+    #2
+  \endscope
+  \scope[shift={(31.717:1.701\tikz@lib@fold@length)},rotate=-116.565]
+    #3
+  \endscope
+  \scope[xshift=\tikz@lib@fold@length,rotate=180]
+    #4
+  \endscope
+  \scope[rotate=63.435]
+    #5
+  \endscope
+}%
+
+\def\tikz@lib@fold@goldenrhombusl#1#2#3#4#5{% left leaning golden rhombus
+  \scope[xshift=.276\tikz@lib@fold@length,yshift=.447\tikz@lib@fold@length, xslant=-0.447]
+    #1
+  \endscope
+  \scope[shift={(116.565:\tikz@lib@fold@length)}]
+    #2
+  \endscope
+  \scope[shift={(58.283:1.051\tikz@lib@fold@length)},rotate=-63.435]
+    #3
+  \endscope
+  \scope[xshift=\tikz@lib@fold@length,rotate=180]
+    #4
+  \endscope
+  \scope[rotate=116.565]
+    #5
+  \endscope
+}%
+
 \def\tikz@lib@fold@pentagon#1#2#3#4#5#6{%
   \scope[xshift=.5\tikz@lib@fold@length,yshift=0.68819\tikz@lib@fold@length]
     #1
@@ -2074,5 +2146,238 @@
              {\tikz@lib@fold@path}
              {\tikz@lib@fold@cut@path}
         }
+  \endgroup
+}%
+
+%rhombic (Catalan) dodecahedron
+
+\def\tikzfoldingrhombicdodecahedron#1[#2]#3;{%
+  \begingroup%
+    \tikzset{#2}%
+    \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@A}
+    {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@B}
+      {\tikz@lib@fold@cut@path}
+      {\tikz@lib@fold@ear@path}
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@ear@path}
+    }
+    {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@C}
+      {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@I}
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@ear@path}
+      }
+      {\tikz@lib@fold@cut@path}
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@G}
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@cut@path}
+      }
+    }
+    {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@D}
+      {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@E}
+        {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@J}
+          {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@L}
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+          {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@K}
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+        }
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@ear@path}
+      }
+      {\tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@H}
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@ear@path}
+      }
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@ear@path}
+    }
+    {\tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@F}
+      {\tikz@lib@fold@cut@path}
+      {\tikz@lib@fold@cut@path}
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@cut@path}
+    }
+  \endgroup
+}%
+
+%golden rhombic dodecahedron
+\def\tikzfoldinggoldenrhombicdodecahedron#1[#2]#3;{%
+  \begingroup%
+    \tikzset{#2}%
+    \tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@A}
+    {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@B}
+      {\tikz@lib@fold@cut@path}
+      {\tikz@lib@fold@ear@path}
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@path}
+    }
+    {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@C}
+      {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@I}
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@ear@path}
+      }
+      {\tikz@lib@fold@cut@path}
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@G}
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@cut@path}
+      }
+    }
+    {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@D}
+      {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@E}
+        {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@J}
+          {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@L}
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+          {\tikz@lib@fold@goldenrhombusl{\tikz@lib@fold@face@K}
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@path}
+          }
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+        }
+        {\tikz@lib@fold@cut@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@ear@path}
+      }
+      {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@H}
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@ear@path}
+      }
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@path}
+    }
+    {\tikz@lib@fold@goldenrhombusr{\tikz@lib@fold@face@F}
+      {\tikz@lib@fold@cut@path}
+      {\tikz@lib@fold@cut@path}
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@cut@path}
+    }
+  \endgroup
+}%
+
+%rhombic tricontahedron
+
+\def\tikzfoldingrhombictricontahedron#1[#2]#3;{%
+  \begingroup%
+    \tikzset{#2}%
+    \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@A}
+    { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@B}
+      { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@F}
+        { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@I}
+          { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@J}
+            { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@K}
+              {\tikz@lib@fold@path}
+              {\tikz@lib@fold@ear@path}
+              {\tikz@lib@fold@path}
+              {\tikz@lib@fold@ear@path}
+            }
+            {\tikz@lib@fold@ear@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+          {\tikz@lib@fold@ear@path}
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+        }
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@path}
+        { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@H}
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@cut@path}
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+        }
+      }
+      { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@G}
+        { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@L}
+          { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@N}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+          {\tikz@lib@fold@cut@path}
+          {\tikz@lib@fold@path}
+          { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@M}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+        }
+        {\tikz@lib@fold@ear@path}
+        {\tikz@lib@fold@path}
+        {\tikz@lib@fold@path}
+      }
+      {\tikz@lib@fold@path}
+      {\tikz@lib@fold@ear@path}
+    }
+    { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@C}
+          { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@N}
+          { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@N}
+          { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@N}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+          {\tikz@lib@fold@ear@path}
+          {\tikz@lib@fold@path}
+          { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@N}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@cut@path}
+            {\tikz@lib@fold@path}
+            {\tikz@lib@fold@ear@path}
+          }
+    }
+    { \tikz@lib@fold@squarerhombusl{\tikz@lib@fold@face@D}
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+    }
+    { \tikz@lib@fold@squarerhombusr{\tikz@lib@fold@face@E}
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+          {\tikz@lib@fold@path}
+          {\tikz@lib@fold@ear@path}
+    }
   \endgroup
 }%


### PR DESCRIPTION
**more options for calendars**

addresses own issue #1020 

adds square-of-two rhombic icosahedron (type 1) and golden rhombic icosahedron (makes a nice flat lying calendar).

**Checklist**

I'm very happy to contribute my changes/enhancements under the following terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]
- [x] Add an example in the manual.

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
