### PR TITLE
Refine error recovery after missing semicolon

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2486,12 +2486,27 @@
 \def\tikz@expand{%
   \advance\tikz@expandcount by -1
   \ifnum\tikz@expandcount<0\relax%
+    \expandafter\pgfutil@firstoftwo
+  \else
+    \expandafter\pgfutil@secondoftwo
+  \fi
+  {%
     \tikzerror{Giving up on this path. Did you forget a semicolon?}%
-    \let\pgfutil@next=\tikz@finish%
-  \else%
-    \let\pgfutil@next=\tikz@@expand
-  \fi%
-  \pgfutil@next}%
+    % since the last token caused an error we should reinsert it and therefore save it
+    \global\let\tikz@expand@last@token=\pgf@let@token
+    \tikz@finish%
+    %
+    % To be combatible with `scopes` lib, which uses a redefined 
+    % \tikz@lib@scope@check to check the next token, the reinsertion is done
+    % here, not at the end of (every) \tikz@finish.
+    %
+    \expandafter\let\expandafter\tikz@expand@last@token@\csname tikz@expand@last@token\endcsname
+    \global\let\tikz@expand@last@token=\relax
+    \tikz@expand@last@token@
+  }{%
+    \tikz@@expand
+  }%
+}
 
 \def\tikz@@expand{%
   \expandafter\tikz@scan@next@command\pgf@let@token}%


### PR DESCRIPTION
**Motivation for this change**

This PR tries to make https://github.com/hmenke/pgf/commit/8a6c14c9789e8bdc687506afa7b6723bb8249717 pass the <s>CI</s> manual building. Currently, two compatibility issues are already handled, one with `chains` lib and another with `scopes` lib.

I made it as a PR so other `pgf-tikz` members could directly add commits to fix remaining problems.

Fixes #1025

An example for testing
```tex
\documentclass{article}
\usepackage{tikz}
\usetikzlibrary{chains, scopes}

\begin{document}
% Test with `chains` lib, when \pgf@let@token contains an \else
\begin{tikzpicture}[
    start chain,
    every node/.style={on chain, join},
  ]
  
  \node (a)     {X};
  \node (b)     {Y};
\end{tikzpicture}

% Test with `scopes` lib
\begin{tikzpicture}
  \node[red] (existing) at (2,0) {Y};
  
  {[start chain]
    \node [on chain,join] {X};
    \chainin (existing) [join];
  }
\end{tikzpicture}

% Test error recovery after missing semicolon
\begin{tikzpicture}
  \draw (0,0) -- +(1,1) %;
  \draw (0,1) -- +(1,-1);
\end{tikzpicture}

\end{document}
```

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
