### PR TITLE
check whether expanded is a primitive

### DIFF
--- a/tex/generic/pgf/utilities/pgfkeys.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeys.code.tex
@@ -55,6 +55,17 @@
   \let\pgfkeys@unexpanded \normalunexpanded
 \fi
 
+\begingroup
+  \edef\pgfkeys@tmpa{\string\expanded}
+  \edef\pgfkeys@tmpb{\meaning\pgfkeys@expanded}
+  \expandafter
+\endgroup
+\ifx\pgfkeys@tmpa\pgfkeys@tmpb
+\else
+  \pgfkeys@error{PGF requires the \noexpand\expanded primitive}
+  \csname @@end\expandafter\endcsname\expandafter\end%
+\fi
+
 
 % Set a key to a value
 %


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

In the lights of https://tex.stackexchange.com/questions/603455/beamer-error-due-to-pgf-package I think it is a good idea to test whether the `\expanded` primitive is available, and if not throw a meaningful error message and abort the current TeX run (similar to how the checks for e-TeX are currently enforced). This PR does just that inside of `pgfkeys.code.tex` in an engine independent way.

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
