### PR TITLE
To allow pgfpages with TRT page direction

### DIFF
--- a/tex/latex/pgf/utilities/pgfpages.sty
+++ b/tex/latex/pgf/utilities/pgfpages.sty
@@ -34,7 +34,27 @@
 \pgfphysicalpageemptytrue
 \pgf@holdingphysicalpagefalse
 
-\let\pgfpagespoint\pgfpoint
+\def\pgfpagespoint{%
+  % Delay the definition of \pgfpagespoint in case the \pagedir is set at the
+  % beginning of document, but still assume that the \pagedir is constant 
+  % throughout the document.
+  \pgfpages@test@pagedir\pgfpagespoint}
+
+\def\pgfpages@test@pagedir{%
+  \let\pgfpagespoint\pgfpoint
+  \ifdefined\luatexversion
+    % \pagedir returns a three-char string and \pagedirection returns an int
+    \ifcase\pagedirection
+        % 0, TLT (latin)
+    \or % 1, TRT (arabic)
+      \def\pgfpagespoint##1##2{\pgfpoint{##1}{##2}\pgf@x=-\pgf@x}%
+    \or % 2, LTL (mongolian)
+      % ... need any transformations?
+    \or % 3, RTT (cjk)
+      % ... need \pgf@x=-\pgf@x ?
+    \fi
+  \fi
+}
 
 % Define a layout
 %
@@ -1137,4 +1157,3 @@
     \pgfshipoutphysicalpage
   \fi
 }
-

--- a/tex/latex/pgf/utilities/pgfpages.sty
+++ b/tex/latex/pgf/utilities/pgfpages.sty
@@ -34,6 +34,7 @@
 \pgfphysicalpageemptytrue
 \pgf@holdingphysicalpagefalse
 
+\let\pgfpagespoint\pgfpoint
 
 % Define a layout
 %
@@ -46,7 +47,7 @@
 % \pgfpagesdeclarelayout{resize to}{
 %    \pgfpagesphysicalpageoptions{logical pages=1,physical height=\pgfpageoptionheight,physical width=\pgfpageoptionwidth}
 %    \pgfpageslogicalpageoptions{1}{resized width=\pgfphysicalwidth,%
-%      resized height=\pgfphysicalheight,center=\pgfpoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight}}}
+%      resized height=\pgfphysicalheight,center=\pgfpagespoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight}}}
 
 \newcommand\pgfpagesdeclarelayout[3]{
   \expandafter\newcommand\csname pgfpages@layoutbefore@#1\endcsname{#2}
@@ -131,32 +132,32 @@
 
 \define@key{pgfpagesuselayoutoption}{second right}[]%
 {%
-  \def\pgfpageoptionfirstcenter{\pgfpoint{.5\paperwidth}{.5\paperheight}}%
-  \def\pgfpageoptionsecondcenter{\pgfpoint{1.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionfirstcenter{\pgfpagespoint{.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionsecondcenter{\pgfpagespoint{1.5\paperwidth}{.5\paperheight}}%
   \def\pgfpageoptiontwoheight{\paperheight}%
   \def\pgfpageoptiontwowidth{2\paperwidth}%
 }
 
 \define@key{pgfpagesuselayoutoption}{second left}[]%
 {%
-  \def\pgfpageoptionfirstcenter{\pgfpoint{1.5\paperwidth}{.5\paperheight}}%
-  \def\pgfpageoptionsecondcenter{\pgfpoint{.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionfirstcenter{\pgfpagespoint{1.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionsecondcenter{\pgfpagespoint{.5\paperwidth}{.5\paperheight}}%
   \def\pgfpageoptiontwoheight{\paperheight}%
   \def\pgfpageoptiontwowidth{2\paperwidth}%
 }
 
 \define@key{pgfpagesuselayoutoption}{second top}[]%
 {%
-  \def\pgfpageoptionfirstcenter{\pgfpoint{.5\paperwidth}{.5\paperheight}}%
-  \def\pgfpageoptionsecondcenter{\pgfpoint{.5\paperwidth}{1.5\paperheight}}%
+  \def\pgfpageoptionfirstcenter{\pgfpagespoint{.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionsecondcenter{\pgfpagespoint{.5\paperwidth}{1.5\paperheight}}%
   \def\pgfpageoptiontwoheight{2\paperheight}%
   \def\pgfpageoptiontwowidth{\paperwidth}%
 }
 
 \define@key{pgfpagesuselayoutoption}{second bottom}[]%
 {%
-  \def\pgfpageoptionfirstcenter{\pgfpoint{.5\paperwidth}{1.5\paperheight}}%
-  \def\pgfpageoptionsecondcenter{\pgfpoint{.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionfirstcenter{\pgfpagespoint{.5\paperwidth}{1.5\paperheight}}%
+  \def\pgfpageoptionsecondcenter{\pgfpagespoint{.5\paperwidth}{.5\paperheight}}%
   \def\pgfpageoptiontwoheight{2\paperheight}%
   \def\pgfpageoptiontwowidth{\paperwidth}%
 }
@@ -176,7 +177,7 @@
   }
   \pgfpageslogicalpageoptions{1}
   {%
-    center=\pgfpoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight},%
+    center=\pgfpagespoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight},%
     corner width=\pgfpageoptioncornerwidth%
   }%
 }
@@ -197,7 +198,7 @@
     resized width=\pgfphysicalwidth,%
     resized height=\pgfphysicalheight,%
     border shrink=\pgfpageoptionborder,%
-    center=\pgfpoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    center=\pgfpagespoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight}%
   }%
 }
 
@@ -265,14 +266,14 @@
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=\pgfphysicalheight,%
-      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+      center=\pgfpagespoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{2}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=\pgfphysicalheight,%
-      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+      center=\pgfpagespoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
     }%
   \else
     % stack on top of one another
@@ -281,14 +282,14 @@
       border shrink=\pgfpageoptionborder,%
       resized width=\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+      center=\pgfpagespoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{2}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+      center=\pgfpagespoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
     }%
   \fi    
 }
@@ -312,28 +313,28 @@
     border shrink=\pgfpageoptionborder,%
     resized width=.5\pgfphysicalwidth,%
     resized height=.5\pgfphysicalheight,%
-    center=\pgfpoint{.25\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    center=\pgfpagespoint{.25\pgfphysicalwidth}{.75\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{2}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.5\pgfphysicalwidth,%
     resized height=.5\pgfphysicalheight,%
-    center=\pgfpoint{.75\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    center=\pgfpagespoint{.75\pgfphysicalwidth}{.75\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{3}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.5\pgfphysicalwidth,%
     resized height=.5\pgfphysicalheight,%
-    center=\pgfpoint{.25\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    center=\pgfpagespoint{.25\pgfphysicalwidth}{.25\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{4}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.5\pgfphysicalwidth,%
     resized height=.5\pgfphysicalheight,%
-    center=\pgfpoint{.75\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    center=\pgfpagespoint{.75\pgfphysicalwidth}{.25\pgfphysicalheight}%
   }%
 }
 
@@ -358,42 +359,42 @@
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.167\pgfphysicalwidth}{.75\pgfphysicalheight}%
+      center=\pgfpagespoint{.167\pgfphysicalwidth}{.75\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{2}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+      center=\pgfpagespoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{3}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.833\pgfphysicalwidth}{.75\pgfphysicalheight}%
+      center=\pgfpagespoint{.833\pgfphysicalwidth}{.75\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{4}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.167\pgfphysicalwidth}{.25\pgfphysicalheight}%
+      center=\pgfpagespoint{.167\pgfphysicalwidth}{.25\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{5}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+      center=\pgfpagespoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{6}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.833\pgfphysicalwidth}{.25\pgfphysicalheight}%
+      center=\pgfpagespoint{.833\pgfphysicalwidth}{.25\pgfphysicalheight}%
     }%
   \else
     % stack on top of one another
@@ -402,42 +403,42 @@
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.25\pgfphysicalwidth}{.833\pgfphysicalheight}%
+      center=\pgfpagespoint{.25\pgfphysicalwidth}{.833\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{2}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.75\pgfphysicalwidth}{.833\pgfphysicalheight}%
+      center=\pgfpagespoint{.75\pgfphysicalwidth}{.833\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{3}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+      center=\pgfpagespoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{4}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+      center=\pgfpagespoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{5}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.25\pgfphysicalwidth}{.167\pgfphysicalheight}%
+      center=\pgfpagespoint{.25\pgfphysicalwidth}{.167\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{6}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.75\pgfphysicalwidth}{.167\pgfphysicalheight}%
+      center=\pgfpagespoint{.75\pgfphysicalwidth}{.167\pgfphysicalheight}%
     }%
   \fi    
 }
@@ -463,56 +464,56 @@
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.125\pgfphysicalwidth}{.75\pgfphysicalheight}%
+      center=\pgfpagespoint{.125\pgfphysicalwidth}{.75\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{2}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.375\pgfphysicalwidth}{.75\pgfphysicalheight}%
+      center=\pgfpagespoint{.375\pgfphysicalwidth}{.75\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{3}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.625\pgfphysicalwidth}{.75\pgfphysicalheight}%
+      center=\pgfpagespoint{.625\pgfphysicalwidth}{.75\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{4}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.875\pgfphysicalwidth}{.75\pgfphysicalheight}%
+      center=\pgfpagespoint{.875\pgfphysicalwidth}{.75\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{5}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.125\pgfphysicalwidth}{.25\pgfphysicalheight}%
+      center=\pgfpagespoint{.125\pgfphysicalwidth}{.25\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{6}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.375\pgfphysicalwidth}{.25\pgfphysicalheight}%
+      center=\pgfpagespoint{.375\pgfphysicalwidth}{.25\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{7}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.625\pgfphysicalwidth}{.25\pgfphysicalheight}%
+      center=\pgfpagespoint{.625\pgfphysicalwidth}{.25\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{8}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.25\pgfphysicalwidth,%
       resized height=.5\pgfphysicalheight,%
-      center=\pgfpoint{.875\pgfphysicalwidth}{.25\pgfphysicalheight}%
+      center=\pgfpagespoint{.875\pgfphysicalwidth}{.25\pgfphysicalheight}%
     }%
   \else
     % stack on top of one another
@@ -521,56 +522,56 @@
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.25\pgfphysicalwidth}{.875\pgfphysicalheight}%
+      center=\pgfpagespoint{.25\pgfphysicalwidth}{.875\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{2}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.75\pgfphysicalwidth}{.875\pgfphysicalheight}%
+      center=\pgfpagespoint{.75\pgfphysicalwidth}{.875\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{3}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.25\pgfphysicalwidth}{.625\pgfphysicalheight}%
+      center=\pgfpagespoint{.25\pgfphysicalwidth}{.625\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{4}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.75\pgfphysicalwidth}{.625\pgfphysicalheight}%
+      center=\pgfpagespoint{.75\pgfphysicalwidth}{.625\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{5}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.25\pgfphysicalwidth}{.375\pgfphysicalheight}%
+      center=\pgfpagespoint{.25\pgfphysicalwidth}{.375\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{6}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.75\pgfphysicalwidth}{.375\pgfphysicalheight}%
+      center=\pgfpagespoint{.75\pgfphysicalwidth}{.375\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{7}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.25\pgfphysicalwidth}{.125\pgfphysicalheight}%
+      center=\pgfpagespoint{.25\pgfphysicalwidth}{.125\pgfphysicalheight}%
     }%
     \pgfpageslogicalpageoptions{8}
     {%
       border shrink=\pgfpageoptionborder,%
       resized width=.5\pgfphysicalwidth,%
       resized height=.25\pgfphysicalheight,%
-      center=\pgfpoint{.75\pgfphysicalwidth}{.125\pgfphysicalheight}%
+      center=\pgfpagespoint{.75\pgfphysicalwidth}{.125\pgfphysicalheight}%
     }%
   \fi    
 }
@@ -594,112 +595,112 @@
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.125\pgfphysicalwidth}{.875\pgfphysicalheight}%
+    center=\pgfpagespoint{.125\pgfphysicalwidth}{.875\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{2}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.375\pgfphysicalwidth}{.875\pgfphysicalheight}%
+    center=\pgfpagespoint{.375\pgfphysicalwidth}{.875\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{3}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.625\pgfphysicalwidth}{.875\pgfphysicalheight}%
+    center=\pgfpagespoint{.625\pgfphysicalwidth}{.875\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{4}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.875\pgfphysicalwidth}{.875\pgfphysicalheight}%
+    center=\pgfpagespoint{.875\pgfphysicalwidth}{.875\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{5}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.125\pgfphysicalwidth}{.625\pgfphysicalheight}%
+    center=\pgfpagespoint{.125\pgfphysicalwidth}{.625\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{6}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.375\pgfphysicalwidth}{.625\pgfphysicalheight}%
+    center=\pgfpagespoint{.375\pgfphysicalwidth}{.625\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{7}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.625\pgfphysicalwidth}{.625\pgfphysicalheight}%
+    center=\pgfpagespoint{.625\pgfphysicalwidth}{.625\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{8}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.875\pgfphysicalwidth}{.625\pgfphysicalheight}%
+    center=\pgfpagespoint{.875\pgfphysicalwidth}{.625\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{9}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.125\pgfphysicalwidth}{.375\pgfphysicalheight}%
+    center=\pgfpagespoint{.125\pgfphysicalwidth}{.375\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{10}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.375\pgfphysicalwidth}{.375\pgfphysicalheight}%
+    center=\pgfpagespoint{.375\pgfphysicalwidth}{.375\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{11}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.625\pgfphysicalwidth}{.375\pgfphysicalheight}%
+    center=\pgfpagespoint{.625\pgfphysicalwidth}{.375\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{12}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.875\pgfphysicalwidth}{.375\pgfphysicalheight}%
+    center=\pgfpagespoint{.875\pgfphysicalwidth}{.375\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{13}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.125\pgfphysicalwidth}{.125\pgfphysicalheight}%
+    center=\pgfpagespoint{.125\pgfphysicalwidth}{.125\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{14}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.375\pgfphysicalwidth}{.125\pgfphysicalheight}%
+    center=\pgfpagespoint{.375\pgfphysicalwidth}{.125\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{15}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.625\pgfphysicalwidth}{.125\pgfphysicalheight}%
+    center=\pgfpagespoint{.625\pgfphysicalwidth}{.125\pgfphysicalheight}%
   }%
   \pgfpageslogicalpageoptions{16}
   {%
     border shrink=\pgfpageoptionborder,%
     resized width=.25\pgfphysicalwidth,%
     resized height=.25\pgfphysicalheight,%
-    center=\pgfpoint{.875\pgfphysicalwidth}{.125\pgfphysicalheight}%
+    center=\pgfpagespoint{.875\pgfphysicalwidth}{.125\pgfphysicalheight}%
   }%
 }
 
@@ -778,7 +779,7 @@
 %
 % Example:
 %
-% \pgfpageslogicalpageoptions{1}{scale=0.5,center=\pgfpoint{0cm}{2cm}}
+% \pgfpageslogicalpageoptions{1}{scale=0.5,center=\pgfpagespoint{0cm}{2cm}}
 
 \newcommand\pgfpageslogicalpageoptions[2]{%
   \pgf@cpn=#1\relax%
@@ -903,7 +904,7 @@
         \fi%
         \pgfutil@tempdima=\csname pgfpages@p@\the\pgf@cpn @width\endcsname\relax%
         \pgfutil@tempdimb=\csname pgfpages@p@\the\pgf@cpn @height\endcsname\relax%
-        \pgflowlevel{\pgftransformshift{\pgfpoint{-.5\pgfutil@tempdima}{-.5\pgfutil@tempdimb}}}%
+        \pgflowlevel{\pgftransformshift{\pgfpagespoint{-.5\pgfutil@tempdima}{-.5\pgfutil@tempdimb}}}%
         \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @bordercode\endcsname\relax%
         \else%
           \pgfpathmoveto{\pgfpointorigin}%


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

Fixes #911 and allow using `pgfpages` in case of TRT page direction (lualatex)
  just with `\def\pgfpagespoint#1#2{\pgfpoint{-#1}{#2}}`


**Checklist**

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ ] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
