### PR TITLE
Simplify \coordinate at parsing #785

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -3756,14 +3756,8 @@
   \pgfutil@ifnextchar t{\tikz@@coordinate@@at[#1](#2)a}%
   {\tikz@fig ode[shape=coordinate,#1](#2){}a}%
 }%
-\def\tikz@@coordinate@@at[#1](#2)at#3({%
-  \def\tikz@coordinate@caller{\tikz@fig ode[shape=coordinate,#1](#2)at}%
-  \tikz@scan@one@point\tikz@@coordinate@at@math(%
-}%
-\def\tikz@@coordinate@at@math#1{%
-  \pgf@process{#1}%
-  \edef\tikz@temp{(\the\pgf@x,\the\pgf@y)}%
-  \expandafter\tikz@coordinate@caller\tikz@temp{}%
+\def\tikz@@coordinate@@at[#1](#2)at#3(#4){%
+  \tikz@fig ode[shape=coordinate,#1](#2)at(#4){}%
 }%
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

This is another attempt at fixing #785 to make the \coordinate at
construction compatible with the (as of yet) internal \tikz@dcl@coord@
mechanism.

In some ways this is a quick and dirty fix because it doesn't remove
the flaw of the original implementation of expecting a literal ( at
the start of the coordinate. In principle the same as for
\tikz@scan@one@point should be done which expands tokens until it finds
a literal (.

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
