### PR TITLE
Add missing word to decorations documentation

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-decorations.tex
@@ -167,7 +167,7 @@ decorate the decorated path once more.
 \end{codeexample}
 
 One final word of warning: Decorations can be pretty slow to typeset and they
-can be inaccurate. The reason is that \pgfname\ has to a \emph{lot} of rather
+can be inaccurate. The reason is that \pgfname\ has to do a \emph{lot} of rather
 difficult computations in the background and \TeX\ is not very good at doing
 math. Decorations are fastest when applied to straight line segments, but even
 then they are much slower than other alternatives. For instance, the |ticks|


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

As stated in the commit title, the documentation is missing a word in a sentence.

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
