### PR TITLE
Add reference for transform key

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
@@ -1385,7 +1385,8 @@ shapes. This library is included mostly for historical reasons, using the
             text within a group, for example, |W{\kern-1ptA}TER|.
         \item Each character is positioned using the center of its baseline. To
             move the text vertically (relative to the path), the additional
-            transform key should be used.
+            transform key should be used (see
+            Section~\ref{section-decorations-adjust} for details).
         \item No attempt is made to ensure characters do not overlap when the
             angle between segments is considerably less than 180$^\circ$ (this
             is tricky to do in \TeX{} without a huge processing overhead). In

--- a/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-decorations.tex
@@ -1385,7 +1385,7 @@ shapes. This library is included mostly for historical reasons, using the
             text within a group, for example, |W{\kern-1ptA}TER|.
         \item Each character is positioned using the center of its baseline. To
             move the text vertically (relative to the path), the additional
-            transform key should be used (see
+            decoration key |raise| should be used (see
             Section~\ref{section-decorations-adjust} for details).
         \item No attempt is made to ensure characters do not overlap when the
             angle between segments is considerably less than 180$^\circ$ (this


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

The description of the `text along path' decoration mentions using the
transform key to move text vertically (relative to the baseline).
Unfortunately, "transform" appears more than 1000 times in the
documentation, which makes finding the relevant documentation for that
key difficult, as evidenced personally and a question on TeX - LaTeX
Stack Exchange that addresses this issue.

This change adds a reference to the appropriate section in the
documentation for the `/pgf/decoration/transform` key so that future
users don't have this same difficulty. (It effectively follows the
recommendation in the answer to the TeX - LaTeX Stack Exchange
question, which has not been done in the intervening eight years.)

How can I move a "text along path" vertically? (TeX - LaTeX Stack
Exchange): https://tex.stackexchange.com/a/134589

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

Please check the boxes to explicitly state your agreement to these terms:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
