### PR TITLE
Blend mode as array is deprecated #1037

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-common-pdf.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-common-pdf.def
@@ -89,7 +89,7 @@
       \pgferror{Unknown blend mode '#1'}%
       \def\pgf@temp{Normal}%
     \fi%
-    \edef\pgf@temp{/pgf@bm\pgf@temp << /BM [ /\pgf@temp ] >>}%<<
+    \edef\pgf@temp{/pgf@bm\pgf@temp << /BM /\pgf@temp >>}%<<
     \expandafter\pgfutil@addpdfresource@extgs\expandafter{\pgf@temp}%
   \fi%
   \pgfsysprotocol@literal{\csname pgf@sys@pdf@bm@#1\endcsname\space gs}%


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

Fixes #1037 

**Checklist**

Please check the boxes below and [signoff your commits][git-s] to explicitly
state your agreement to the [Developer Certificate of Origin][DCO]:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
