### PR TITLE
diamond shape: keep aspect when checking against minimum ht/wd

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-shapes.tex
@@ -627,10 +627,13 @@ that apply to most shapes:
     %
 \end{key}
 
-\begin{key}{/pgf/shape aspect=\meta{aspect ratio}}
+\begin{key}{/pgf/shape aspect=\meta{aspect ratio} (initially none)}
         \keyalias{tikz}
     Sets a desired aspect ratio for the shape. For the |diamond| shape, this
-    option sets the ratio between width and height of the shape.
+    option sets the ratio between width and height of the shape. Unlike
+    |/pgf/aspect| which only recommends the ratio, this key ensures it.
+
+    If the special value |none| is given, the ratio assurance is canceled.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{shapes.geometric}}]
 \begin{tikzpicture}

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
@@ -210,10 +210,15 @@
 %
 \pgfkeys{/pgf/.cd,
     aspect/.code={\pgfsetshapeaspect{#1}},% this for tikz...
-    shape aspect/.initial=1,% but this is consistent with other pgfset stuff.
+    shape aspect/.initial=none,% but this is consistent with other pgfset stuff.
     shape aspect/.code={%
-        \pgfkeys{/pgf/aspect=#1}%
-        \pgfkeyssetvalue{/pgf/shape aspect}{#1}
+        \edef\pgf@lib@temp{#1}%
+        \ifx\pgf@lib@temp\pgf@nonetext
+          \pgfkeys{/pgf/aspect=1}%
+        \else
+          \pgfkeys{/pgf/aspect=#1}%
+        \fi
+        \pgfkeyssetvalue{/pgf/shape aspect}{#1}%
     }%
 }%
 
@@ -252,20 +257,29 @@
     \pgf@y=\pgfshapeaspectinverse\pgf@xa%
     \advance\pgf@y by\pgf@ya%
     %
-    % Check against minimum height/width while keeping the shape aspect
+    % Check against minimum height/width while keeping the shape aspect 
+    % if `/pgf/shape aspect` is set
     %
     \pgfmathsetlength\pgf@xb{\pgfkeysvalueof{/pgf/minimum width}}%
     \pgf@xb=.5\pgf@xb%
+    \pgfkeysgetvalue{/pgf/shape aspect}\pgf@lib@temp
+    \PackageWarning{pgf}{\meaning\pgf@lib@temp}%
     \ifdim\pgf@x<\pgf@xb%
       % yes, too small. Enlarge...
-      \advance\pgf@y by\pgfshapeaspectinverse\dimexpr\pgf@xb-\pgf@x\relax
+      \ifx\pgf@lib@temp\pgf@nonetext
+      \else
+        \advance\pgf@y by\pgfshapeaspectinverse\dimexpr\pgf@xb-\pgf@x\relax
+      \fi
       \pgf@x=\pgf@xb%
     \fi%
     \pgfmathsetlength\pgf@yb{\pgfkeysvalueof{/pgf/minimum height}}%
     \pgf@yb=.5\pgf@yb%
     \ifdim\pgf@y<\pgf@yb%
       % yes, too small. Enlarge...
-      \advance\pgf@x by\pgfshapeaspect\dimexpr\pgf@yb-\pgf@y\relax
+      \ifx\pgf@lib@temp\pgf@nonetext
+      \else
+        \advance\pgf@x by\pgfshapeaspect\dimexpr\pgf@yb-\pgf@y\relax
+      \fi
       \pgf@y=\pgf@yb%
     \fi%
     %

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
@@ -252,18 +252,20 @@
     \pgf@y=\pgfshapeaspectinverse\pgf@xa%
     \advance\pgf@y by\pgf@ya%
     %
-    % Check against minimum height/width
+    % Check against minimum height/width while keeping the shape aspect
     %
     \pgfmathsetlength\pgf@xb{\pgfkeysvalueof{/pgf/minimum width}}%
     \pgf@xb=.5\pgf@xb%
     \ifdim\pgf@x<\pgf@xb%
       % yes, too small. Enlarge...
+      \advance\pgf@y by\pgfshapeaspectinverse\dimexpr\pgf@xb-\pgf@x\relax
       \pgf@x=\pgf@xb%
     \fi%
     \pgfmathsetlength\pgf@yb{\pgfkeysvalueof{/pgf/minimum height}}%
     \pgf@yb=.5\pgf@yb%
     \ifdim\pgf@y<\pgf@yb%
       % yes, too small. Enlarge...
+      \advance\pgf@x by\pgfshapeaspect\dimexpr\pgf@yb-\pgf@y\relax
       \pgf@y=\pgf@yb%
     \fi%
     %

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.symbols.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.symbols.code.tex
@@ -586,9 +586,14 @@
 %
 \pgfkeys{/pgf/.cd,
   aspect/.code={\pgfsetshapeaspect{#1}},% this for tikz...
-  shape aspect/.initial=1,% but this is consistent with other pgfset stuff.
+  shape aspect/.initial=none,% but this is consistent with other pgfset stuff.
   shape aspect/.code={%
-    \pgfkeys{/pgf/aspect=#1}%
+    \edef\pgf@lib@temp{#1}%
+    \ifx\pgf@lib@temp\pgf@nonetext
+      \pgfkeys{/pgf/aspect=1}%
+    \else
+      \pgfkeys{/pgf/aspect=#1}%
+    \fi
     \pgfkeyssetvalue{/pgf/shape aspect}{#1}
   }%
 }%


### PR DESCRIPTION
**Motivation for this change**

Currently, when a `diamond` shape is enlarged when checking against `minimum height/width`, the `shape aspect` is not kept. This PR fixes the problem.

Example
```tex
\documentclass{article}
\usepackage{tikz}
\usetikzlibrary{shapes.geometric}

\begin{document}
% shape aspect is initially 1 
\begin{tikzpicture}[nodes={diamond, draw}]
  \node[minimum width=50pt] {x};
  \node[minimum height=50pt] at (2,0) {x};
\end{tikzpicture}
\end{document}
```
![image](https://user-images.githubusercontent.com/6376638/130149305-0e999e06-5cc1-4478-892e-ae8c2d89e7f4.png)


**Checklist**

Please check the boxes below and [signoff your commits][git-s] to explicitly
state your agreement to the [Developer Certificate of Origin][DCO]:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
