### PR TITLE
external: fix compatibility with `fadings` lib #1044

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzexternalshared.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzexternalshared.code.tex
@@ -510,8 +510,7 @@
 
 % can be used to (temporarily) disable the externalization.
 \def\tikzexternaldisable{%
-    \let\tikz=\tikzexternal@origtikz
-    \tikzexternal@TEXDIALECT@restore@picture
+    \tikzexternaldisable@nofading
     \pgfutil@ifundefined{tikzexternal@orig@tikzfadingfrompicture}
     {}% NOP
     {%
@@ -519,12 +518,16 @@
         \let\endtikzfadingfrompicture=\tikzexternal@orig@endtikzfadingfrompicture
         \let\tikzfading=\tikzexternal@orig@tikzfading
     }%
+}%
+\def\tikzexternaldisable@nofading{%
+    \let\tikz=\tikzexternal@origtikz
+    \tikzexternal@TEXDIALECT@restore@picture
     \iftikzexternal@optimize
         \ifpgf@external@grabshipout
             \tikzexternal@optimize@RESTORE
         \fi
     \fi
-}%
+}
 % re-enables externalization after a \tikzexternalizedisable.
 \def\tikzexternalenable{%
     \if\tikzexternalize@hasbeencalled1%
@@ -541,14 +544,14 @@
             }{}%
             \def\tikzfadingfrompicture{%
                 \begingroup
-                \tikzexternaldisable
+                \tikzexternaldisable@nofading
                 \tikzexternal@orig@tikzfadingfrompicture}%
             \def\endtikzfadingfrompicture{%
                 \tikzexternal@orig@endtikzfadingfrompicture
                 \endgroup}%
             \def\tikzfading[##1]{%
                 \begingroup
-                \tikzexternaldisable
+                \tikzexternaldisable@nofading
                 \tikzexternal@orig@tikzfading[##1]%
                 \endgroup}%
         }%


### PR DESCRIPTION
**Motivation for this change**

With code
```tex
\usetikzlibrary{external, fadings}
\tikzexternalize
\begin{document}

\begin{tikzfadingfrompicture}[name=...]
  ...
\end{tikzfadingfrompicture}
```
after `\tikzexternalize`, the `tikzfadingfrompicture` env is redefined to
https://github.com/pgf-tikz/pgf/blob/85d2c38b78407e5b1ba42140dfd11fcdf8df1edf/tex/generic/pgf/frontendlayer/tikz/libraries/tikzexternalshared.code.tex#L542-L548
But the `\tikzexternaldisable` in `\tikzfadingfrompicture` redefines `\endtikzfadingfrompicture` again, which makes the group opened by `\tikzfadingfrompicture` not closed and is wrong.
https://github.com/pgf-tikz/pgf/blob/85d2c38b78407e5b1ba42140dfd11fcdf8df1edf/tex/generic/pgf/frontendlayer/tikz/libraries/tikzexternalshared.code.tex#L518-L519

This PR fixes this by removing the fading compatibility code at `\tikzfadingfrompicture` and `\tikzfading`.

Fixes #1044

**Example for testing**
```tex
\documentclass{article}
\usepackage{tikz}
\usetikzlibrary{external, fadings, patterns}

\tikzexternalize

\begin{document}
% adapted from pgfmanual, sec. 23.4.1
\def\background{%
  \fill [black!20] (-1.2,-1.2) rectangle (1.2,1.2);
  \pattern [pattern=checkerboard,pattern color=black!30]
                   (-1.2,-1.2) rectangle (1.2,1.2);}

% test tikzfadingfrompicture env
\begin{tikzfadingfrompicture}[name=fade right with circle]
  \shade[left color=transparent!0,
         right color=transparent!100] (0,0) rectangle (2,2);
  \fill[transparent!50] (1,1) circle (0.7);
\end{tikzfadingfrompicture}

\begin{tikzpicture}
  \background
  \fill [path fading=fade right with circle,red] (-1,-1) rectangle (1,1);
\end{tikzpicture}

% test \tikzfading
\tikzfading[name=fade out,
            inner color=transparent!0,
            outer color=transparent!100]

\begin{tikzpicture}
  \background
  \fill [blue,path fading=fade out] (-1,-1) rectangle (1,1);
\end{tikzpicture}

\end{document}
```
![image](https://user-images.githubusercontent.com/6376638/130952985-173c559a-b5f9-4c3c-8cbc-c034024329eb.png)


**Checklist**

Please check the boxes below and [signoff your commits][git-s] to explicitly
state your agreement to the [Developer Certificate of Origin][DCO]:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
