### PR TITLE
Changed an example diagram to avoid floating-point rounding errors.

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-pics.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-pics.tex
@@ -272,7 +272,7 @@ braces:
     %
 \begin{codeexample}[]
 \tikz \draw (0,0) .. controls(1,0) and (2,1) .. (3,1)
-  foreach \t in {0, 0.1, ..., 1} {
+  foreach \t in {0, 0.25, ..., 1} {
     pic [pos=\t] {code={\draw circle [radius=2pt];}}
   };
 \end{codeexample}


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

An example diagram in 18.2 The Pic Syntax showed off a floating-point rounding error. I've tweaked that diagram to remove the rounding error while aiming to keep the example clean.

**Checklist**

Please check the boxes below and [signoff your commits][git-s] to explicitly
state your agreement to the [Developer Certificate of Origin][DCO]:

- [ ✓ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ ✓ ] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
