### PR TITLE
Tweaked `foreach` loops in example diagrams to avoid a floating-point rounding error.

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-base-animations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-base-animations.tex
@@ -339,7 +339,7 @@ key:
     animation list={0.333/\frac{1}{3},0.666/\frac{2}{3},1,1.333/1\frac{1}{3},1.666/1\frac{2}{3}},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \pgfanimateattribute{translate}{
     whom = node, begin on = {click},
     exit control={1}{0},
@@ -370,7 +370,7 @@ key:
     animation list={0.5,1,1.5,2,2.5},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \pgfanimateattribute{translate}{
     whom = node, begin on = {click},
     entry = {0s}{\pgfpointorigin},
@@ -392,7 +392,7 @@ key:
     animation list={0.5,1,1.5,2},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \pgfanimateattribute{translate}{
     whom = node, begin on = {click},
     entry = {0s}{\pgfpointorigin},

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-animations.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-animations.tex
@@ -2544,7 +2544,7 @@ entry control={0.9}{1},
     animation list={0.333/\frac{1}{3},0.666/\frac{2}{3},1,1.333/1\frac{1}{3},1.666/1\frac{2}{3}},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \node :yshift = { begin on = click,
                     0s = { exit control = {1}{0}, "0cm" },
                     1s = "-5mm",
@@ -2558,7 +2558,7 @@ entry control={0.9}{1},
     animation list={0.333/\frac{1}{3},0.666/\frac{2}{3},1,1.333/1\frac{1}{3},1.666/1\frac{2}{3}},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \node :yshift = { begin on = click,
                     0s = "0cm",
                     1s = "-5mm",
@@ -2572,7 +2572,7 @@ entry control={0.9}{1},
     animation list={0.333/\frac{1}{3},0.666/\frac{2}{3},1,1.333/1\frac{1}{3},1.666/1\frac{2}{3}},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \node :yshift = { begin on = click,
                     0s = { exit control = {1}{0}, "0cm" },
                     1s = "-5mm",
@@ -2608,7 +2608,7 @@ entry control={0.9}{1},
     animation list={0.333/\frac{1}{3},0.666/\frac{2}{3},1,1.333/1\frac{1}{3},1.666/1\frac{2}{3}},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \node :yshift = { begin on = click, ease, 0s = "0cm", 2s = "-10mm" }
     [fill = blue!20, draw = blue, very thick, circle] {Click me!};
 }
@@ -2630,7 +2630,7 @@ from one value to the next. There are two keys for this:
     animation list={0.5,1,1.5,2,2.5},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \node :yshift = { begin on = click,
                     0s = "0cm",
                     1s = {stay, "-5mm"},
@@ -2651,7 +2651,7 @@ from one value to the next. There are two keys for this:
     animation list={0.5,1,1.5,2,2.5},
 ]
 \tikz {
-  \foreach \i in {0,0.1,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
+  \foreach \i in {0,0.125,...,1} \draw (-0.9,.9-\i) -- ++(1.8,0);
   \node :yshift = { begin on = click,
                     0s = "0cm",
                     1s = {jump, "-5mm"},

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-coordinates.tex
@@ -1222,7 +1222,7 @@ Here are two examples:
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (4,4);
 
-  \foreach \i in {0,0.1,...,2}
+  \foreach \i in {0,0.125,...,2}
     \fill ($(2,2) !\i! \i*180:(3,2)$) circle (2pt);
 \end{tikzpicture}
 \end{codeexample}

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-pics.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-pics.tex
@@ -272,7 +272,7 @@ braces:
     %
 \begin{codeexample}[]
 \tikz \draw (0,0) .. controls(1,0) and (2,1) .. (3,1)
-  foreach \t in {0, 0.25, ..., 1} {
+  foreach \t in {0, 0.125, ..., 1} {
     pic [pos=\t] {code={\draw circle [radius=2pt];}}
   };
 \end{codeexample}

--- a/doc/generic/pgf/text-en/pgfmanual-en-tikz-pics.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tikz-pics.tex
@@ -272,7 +272,7 @@ braces:
     %
 \begin{codeexample}[]
 \tikz \draw (0,0) .. controls(1,0) and (2,1) .. (3,1)
-  foreach \t in {0, 0.1, ..., 1} {
+  foreach \t in {0, 0.25, ..., 1} {
     pic [pos=\t] {code={\draw circle [radius=2pt];}}
   };
 \end{codeexample}


### PR DESCRIPTION
…-point rounding error.

Signed-off-by: 3geek14 <nerd.of.pi@gmail.com>

<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

An example in The Pic Syntax uses `{0, 0.1, ..., 1}` for a `foreach` loop. Due to floating-point arithmetic, this leaves out the value `1`. Rather than changing it to `1.01` or adding `, 1` to the list or using integers and dividing by 10 later…I changed the step to `0.25` to avoid the rounding error while maintaining the simplicity of the example.

**Checklist**

Please check the boxes below and [signoff your commits][git-s] to explicitly
state your agreement to the [Developer Certificate of Origin][DCO]:

- [ ✓ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ ✓ ] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
