### PR TITLE
Add warning about floating-point arithmetic to `foreach` introduction

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
@@ -1100,11 +1100,16 @@ however, be dimensionless real numbers) as in the following example:
 \end{codeexample}
 
 If you provide \emph{two} numbers before the |...|, the |\foreach| statement
-will use their difference for the stepping:
+will use their difference for the stepping, but be wary of floating-point
+rounding errors:
 %
 \begin{codeexample}[]
-\tikz \foreach \x in {-1,-0.5,...,1}
-       \draw (\x cm,-1pt) -- (\x cm,1pt);
+\begin{tikzpicture}
+  \foreach \x in {-1,-0.5,...,1}
+    \draw (\x cm,-1pt) -- (\x cm,1pt);
+  \foreach \x in {-1,-0.8,...,1}
+    \draw (\x cm,-7pt) -- (\x cm,-5pt);
+\end{tikzpicture}
 \end{codeexample}
 
 We can also nest loops to create interesting effects:

--- a/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-tutorial.tex
@@ -1107,7 +1107,8 @@ rounding errors:
 \begin{tikzpicture}
   \foreach \x in {-1,-0.5,...,1}
     \draw (\x cm,-1pt) -- (\x cm,1pt);
-  \foreach \x in {-1,-0.8,...,1}
+  \foreach \x in {-1,-0.9,...,0}
+    % tick at 0 is not drawn due to rounding errors
     \draw (\x cm,-7pt) -- (\x cm,-5pt);
 \end{tikzpicture}
 \end{codeexample}


### PR DESCRIPTION
Signed-off-by: 3geek14 <nerd.of.pi@gmail.com>

<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

On #1050, @muzimuzhi suggested it might be worth adding a warning about floating-point errors in `foreach` loops to the tutorial where they are first introduced. I think my suggested change might be a bit cryptic about what sorts of rounding errors show up, but I don't know how explicit it's worth being here, when it's spelled out in far more detail in section 88, Repeating Things: The Foreach Statement. I also added to the example code a second loop that does have a rounding error preventing the final tick from being drawn.

**Checklist**

Please check the boxes below and [signoff your commits][git-s] to explicitly
state your agreement to the [Developer Certificate of Origin][DCO]:

- [ ✓ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ ✓ ] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
