### PR TITLE
Avoid spurious tokens in \pgfcalendarifdate expansion

### DIFF
--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -207,7 +207,7 @@
 }
 
 
-\long\def\pgfcalendar@launch@ifdate#1#2#3{%
+\long\def\pgfcalendar@launch@ifdate#1{%
   % When this macro is called, the pgfcalendarifdatexxxx macros must
   % be setup correctly
   %
@@ -215,9 +215,9 @@
   \pgfcalendarmatchesfalse%
   \pgfqkeys{/pgf/calendar}{#1}%
   \ifpgfcalendarmatches%
-    #2%
+    \expandafter\@firstoftwo
   \else%
-    #3%
+    \expandafter\@secondoftwo
   \fi%
 }
 


### PR DESCRIPTION
**Motivation for this change**

Just like other similar macros in LaTeX, `\pgfcalendarifdate` should avoid 
inserting tokens (namely `\else` of `\if`) behind its result. For example
```latex
\pgfcalendarifdate{\today}{Sunday}{\textbf}{\textit}{Some text}
```
should apply `\textbf` to `Some text` on Sundays and `\textit` on all other 
days. The unexpected extra tokens would get in the way.

**Checklist**

Please check the boxes below and [signoff your commits][git-s] to explicitly
state your agreement to the [Developer Certificate of Origin][DCO]:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ ] Documentation changes are licensed under [FDLv1.2][FDL]
  (no documentation changes)

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
