### PR TITLE
Fix typo in docs

### DIFF
--- a/doc/generic/pgf/text-en/pgfmanual-en-library-lsystems.tex
+++ b/doc/generic/pgf/text-en/pgfmanual-en-library-lsystems.tex
@@ -18,7 +18,7 @@ subsequently used to model branching patterns in plants and produce fractal
 patterns. Typically, an L-system consists of a set of symbols, each of which is
 associated with some graphical action (such as ``turn left'' or ``move
 forward'') and a set of rules (``production'' or ``rewrite'' rules). Given a
-string of symbols, the rewrite rules are applied several times and the when
+string of symbols, the rewrite rules are applied several times and when the
 resulting string is processed the action associated with each symbol is
 executed.
 


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
