### PR TITLE
angles: set pics/code in angle

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryangles.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryangles.code.tex
@@ -14,11 +14,13 @@
 \tikzset{
   pics/angle/.style = {
     setup code  = \tikz@lib@angle@parse#1\pgf@stop,
+    code = {},
     background code = \tikz@lib@angle@background#1\pgf@stop,
     foreground code = \tikz@lib@angle@foreground#1\pgf@stop,
   },
   pics/right angle/.style = {
     setup code  = \tikz@lib@angle@parse#1\pgf@stop,
+    code = {},
     background code = \tikz@lib@rightangle@background#1\pgf@stop,
     foreground code = \tikz@lib@rightangle@foreground#1\pgf@stop,
   },


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Fixes #1068

When angle (or right angle) pics appear within another pic, they may
cause a stack overflow because they don't reset /tikz/pics/code.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
