### PR TITLE
pgfmath: reset " catcode inside parser

### DIFF
--- a/tex/generic/pgf/math/pgfmathparser.code.tex
+++ b/tex/generic/pgf/math/pgfmathparser.code.tex
@@ -203,6 +203,10 @@
 \def\pgfmath@dots{...}
 \def\pgfmath@char@zero{0}
 \def\pgfmath@char@quote{"}
+\begingroup
+  \catcode`\"=13
+  \gdef\pgfmath@char@quote@active{"}
+\endgroup
 \def\pgfmath@char@exclamation{!}
 \def\pgfmath@char@plus{+}
 \def\pgfmath@char@minus{-}
@@ -338,7 +342,7 @@
       % See |\pgfmathdeclareoperator| (below). Note that |+| and |-|
       % that are also declared as operators have been tested before so
       % they should never be parsed as binary (infix) operator at this stage.
-      \expandafter\ifx\csname pgfmath@operation@\expandafter\string\pgfmath@token @prefix\endcsname\pgfmath@token
+      \ifcsname pgfmath@operation@\expandafter\string\pgfmath@token @prefix\endcsname
         \let\pgfmath@parse@next=\pgfmath@parse@prefix@operator
       \else
         \ifpgfmath@quickparse
@@ -370,22 +374,27 @@
 \def\pgfmath@parse@prefix@operator{%
   \ifx\pgfmath@token\pgfmath@char@quote% Quote character.
     \let\pgfmath@parse@next=\pgfmath@parse@operand@quote%
-  \else%
-    \ifx\pgfmath@token\pgfmath@char@exclamation% Prefix !.
-      \pgfmath@stack@push@operation{not}%
-      \let\pgfmath@parse@next=\pgfmath@parse@@operand%
-    \else% Anything else, just push and hope.
-      \expandafter\pgfmath@stack@push@operation\expandafter{\pgfmath@token}%
-      \let\pgfmath@parse@next=\pgfmath@parse@@operand%
-    \fi%
-  \fi%
+  \else\ifx\pgfmath@token\pgfmath@char@quote@active% Active quote character.
+    \let\pgfmath@parse@next=\pgfmath@parse@operand@quote@active%
+  \else\ifx\pgfmath@token\pgfmath@char@exclamation% Prefix !.
+    \pgfmath@stack@push@operation{not}%
+    \let\pgfmath@parse@next=\pgfmath@parse@@operand%
+  \else% Anything else, just push and hope.
+    \expandafter\pgfmath@stack@push@operation\expandafter{\pgfmath@token}%
+    \let\pgfmath@parse@next=\pgfmath@parse@@operand%
+  \fi\fi\fi%
   \pgfmath@parse@next%
 }%
 
 
 % Quote part of an expression.
 %
-\def\pgfmath@parse@operand@quote#1"{%
+\def\pgfmath@parse@operand@quote#1"{\pgfmath@parse@operand@quote@indeed{#1}}
+\begingroup
+  \catcode`\"=13
+  \gdef\pgfmath@parse@operand@quote@active#1"{\pgfmath@parse@operand@quote@indeed{#1}}
+\endgroup
+\def\pgfmath@parse@operand@quote@indeed#1{%
   \def\pgfmathresult{#1}%
   \expandafter\pgfmath@stack@push@operand\expandafter{\pgfmathresult}%
   \pgfmath@parse@@operator%


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Fixes #1062

This will prevent the use of babel hyphens in pgfmath quoted text, but I'm pretty sure that this is a very niche use-case. See also discussion in the issue thread.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
