### PR TITLE
Protect against comma in pgfkeys arguments

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/circuits/tikzlibrarycircuits.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/circuits/tikzlibrarycircuits.code.tex
@@ -144,8 +144,8 @@
   },
   circuit symbol unit/.code=\pgfmathsetlength\tikzcircuitssizeunit{#1},
   circuit symbol size/.style args={width #1 height #2}{
-    minimum width=#1*\tikzcircuitssizeunit,
-    minimum height=#2*\tikzcircuitssizeunit
+    minimum width={(#1)*\tikzcircuitssizeunit},
+    minimum height={(#2)*\tikzcircuitssizeunit}
   },
   huge circuit symbols/.style={circuit symbol unit=10pt},
   large circuit symbols/.style={circuit symbol unit=8pt},

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/datavisualization/tikzlibrarydatavisualization.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/datavisualization/tikzlibrarydatavisualization.code.tex
@@ -245,14 +245,14 @@
       \tikz@lib@dv@handle@data@group@use{#1}{#2}}}}%
 
 \def\tikz@lib@dv@handle@data@group@def#1#2={%
-  \pgfkeys{/pgf/data/new group=#2}%
+  \pgfkeys{/pgf/data/new group={#2}}%
   \tikz@lib@dv@handle@data@group@extend{#1}{#2}+=%
 }%
 
 \def\tikz@lib@dv@handle@data@group@extend#1#2+={%
   \pgfutil@ifnextchar\bgroup{
     \begingroup%
-      \pgfkeys{/pgf/data/store in group=#2}%
+      \pgfkeys{/pgf/data/store in group={#2}}%
       \pgf@dv@do@adddata{\pgfkeysvalueof{/pgf/data visualization/obj}.add data({{\begingroup\pgfkeys{/pgf/data/.cd,/pgf/every data/.try,#1}}})}%
       \afterassignment\tikz@lib@dv@parse@loop%
       \let\tikz@dummy=%get rid of \bgroup
@@ -423,7 +423,7 @@
   store/.code=,% ignore
   when/.code=,% ignore
   class/.store in=\tikz@dv@new@class,
-  before creation/.code=#1,
+  before creation/.code={#1},
   after creation/.store in=\tikz@dv@new@after,
   arg1/.store in=\tikz@dv@arg@a,
   arg2/.store in=\tikz@dv@arg@b,
@@ -507,7 +507,7 @@
       arg3 from key=/tikz/data visualization/#1/scaling,
       arg4 from key=/tikz/data visualization/#1/function
     },
-    #1/attribute/.initial=#1,
+    #1/attribute/.initial={#1},
     #1/function/.initial=,
     #1/scaling/.initial=,
     #1/scaling/default/.initial=0 at 0 and 1 at 1,
@@ -826,7 +826,7 @@
 \def\tikz@lib@dv@special@at#1#2{%
   % Ok, calculate direction vector:
   \tikzpointandanchordirection{\pgfkeysvalueof{#1/scaling mapper}.set in to(min)}{\pgfkeysvalueof{#1/scaling mapper}.set in to(max)}
-  \tikzset{anchor/.expanded=#2}
+  \tikzset{anchor/.expanded={#2}}
 }%
 
 
@@ -1436,9 +1436,9 @@
 \tikzset{
   /tikz/data visualization/axis options/.cd,
   unit vector/.code=\tikz@scan@one@point\tikz@lib@dv@uv#1,
-  length/.style={\tikz@dv@axis/scaling=min at 0 and max at #1},
+  length/.style={\tikz@dv@axis/scaling=min at 0 and max at {#1}},
   unit length/.code={\tikz@dv@parse@unit@length{#1}},
-  power unit length/.style={\tikz@dv@axis/scaling=1 at 0 and 10 at #1}
+  power unit length/.style={\tikz@dv@axis/scaling=1 at 0 and 10 at {#1}}
 }%
 
 \def\tikz@lib@dv@uv#1{%
@@ -1454,7 +1454,7 @@
   \fi%
 }%
 \def\tikz@dv@parse@unit@length@#1per#2units\pgf@stop{
-  \pgfkeysalso{\tikz@dv@axis/scaling=0 at 0 and #2 at #1}
+  \pgfkeysalso{\tikz@dv@axis/scaling=0 at 0 and {#2} at {#1}}
 }%
 
 
@@ -1467,7 +1467,7 @@
     #1/.code={
       \def\tikz@visualizer{#1}%
       \pgfkeys{/tikz/data visualization/visualizer options/.cd,##1}
-      \pgf@dv@do@adddata{\pgfkeysvalueof{/pgf/data visualization/obj}.add data(\pgfkeys{/data point/set=#1})}%
+      \pgf@dv@do@adddata{\pgfkeysvalueof{/pgf/data visualization/obj}.add data(\pgfkeys{/data point/set={#1}})}%
     },
     /utils/exec={
       \advance\tikzdvvisualizercounter by 1\relax
@@ -1491,7 +1491,7 @@
     /tikz/data visualization/visualizers/#1/label in legend options/.style={#3},
   },
   style sheet/.style={/data point/set/.style sheet={#1}},
-  /pgf/data/set/.style={/data point/set=#1},
+  /pgf/data/set/.style={/data point/set={#1}},
 }%
 
 \tikzdatavisualizationset{
@@ -1521,7 +1521,7 @@
 
 \def\tikz@do@visualizer#1#2{%
   \tikzdatavisualizationset{
-    #2=#1
+    #2={#1}
   }
 }%
 
@@ -1568,7 +1568,7 @@
           #2]
           \tikzdatavisualizationset{every data set label/.try}
           \path [
-            /data point/set=#1,/utils/exec=\pgf@signalstyle.emit(),
+            /data point/set={#1},/utils/exec=\pgf@signalstyle.emit(),
             /tikz/data visualization/.cd,every label in data/.try]
           (label visualizer coordinate') --
           (label visualizer coordinate)
@@ -2038,7 +2038,7 @@
       /tikz/.cd,
       every label/.try,
       /tikz/data visualization/legend entry options/.cd,
-      setup={/data point/set=#1},
+      setup={/data point/set={#1}},
       /tikz/data visualization/visualizers/#1/label in legend options/.try,
       #2,
     }
@@ -2220,8 +2220,8 @@
   %
   %
   visualizer options/.cd,
-  attribute 1/.style={/data point/\tikz@visualizer/attribute 1=#1},
-  attribute 2/.style={/data point/\tikz@visualizer/attribute 2=#1},
+  attribute 1/.style={/data point/\tikz@visualizer/attribute 1={#1}},
+  attribute 2/.style={/data point/\tikz@visualizer/attribute 2={#1}},
 }%
 
 
@@ -2264,7 +2264,7 @@
 
 \pgfdvdeclarestylesheet{vary thickness}
 {
-  default style/.style={line width={0.3pt+#1*0.2pt}}
+  default style/.style={line width={0.3pt+(#1)*0.2pt}}
 }%
 
 \pgfdvdeclarestylesheet{vary dashing}

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzexternalshared.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzexternalshared.code.tex
@@ -121,7 +121,7 @@
 
 \pgfqkeys{/tikz/external}{
     figure list/.is if=tikzexternal@genfigurelist,
-    aux in dpth/.style={/pgf/images/aux in dpth=#1},%
+    aux in dpth/.style={/pgf/images/aux in dpth={#1}},%
     disable dependency files/.code={%
         \let\tikzexternalfiledependsonfile@ACTIVE=\tikzexternalfiledependsonfile
     },

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryanimations.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryanimations.code.tex
@@ -489,8 +489,8 @@
   origin/.code=\tikz@anim@parse@origin{#1},
   transform/.code=\tikz@anim@add{\pgfanimationset{transform={\let\tikz@transform\relax\tikzset{#1}}}},
   along/.code=\tikz@anim@handle@along#1\pgf@stop,
-  entry control/.code=\tikz@anim@add{\pgfanimationset{entry control=#1}},
-  exit control/.code=\tikz@anim@add{\pgfanimationset{exit control=#1}},
+  entry control/.code=\tikz@anim@add{\pgfanimationset{entry control={#1}}},
+  exit control/.code=\tikz@anim@add{\pgfanimationset{exit control={#1}}},
   stay/.code=\tikz@anim@add{\pgfanimationset{stay}},
   jump/.code=\tikz@anim@add{\pgfanimationset{jump}},
   ease/.style={

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarychains.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarychains.code.tex
@@ -145,10 +145,10 @@
   \xdef\tikzchaincurrent{#1-\the\c@pgf@counta}%
   \expandafter\xdef\csname tikz@lib@chain@count@#1\endcsname{\the\c@pgf@counta}%
   \ifnum\c@pgf@counta=1\relax%
-    \tikzset{alias/.expanded=#1-begin} % Define pseudostart
+    \tikzset{alias/.expanded={#1-begin}} % Define pseudostart
   \fi%
-  \tikzset{alias/.expanded=#1-end} % Define pseudostart
-  \tikzset{alias/.expanded=#1-\the\c@pgf@counta} % Define pseudostart
+  \tikzset{alias/.expanded={#1-end}} % Define pseudostart
+  \tikzset{alias/.expanded={#1-\the\c@pgf@counta}} % Define pseudostart
   \tikz@lib@chain@direction%
   \tikzset{every on chain/.try}%
 }%

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryshapes.multipart.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryshapes.multipart.code.tex
@@ -12,12 +12,12 @@
 \usepgflibrary{shapes.multipart}%
 
 \pgfkeys{/tikz/rectangle split/parts/.code={%
-    \pgfkeys{/pgf/rectangle split parts=#1}%
+    \pgfkeys{/pgf/rectangle split parts={#1}}%
     }%
 }%
 
 \pgfkeys{/tikz/rectangle split use custom fill/.code={%
-    \pgfkeys{/pgf/rectangle split use custom fill=#1}%
+    \pgfkeys{/pgf/rectangle split use custom fill={#1}}%
     \pgfkeys{/tikz/fill=none}}%
 }%
 

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryspy.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryspy.code.tex
@@ -38,9 +38,9 @@
 \let\tikz@lib@spy@collection=\pgfutil@empty%
 
 \tikzset{spy scope/.style={
-    size/.style={minimum size=##1},
-    height/.style={minimum height=##1},
-    width/.style={minimum width=##1},
+    size/.style={minimum size={##1}},
+    height/.style={minimum height={##1}},
+    width/.style={minimum width={##1}},
     execute at begin scope={%
       \let\tikz@lib@spy@save=\tikz@lib@spy@collection%
       \setbox\tikz@lib@spybox=\hbox\bgroup\bgroup%
@@ -58,7 +58,7 @@
   },
   lens/.store in=\tikz@lib@spy@lens,
   lens=,
-  magnification/.style={lens={scale=#1}},
+  magnification/.style={lens={scale={#1}}},
   spy connection path/.store in=\tikz@lib@spy@path,
   spy connection path=
 }%

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryturtle.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryturtle.code.tex
@@ -37,7 +37,7 @@
 % given, by turtle distance
 \tikzset{
   turtle/back/.default=\pgfkeysvalueof{/tikz/turtle/distance},
-  turtle/back/.style={turtle forward=-#1}
+  turtle/back/.style={turtle forward={-(#1)}}
 }%
 
 
@@ -71,13 +71,13 @@
 
 % Shortcuts:
 \tikzset{turtle/.cd,
-  fd/.style={forward=#1},
+  fd/.style={forward={#1}},
   fd/.default=\pgfkeysvalueof{/tikz/turtle/distance},
-  bk/.style={back=#1},
+  bk/.style={back={#1}},
   bk/.default=\pgfkeysvalueof{/tikz/turtle/distance},
-  lt/.style={left=#1},
+  lt/.style={left={#1}},
   lt/.default=90,
-  rt/.style={right=#1},
+  rt/.style={right={#1}},
   rt/.default=90}%
 
 

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -576,7 +576,7 @@
   scope fading/.default=}%
 \tikzset{fit fading/.is if=tikz@fade@adjust}%
 \tikzset{fading transform/.store in=\tikz@fade@transform}%
-\tikzset{fading angle/.style={fading transform={rotate=#1}}}%
+\tikzset{fading angle/.style={fading transform={rotate={#1}}}}%
 
 \newif\iftikz@fade@adjust%
 \tikz@fade@adjusttrue%
@@ -1647,7 +1647,7 @@
 % Setting keys
 %
 
-\pgfkeys{/tikz/style/.style=#1}%
+\pgfkeys{/tikz/style/.style={#1}}%
 
 \pgfkeys{/tikz/.unknown/.code=%
   % Is it a pgf key?
@@ -5136,7 +5136,7 @@
 \tikzset{cs/angle/.store in=\tikz@cs@angle}%
 \tikzset{cs/x radius/.store in=\tikz@cs@xradius}%
 \tikzset{cs/y radius/.store in=\tikz@cs@yradius}%
-\tikzset{cs/radius/.style={/tikz/cs/x radius=#1,/tikz/cs/y radius=#1}}%
+\tikzset{cs/radius/.style={/tikz/cs/x radius={#1},/tikz/cs/y radius={#1}}}%
 \tikzset{cs/name/.store in=\tikz@cs@node}%
 \tikzset{cs/anchor/.store in=\tikz@cs@anchor}%
 
@@ -5476,18 +5476,18 @@
   }%
 }%
 \def\tikz@parse@main@intersection#1#2of #3 and #4){%
-  \tikzset{cs/solution=#2}%
+  \tikzset{cs/solution={#2}}%
   \pgfutil@in@{--}{#3}%
   \ifpgfutil@in@%
     \tikz@reparse@line{first}#3\pgf@stop%
   \else%
-    \tikzset{cs/first node=#3}%
+    \tikzset{cs/first node={#3}}%
   \fi%
   \pgfutil@in@{--}{#4}%
   \ifpgfutil@in@%
     \tikz@reparse@line{second}#4\pgf@stop%
   \else%
-    \tikzset{cs/second node=#4}%
+    \tikzset{cs/second node={#4}}%
   \fi%
   \tikz@parse@cs@intersection()% advanced hackery...
   \edef\pgf@marshal{\noexpand#1{\noexpand\pgfqpoint{\the\pgf@x}{\the\pgf@y}}}%

--- a/tex/generic/pgf/libraries/decorations/pgflibrarydecorations.shapes.code.tex
+++ b/tex/generic/pgf/libraries/decorations/pgflibrarydecorations.shapes.code.tex
@@ -25,24 +25,24 @@
   shape scaled/.is if=pgfshapedecorationscaled,
   shape evenly spread/.store in=\pgf@lib@shapedecoration@spread,
   shape start size/.style={%
-    shape start width=#1,
-    shape start height=#1%
+    shape start width={#1},
+    shape start height={#1}%
   },%
   shape end size/.style={%
-    shape end width=#1,
-    shape end height=#1%
+    shape end width={#1},
+    shape end height={#1}%
   },%
   shape size/.style={%
-    shape start size=#1,
-    shape end size=#1%
+    shape start size={#1},
+    shape end size={#1}%
   },%
   shape width/.style={%
-    shape start width=#1,
-    shape end width=#1
+    shape start width={#1},
+    shape end width={#1}
   },
   shape height/.style={%
-    shape start height=#1,
-    shape end height=#1
+    shape start height={#1},
+    shape end height={#1}
   }
 }%
 

--- a/tex/generic/pgf/libraries/pgflibrarylindenmayersystems.code.tex
+++ b/tex/generic/pgf/libraries/pgflibrarylindenmayersystems.code.tex
@@ -26,7 +26,7 @@
     },%
     left angle/.code={\pgfmathparse{#1}\let\pgflsystemleftangle=\pgfmathresult},%
     right angle/.code={\pgfmathparse{#1}\let\pgflsystemrightangle=\pgfmathresult},%
-    angle/.style={/pgf/lindenmayer system/left angle=#1, /pgf/lindenmayer system/right angle=#1},%
+    angle/.style={/pgf/lindenmayer system/left angle={#1}, /pgf/lindenmayer system/right angle={#1}},%
     randomize angle percent/.code={%
         \pgfmathparse{#1}%
         \let\pgflsystemrandomizeanglepercent=\pgfmathresult%

--- a/tex/generic/pgf/libraries/pgflibraryplotmarks.code.tex
+++ b/tex/generic/pgf/libraries/pgflibraryplotmarks.code.tex
@@ -258,7 +258,7 @@
   % backw. compat: the extra search path confuses the '.unknown'
   % handlers, so this here is deprecated:
   /pgf/text mark/style/.style={/pgf/text mark style={#1}},%
-  /pgf/text mark/as node/.style={/pgf/text mark as node=#1},%
+  /pgf/text mark/as node/.style={/pgf/text mark as node={#1}},%
 }%
 
 \pgfdeclareplotmark{text}

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
@@ -212,7 +212,7 @@
     aspect/.code={\pgfsetshapeaspect{#1}},% this for tikz...
     shape aspect/.initial=1,% but this is consistent with other pgfset stuff.
     shape aspect/.code={%
-        \pgfkeys{/pgf/aspect=#1}%
+        \pgfkeys{/pgf/aspect={#1}}%
         \pgfkeyssetvalue{/pgf/shape aspect}{#1}
     }%
 }%
@@ -369,7 +369,7 @@
         \pgfkeyslet{/pgf/star point ratio}{\pgf@lib@temp}%
         \pgf@lib@shapes@starouterradiususesratiotrue%
     },%
-    star rotate/.style={/pgf/shape border rotate=#1},% For compatibility with 1.18
+    star rotate/.style={/pgf/shape border rotate={#1}},% For compatibility with 1.18
 }%
 
 
@@ -676,7 +676,7 @@
 %
 \pgfkeys{/pgf/.cd,
     regular polygon sides/.initial=5,
-    regular polygon rotate/.style={/pgf/shape border rotate=#1}% For compatibility with 1.18
+    regular polygon rotate/.style={/pgf/shape border rotate={#1}}% For compatibility with 1.18
 }%
 
 
@@ -931,8 +931,8 @@
     trapezium left angle/.initial=60,
     trapezium right angle/.initial=60,
     trapezium angle/.style={
-        /pgf/trapezium left angle=#1,
-        /pgf/trapezium right angle=#1
+        /pgf/trapezium left angle={#1},
+        /pgf/trapezium right angle={#1}
     },%
     trapezium stretches/.is if=pgf@lib@sh@trapeziumstretches,%
     trapezium stretches body/.is if=pgf@lib@sh@trapeziumstretchesbody,%
@@ -2346,13 +2346,13 @@
         \pgfutil@in@{and}{#1}%
         \ifpgfutil@in@%
             \def\pgf@marshal##1and##2\@@{%
-                \pgfkeys{/pgf/kite upper vertex angle=##1}%
-                \pgfkeys{/pgf/kite lower vertex angle=##2}%
+                \pgfkeys{/pgf/kite upper vertex angle={##1}}%
+                \pgfkeys{/pgf/kite lower vertex angle={##2}}%
             }%
             \expandafter\pgf@marshal#1\@@%
         \else%
-            \pgfkeys{/pgf/kite upper vertex angle=#1}%
-            \pgfkeys{/pgf/kite lower vertex angle=#1}%
+            \pgfkeys{/pgf/kite upper vertex angle={#1}}%
+            \pgfkeys{/pgf/kite lower vertex angle={#1}}%
         \fi%
     }%
 }%

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.misc.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.misc.code.tex
@@ -77,8 +77,8 @@
 \pgfkeys{/pgf/.cd,
     rounded rectangle west arc/.initial=convex,
     rounded rectangle east arc/.initial=convex,
-    rounded rectangle left arc/.style={/pgf/rounded rectangle west arc=#1},%
-    rounded rectangle right arc/.style={/pgf/rounded rectangle east arc=#1},%
+    rounded rectangle left arc/.style={/pgf/rounded rectangle west arc={#1}},%
+    rounded rectangle right arc/.style={/pgf/rounded rectangle east arc={#1}},%
     rounded rectangle arc length/.initial=180%
 }%
 
@@ -549,7 +549,7 @@
     chamfered rectangle ysep/.initial=.666ex%
 }%
  \pgfkeys{/pgf/chamfered rectangle sep/.style={%
-    /pgf/chamfered rectangle xsep=#1,/pgf/chamfered rectangle ysep=#1}%
+    /pgf/chamfered rectangle xsep={#1},/pgf/chamfered rectangle ysep={#1}}%
 }%
 
 

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.symbols.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.symbols.code.tex
@@ -588,7 +588,7 @@
   aspect/.code={\pgfsetshapeaspect{#1}},% this for tikz...
   shape aspect/.initial=1,% but this is consistent with other pgfset stuff.
   shape aspect/.code={%
-    \pgfkeys{/pgf/aspect=#1}%
+    \pgfkeys{/pgf/aspect={#1}}%
     \pgfkeyssetvalue{/pgf/shape aspect}{#1}
   }%
 }%
@@ -2104,7 +2104,7 @@
 \pgfkeys{/pgf/.cd,
   tape bend top/.initial=in and out,
   tape bend bottom/.initial=in and out,
-  tape bend/.style={/pgf/tape bend top=#1, /pgf/tape bend bottom=#1},
+  tape bend/.style={/pgf/tape bend top={#1}, /pgf/tape bend bottom={#1}},
   tape bend height/.initial=5pt,
 }%
 

--- a/tex/generic/pgf/math/pgfmathfloat.code.tex
+++ b/tex/generic/pgf/math/pgfmathfloat.code.tex
@@ -1010,7 +1010,7 @@
     fixed zerofill/.default=true,
     sci zerofill/.is if=   pgfmathfloat@usezerofill@sci,
     sci zerofill/.default=true,
-    zerofill/.style=       {/pgf/number format/fixed zerofill=#1,/pgf/number format/sci zerofill=#1},
+    zerofill/.style=       {/pgf/number format/fixed zerofill={#1},/pgf/number format/sci zerofill={#1}},
     zerofill/.default=     true,
     precision/.store in=   \pgfmathfloat@round@precision,
     sci precision/.code={%

--- a/tex/generic/pgf/modules/pgfmoduledecorations.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduledecorations.code.tex
@@ -56,7 +56,7 @@
   aspect/.code={\pgfmathparse{#1}\let\pgfdecorationsegmentaspect\pgfmathresult},
   start radius/.initial=2.5pt,
   end radius/.initial=2.5pt,
-  radius/.style={start radius=#1,end radius=#1},
+  radius/.style={start radius={#1},end radius={#1}},
   path has corners/.is if=pgfdecoratepathhascorners,
   reverse path/.is if=pgf@decorate@inputsegmentobjects@reverse,
 }%
@@ -2180,11 +2180,11 @@
 \def\pgfsnakesegmentaspect{\pgfdecorationsegmentaspect}%
 
 \pgfset{%
-  /pgf/segment amplitude/.style={/pgf/decoration={amplitude=#1,shape height=2*#1}},
-  /pgf/segment length/.style={/pgf/decoration={segment length=#1}},
-  /pgf/segment angle/.style={/pgf/decoration={angle=#1}},
-  /pgf/segment aspect/.style={/pgf/decoration={aspect=#1}},
-  /pgf/segment object length/.style={/pgf/decoration={shape width=#1,radius=#1}}}%
+  /pgf/segment amplitude/.style={/pgf/decoration={amplitude={#1},shape height={2*(#1)}}},
+  /pgf/segment length/.style={/pgf/decoration={segment length={#1}}},
+  /pgf/segment angle/.style={/pgf/decoration={angle={#1}}},
+  /pgf/segment aspect/.style={/pgf/decoration={aspect={#1}}},
+  /pgf/segment object length/.style={/pgf/decoration={shape width={#1},radius={#1}}}}%
 
 
 

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -887,13 +887,13 @@
 \pgfset{
   inner xsep/.initial     =.3333em,
   inner ysep/.initial     =.3333em,
-  inner sep/.style        ={/pgf/inner xsep=#1,/pgf/inner ysep=#1},
+  inner sep/.style        ={/pgf/inner xsep={#1},/pgf/inner ysep={#1}},
   outer xsep/.initial     =.5\pgflinewidth,
   outer ysep/.initial     =.5\pgflinewidth,
   outer sep/.code         =\pgf@handle@outer@sep{#1},
   minimum width/.initial  =1pt,
   minimum height/.initial =1pt,
-  minimum size/.style     ={/pgf/minimum width=#1,/pgf/minimum height=#1},
+  minimum size/.style     ={/pgf/minimum width={#1},/pgf/minimum height={#1}},
 }%
 
 

--- a/tex/generic/pgf/utilities/pgfkeys.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeys.code.tex
@@ -571,7 +571,7 @@
 %
 % Example:
 %
-% \pgfqkeys{/tikz}{myother length/.code=\def\myotherlength{#1}\pgfkeysalso{length=#1}}
+% \pgfqkeys{/tikz}{myother length/.code=\def\myotherlength{#1}\pgfkeysalso{length={#1}}}
 
 \def\pgfqkeys{\expandafter\pgfkeys@@qset\expandafter{\pgfkeysdefaultpath}}%
 \long\def\pgfkeys@@qset#1#2#3{\def\pgfkeysdefaultpath{#2/}\pgfkeys@parse#3,\pgfkeys@mainstop\def\pgfkeysdefaultpath{#1}}
@@ -589,7 +589,7 @@
 %
 % Example:
 %
-% \pgfkeys{tikz,myother length/.code=\def\myotherlength{#1}\pgfkeysalso{length=#1}}
+% \pgfkeys{tikz,myother length/.code=\def\myotherlength{#1}\pgfkeysalso{length={#1}}}
 
 \long\def\pgfkeysalso#1{\pgfkeys@parse#1,\pgfkeys@mainstop}
 
@@ -609,7 +609,7 @@
 % Example:
 %
 % \begingroup
-%   \pgfqkeysalso{/tikz}{myother length/.code=\def\myotherlength{#1}\pgfkeysalso{length=#1}}
+%   \pgfqkeysalso{/tikz}{myother length/.code=\def\myotherlength{#1}\pgfkeysalso{length={#1}}}
 
 \long\def\pgfqkeysalso#1#2{\def\pgfkeysdefaultpath{#1/}\pgfkeys@parse#2,\pgfkeys@mainstop}
 
@@ -1055,7 +1055,7 @@
 
 % Utilities
 
-\pgfkeys{/utils/exec/.code=#1} % simply execute the given code directly.
+\pgfkeys{/utils/exec/.code={#1}} % simply execute the given code directly.
 
 
 % Errors

--- a/tex/generic/pgf/utilities/pgfkeysfiltered.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeysfiltered.code.tex
@@ -300,7 +300,7 @@
     \pgfkeysiffamilydefined{#2}{%
         \pgfkeyssetvalue{#1/family}{#2}%
     }{%
-        \pgfkeysalso{/errors/family unknown=#2}%
+        \pgfkeysalso{/errors/family unknown={#2}}%
     }%
 }%
 

--- a/tex/latex/pgf/doc/pgfmanual.pdflinks.code.tex
+++ b/tex/latex/pgf/doc/pgfmanual.pdflinks.code.tex
@@ -83,7 +83,7 @@
     /pdflinks/codeexample links/.default=true,
     %
     % How to render a hyperlink
-    /pdflinks/render hyperlink/.code=#1,
+    /pdflinks/render hyperlink/.code={#1},
     %
     % whenever an unqualified key is found, the following key prefix
     % list is tried to find a match.


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Fixes #389

This should guard against most of the accidental injections of commas through forwarded arguments in pgfkeys.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
