### PR TITLE
fix(decorations): expand `pgfkeys` internals in error msg

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.code.tex
@@ -17,8 +17,10 @@
   /pgf/decoration/.unknown/.code=%
     \pgfifdecoration{\pgfkeyscurrentname}{\edef\tikz@decoration@name{\pgfkeyscurrentname}}
     {\pgfifmetadecoration{\pgfkeyscurrentname}{\edef\tikz@decoration@name{\pgfkeyscurrentname}}
+    % Fully expand `\pgfkeyscurrentname' before being used in first-arg of
+    % `/errors/unknown key'.
     {\pgfkeys{/errors/unknown
-        key={/pgf/decoration/\pgfkeyscurrentname}{#1}}}},%
+        key/.expanded={/pgf/decoration/\pgfkeyscurrentname}{\unexpanded{#1}}}}},%
   /pgf/decoration/raise/.code={\def\tikz@dec@shift{\pgftransformyshift{#1}}\tikz@dec@trans},
   /pgf/decoration/mirror/.code={%
     \csname if#1\endcsname


### PR DESCRIPTION
**Motivation for this change**

Implementation note:
Since `\pgfkeyscurrentname` would already been fully expanded in testers `\pgfifdecoration` and `\pgfifmetadecoration`, fully expansion, compared to one-step expansion, is also safe here.

Fixes #1082

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
