### PR TITLE
CI: skip DCO check for co-authored commits

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -16,3 +16,4 @@ jobs:
       uses: pgf-tikz/actions/dco-check@master
       with:
         base_ref: ${{ github.base_ref }}
+        allow_co-authored: true


### PR DESCRIPTION
Make use of
 - https://github.com/pgf-tikz/actions/pull/1

**Motivation for this change**

Allow co-authored commits (in a PR) to pass pgf's DCO check even if they are not signed-off.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
