### PR TITLE
fix(driver): `\let` for two csnames #1088

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
@@ -444,7 +444,7 @@
         /S /Luminosity
         /G @pgfsmask\csname pgfsmaskxform@#1\endcsname
       >> >>}%<<
-  \expandafter\let\csname pgfsmask@#1\endcsname\expandafter\csname pgfsmaskxform@#1\endcsname%
+  \expandafter\let\csname pgfsmask@#1\expandafter\endcsname\csname pgfsmaskxform@#1\endcsname%
 }
 
 % Transparency groups came from pgfsys-pdftex.def


### PR DESCRIPTION
**Motivation for this change**

Fixes #1088

Also an opportunity to provide and use `\pgfexpl@tl@set@eq@@cc` (`\tl_set_eq:cc`).

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
