### PR TITLE
chore: Cleanup `\newif`s

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/datavisualization/tikzlibrarydatavisualization.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/datavisualization/tikzlibrarydatavisualization.code.tex
@@ -1380,7 +1380,6 @@
     \tikzdatavisualizationset{major/.expanded={at={\tikz@lib@dv@ats}},minor/.expanded={at={\tikz@lib@dv@minor@ats}}}%
   \fi%
 }%
-\newif\iftikz@lib@dv@continue
 
 
 \def\tikz@lib@dv@about@log#1{%

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -991,7 +991,6 @@
 
 
 % Pic options
-\newif\iftikz@node@is@pic
 \tikzset{pic text/.store in=\tikzpictext}%
 \let\tikzpictext\relax
 \tikzset{pic text options/.store in=\tikzpictextoptions}%

--- a/tex/generic/pgf/math/pgfmathfloat.code.tex
+++ b/tex/generic/pgf/math/pgfmathfloat.code.tex
@@ -33,7 +33,7 @@
 }
 
 
-\global\newif\ifpgfmathfloatcomparison
+\newif\ifpgfmathfloatcomparison
 \newif\ifpgfmathfloatroundhasperiod
 \newif\ifpgfmathprintnumberskipzeroperiod
 


### PR DESCRIPTION
 - Remove one copy of `\new\iftikz@node@is@pic`. This bool is provided
   twice in a same file.
    https://github.com/pgf-tikz/pgf/blob/1cba64a2061d7bf13b9c8779c0effedf0c902232/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex#L993-L998
    https://github.com/pgf-tikz/pgf/blob/1cba64a2061d7bf13b9c8779c0effedf0c902232/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex#L4776-L4782
 - Remove an invalid `\global` placed before `\newif\ifpgfmathfloatcomparison`.
    If `\ifpgfmathfloatcomparison` needs to be "global", we have to redefine `\pgfmathfloatcomparison(true|false)` to prepend `\global`.


<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
