### PR TITLE
fix(tikz): rewrite `dash expand off`

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -153,32 +153,34 @@
 \tikzset{
     dash expand off/.code={%
         \ifcsname tikz@library@decorations@loaded\endcsname\else
-            \tikzerror{You need \string\usetikzlibrary{decorations} for ``dash offexpand''}%
+            \tikzerror{You need \string\usetikzlibrary{decorations} for ``dash expand off''}%
         \fi
         \tikz@addoption{%
             \pgfgetpath\currentpath
             \pgfprocessround{\currentpath}{\currentpath}%
             \pgf@decorate@parsesoftpath{\currentpath}{\currentpath}%
+            % All of \on, \off, \dashphase, \rest, and \onoff are unit-free.
             % Parse \on and \off from the current path
-            \edef\on{\expandafter\pgfutil@firstoftwo\tikz@dashpattern}%
-            \edef\off{\expandafter\pgfutil@secondoftwo\tikz@dashpattern}%
+            \pgfmathsetmacro\on{\expandafter\pgfutil@firstoftwo\tikz@dashpattern}%
+            \pgfmathsetmacro\off{\expandafter\pgfutil@secondoftwo\tikz@dashpattern}%
             % \dashphase = max(\on - \dashphase, 0)
+            \pgfmathsetmacro\tikz@dashphase{\tikz@dashphase}%
             \pgfmathsubtract@{\on}{\tikz@dashphase}%
-            \pgfmathmax@{\pgfmathresult}{0}%
-            \edef\dashphase{\the\dimexpr\pgfmathresult pt\relax}%
-            % \rest = \pgf@decorate@totalpathlength - \on
-            \edef\rest{\expandafter\pgf@sys@tonumber\dimexpr\pgf@decorate@totalpathlength - \on + 2\dimexpr\dashphase\relax\relax}%
+            \pgfmathmax@{\pgfmathresult,0}%
+            \let\dashphase=\pgfmathresult
+            % \rest = \pgf@decorate@totalpathlength - \on + 2\dashphase
+            \edef\rest{\expandafter\pgf@sys@tonumber\dimexpr\pgf@decorate@totalpathlength - \on pt + 2\dimexpr\dashphase pt\relax\relax}%
             % \onoff = \on + \off
-            \edef\onoff{\expandafter\pgf@sys@tonumber\dimexpr\on+\off\relax}%
+            \edef\onoff{\expandafter\pgf@sys@tonumber\dimexpr\on pt+\off pt\relax}%
             % \nfullonoff = max(floor(\rest/\onoff), 1)
             \pgfmathdivide@{\rest}{\onoff}%
             \pgfmathfloor@{\pgfmathresult}%
-            \pgfmathmax@{\pgfmathresult}{1}%
+            \pgfmathmax@{\pgfmathresult,1}%
             % \offexpand = max(\rest/\nfullonoff - \on, \off)
             \pgfmathdivide@{\rest}{\pgfmathresult}%
             \pgfmathsubtract@{\pgfmathresult}{\on}%
-            \pgfmathmax@{\pgfmathresult}{\off}%
-            \edef\tikz@marshal{\noexpand\pgfsetdash{{\on}{\pgfmathresult}}{\dashphase}}%
+            \pgfmathmax@{\pgfmathresult,\off}%
+            \edef\tikz@marshal{\noexpand\pgfsetdash{{+\on pt}{+\pgfmathresult pt}}{+\dashphase pt}}%
             \tikz@marshal
         }%
     }

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -169,9 +169,9 @@
             \pgfmathmax@{\pgfmathresult,0}%
             \let\dashphase=\pgfmathresult
             % \rest = \pgf@decorate@totalpathlength - \on + 2\dashphase
-            \edef\rest{\expandafter\pgf@sys@tonumber\dimexpr\pgf@decorate@totalpathlength - \on pt + 2\dimexpr\dashphase pt\relax\relax}%
+            \edef\rest{\pgf@sys@tonumber\dimexpr\pgf@decorate@totalpathlength - \on pt + 2\dimexpr\dashphase pt\relax\relax}%
             % \onoff = \on + \off
-            \edef\onoff{\expandafter\pgf@sys@tonumber\dimexpr\on pt+\off pt\relax}%
+            \edef\onoff{\pgf@sys@tonumber\dimexpr\on pt+\off pt\relax}%
             % \nfullonoff = max(floor(\rest/\onoff), 1)
             \pgfmathdivide@{\rest}{\onoff}%
             \pgfmathfloor@{\pgfmathresult}%


### PR DESCRIPTION
**Motivation for this change**

This is the first of a set of PRs aiming at no "Missing character" errors when building `pgfmanual`.

Changes and/or reasons:
 - Fix use of `\pgfmathmax@`. It accepts a clist but was given two mandatory args, hence thrown `Missing Character` errors.
 - In error message, do `s/dash offexpand/dash expand off/`.
 - It (the option `dash expand off`) now works when `dash pattern` and/or `dash phase` values are
   math expressions.

This option was added by commit d640cd539f9e2735e25709d88ecdd3e6106346c1.

**Example for test**
 - before this PR: throws "Missing character" errors
 - with this PR: no such errors
```tex
\documentclass{article}
\usepackage{tikz}
\usetikzlibrary{decorations}

\begin{document}
\tracinglostchars=3

% Excerpted from doc for `dash expand off`, pgfmanual-en-tikz-actions.tex.
% Adapted to pass math expr to `dash pattern` and `dash phase`.
\begin{tikzpicture}[|-|, dash pattern=on 2pt+2pt off 2pt+0pt, dash phase=0pt+0pt]
  \draw [dash expand off] (0pt,30pt) -- (26pt,30pt);
  \draw [dash expand off] (0pt,20pt) -- (24pt,20pt);
  \draw [dash expand off] (0pt,10pt) -- (22pt,10pt);
  \draw [dash expand off] (0pt, 0pt) -- (20pt, 0pt);
\end{tikzpicture}
\end{document}
```

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
