### PR TITLE
fix(animations): Resolve missing characters `p`, `t`

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsysanimations.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsysanimations.code.tex
@@ -1823,7 +1823,7 @@
       \def\pgfsysanim@frac@b{1}%
     \else%
       \let\pgfsysanim@divby\pgfmathresult%
-      \pgfmathsubtract@{\pgf@xc}{\pgfsysanim@prev@time}%
+      \pgfmathsubtract@{\pgf@sys@tonumber\pgf@xc}{\pgfsysanim@prev@time}%
       \pgfmathdivide@{\pgfmathresult}{\pgfsysanim@divby}%
       \ifdim\pgfmathresult pt<0pt\def\pgfmathresult{0}\fi%
       \ifdim\pgfmathresult pt>1pt\def\pgfmathresult{1}\fi%


### PR DESCRIPTION
**Motivation for this change**

Resolve missing character errors (`p` and `t`) which were thrown when both snapshot(s) and timeline are set.

**Example for test**
 - before this PR: throws "Missing character" errors on the line containing `\tikz`
 - with this PR: no such errors

```tex
\documentclass{article}
\usepackage{tikz}
\usetikzlibrary{animations}

\begin{document}
\tracinglostchars=3

\tikzset{make snapshot of=.5}
% usually in its short form `\path [:fill opacity={...}]`
\tikz[animate={myself:fill opacity={0s="1", 2s=".5"}}]
  \path ;
\end{document}
```

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
