### PR TITLE
Resolve all `Missing character` reports in manual

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-base-arrows.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-arrows.tex
@@ -110,7 +110,7 @@ where the arrow tip is drawn transparently so that we can see what is
     \draw [->,thick] (5,-2.25) -- (5,2.25) node [above] {$y$-axis};
 
     \foreach \i in {-3,-2,-1,1,2} \draw (\i+5,-1mm) -- (\i+5,1mm) node [above] {\small$\i$};
-    \foreach \i in {-2,-1,1,2} \draw (49mm,\i) -- (51mm,\i) node [right] {\small$\i$};;
+    \foreach \i in {-2,-1,1,2} \draw (49mm,\i) -- (51mm,\i) node [right] {\small$\i$};
 \end{tikzpicture}
 
 I have also added a coordinate system. The code for drawing an arrow tip always

--- a/doc/generic/pgf/pgfmanual-en-base-transformations.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-transformations.tex
@@ -1032,7 +1032,7 @@ such a local approximation:
     \pgfapproximatenonlineartransformation
     \draw [] (-10pt,-10pt) -- (10pt,10pt);
     \draw [] (10pt,-10pt) -- (-10pt,10pt);
-    \pgftext{foo};
+    \pgftext{foo}
   \end{scope}
 \end{tikzpicture}
 \end{codeexample}
@@ -1062,7 +1062,7 @@ such a local approximation:
     \pgfapproximatenonlineartranslation
     \draw [] (-10pt,-10pt) -- (10pt,10pt);
     \draw [] (10pt,-10pt) -- (-10pt,10pt);
-    \pgftext{foo};
+    \pgftext{foo}
   \end{scope}
 \end{tikzpicture}
 \end{codeexample}

--- a/doc/generic/pgf/pgfmanual-en-library-perspective.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-perspective.tex
@@ -294,7 +294,7 @@ An |r| that lies `below' your drawing can mimic a macro effect.
     q = {(0,8,0)},
     r = {(0,0,-8)}}]
 
-  \simplecuboid{2}{2}{2}]
+  \simplecuboid{2}{2}{2}
 
 \end{tikzpicture}
 \end{codeexample}

--- a/doc/generic/pgf/pgfmanual-en-main-preamble.tex
+++ b/doc/generic/pgf/pgfmanual-en-main-preamble.tex
@@ -179,6 +179,10 @@
   \usepackage[T1]{fontenc}
 \fi
 
+% Promote `Missing character` reports to full errors
+% require texlive 2021 or above
+\tracinglostchars=3
+
 \graphicspath{{../../images/}}
 \input{pgfmanual-en-macros}
 

--- a/doc/generic/pgf/pgfmanual-en-pgfsys-animations.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfsys-animations.tex
@@ -967,7 +967,7 @@ first.
     \scoped [meet={(-1,-2) (1,2)}, name=my view]  {
       \draw (-5mm,-15mm) rectangle (7mm,8mm)
         node [font=\scriptsize, align=right, below left]
-          {target\\ view\\ box};  ;
+          {target\\ view\\ box};
       \filldraw (0,0) circle [radius=3mm];
 } } }
 \end{codeexample}

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryanimations.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryanimations.code.tex
@@ -192,7 +192,7 @@
 }%
 
 \def\tikz@animation@value@rest@base base{%
-  \tikz@anim@sync@scope{}{/utils/exec=\let\tikz@animation@time\tikz@anim@base@text\expandafter\tikz@anim@add\expandafter{\expandafter\tikz@anim@value\expandafter{\tikz@animation@value@head}}}{\tikz@anim@make@entry}%
+  \tikz@anim@sync@scope{}{\let\tikz@animation@time\tikz@anim@base@text\expandafter\tikz@anim@add\expandafter{\expandafter\tikz@anim@value\expandafter{\tikz@animation@value@head}}}{\tikz@anim@make@entry}%
   \pgfutil@ifnextchar\pgf@stop{\tikz@animation@value@rest=}{\tikz@animation@value@rest}%
 }%
 

--- a/tex/generic/pgf/libraries/shapes/circuits/pgflibraryshapes.gates.logic.IEC.code.tex
+++ b/tex/generic/pgf/libraries/shapes/circuits/pgflibraryshapes.gates.logic.IEC.code.tex
@@ -55,7 +55,13 @@
   %
   % Adjust for the width of the gate symbol.
   %
-  \setbox\pgf@hbox\hbox{{\pgfkeysvalueof{/pgf/#1 gate IEC  symbol}}}% add braces as color-aftergroup-fix TT
+  \setbox\pgf@hbox\hbox{%
+    % wrap in `\pgfinterruptpicture' to restore font, like how `\pgfnode` sets
+    % `\pgfnodeparttextbox`
+    \pgfinterruptpicture
+    {\pgfkeysvalueof{/pgf/#1 gate IEC symbol}}%
+    \endpgfinterruptpicture
+  }% add braces as color-aftergroup-fix TT
   \pgf@xa.5\wd\pgf@hbox%
   \pgf@ya.5\ht\pgf@hbox%
   \advance\pgf@ya.5\dp\pgf@hbox%

--- a/tex/generic/pgf/libraries/shapes/circuits/pgflibraryshapes.gates.logic.IEC.code.tex
+++ b/tex/generic/pgf/libraries/shapes/circuits/pgflibraryshapes.gates.logic.IEC.code.tex
@@ -59,9 +59,9 @@
     % wrap in `\pgfinterruptpicture' to restore font, like how `\pgfnode` sets
     % `\pgfnodeparttextbox`
     \pgfinterruptpicture
-    {\pgfkeysvalueof{/pgf/#1 gate IEC symbol}}%
+      {\pgfkeysvalueof{/pgf/#1 gate IEC symbol}}% add braces as color-aftergroup-fix TT
     \endpgfinterruptpicture
-  }% add braces as color-aftergroup-fix TT
+  }%
   \pgf@xa.5\wd\pgf@hbox%
   \pgf@ya.5\ht\pgf@hbox%
   \advance\pgf@ya.5\dp\pgf@hbox%

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.arrows.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.arrows.code.tex
@@ -1308,7 +1308,7 @@
         \arrowboxpoints%
         \ifdim\eastextend>0pt\relax%
             \let\pgf@lib@shapes@arrowbox@referencepoint\midpoint%
-            \csname pgf@anchor@arrow box@border\endcsname{\pgfqpoint{\eastextend}{0pt}};
+            \csname pgf@anchor@arrow box@border\endcsname{\pgfqpoint{\eastextend}{0pt}}%
         \else%
             \arrowboxcorner%
             \pgf@xa\pgf@x%
@@ -1320,7 +1320,7 @@
         \arrowboxpoints%
         \ifdim\westextend>0pt\relax%
             \let\pgf@lib@shapes@arrowbox@referencepoint\midpoint%
-            \csname pgf@anchor@arrow box@border\endcsname{\pgfqpoint{-\westextend}{0pt}};
+            \csname pgf@anchor@arrow box@border\endcsname{\pgfqpoint{-\westextend}{0pt}}%
         \else%
             \arrowboxcorner%
             \pgf@xa\pgf@x%
@@ -1333,7 +1333,7 @@
         \arrowboxpoints%
         \ifdim\eastextend>0pt\relax%
             \let\pgf@lib@shapes@arrowbox@referencepoint\basepoint%
-            \csname pgf@anchor@arrow box@border\endcsname{\pgfqpoint{\eastextend}{0pt}};
+            \csname pgf@anchor@arrow box@border\endcsname{\pgfqpoint{\eastextend}{0pt}}%
         \else%
             \arrowboxcorner%
             \pgf@xa\pgf@x%
@@ -1345,7 +1345,7 @@
         \arrowboxpoints%
         \ifdim\westextend>0pt\relax%
             \let\pgf@lib@shapes@arrowbox@referencepoint\basepoint%
-            \csname pgf@anchor@arrow box@border\endcsname{\pgfqpoint{-\westextend}{0pt}};
+            \csname pgf@anchor@arrow box@border\endcsname{\pgfqpoint{-\westextend}{0pt}}%
         \else%
             \arrowboxcorner%
             \pgf@xa\pgf@x%

--- a/tex/generic/pgf/modules/pgfmoduleanimations.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleanimations.code.tex
@@ -648,7 +648,7 @@
 
 
 \def\pgf@anim@protocol@path@size{%
-  \pgfutil@ifnextchar\pgf@stop\relax\pgf@anim@protocol@path@size@%
+  \pgfutil@ifnextchar\pgf@stop\pgfutil@gobble\pgf@anim@protocol@path@size@%
 }%
 \def\pgf@anim@protocol@path@size@#1#2#3{%
   \pgf@protocolanimsizes@direct{#2}{#3}%

--- a/tex/generic/pgf/systemlayer/pgfsys.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsys.code.tex
@@ -519,7 +519,7 @@
     \pgf@ya#4%
     \advance\pgf@xa by-\pgf@x%
     \advance\pgf@ya by-\pgf@y%
-    \pgfmathdivide@\pgf@xa\pgf@ya%
+    \pgfmathdivide@{\pgf@sys@tonumber\pgf@xa}{\pgf@sys@tonumber\pgf@ya}%
     \let\aspectr\pgfmathresult%
     \pgf@xb#5%
     \pgf@yb#6%
@@ -527,12 +527,12 @@
     \pgf@yc#8%
     \advance\pgf@xc by-\pgf@xb%
     \advance\pgf@yc by-\pgf@yb%
-    \pgfmathdivide@\pgf@xc\pgf@yc%
+    \pgfmathdivide@{\pgf@sys@tonumber\pgf@xc}{\pgf@sys@tonumber\pgf@yc}%
     \let\aspects\pgfmathresult%
     \ifdim\aspectr pt#9\aspects pt%
-      \pgfmathdivide@\pgf@xa\pgf@xc%
+      \pgfmathdivide@{\pgf@sys@tonumber\pgf@xa}{\pgf@sys@tonumber\pgf@xc}%
     \else%
-      \pgfmathdivide@\pgf@ya\pgf@yc%
+      \pgfmathdivide@{\pgf@sys@tonumber\pgf@ya}{\pgf@sys@tonumber\pgf@yc}%
     \fi%
     \advance\pgf@x by.5\pgf@xa%
     \advance\pgf@xb by.5\pgf@xc%

--- a/tex/generic/pgf/systemlayer/pgfsysanimations.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsysanimations.code.tex
@@ -890,7 +890,7 @@
       % Interval too small: Goto end of interval
       \def\pgfmathresult{1.0}%
     \else%
-      \pgfmathdivide@{\pgf@ya}{\pgf@xa}%
+      \pgfmathdivide@{\pgf@sys@tonumber\pgf@ya}{\pgf@sys@tonumber\pgf@xa}%
     \fi%
     \pgf@x\pgfmathresult pt\relax%
     \expandafter\pgfsysanim@splitter\the\pgf@x%
@@ -926,7 +926,7 @@
     % Interval too small: Goto end of interval
     \def\pgfmathresult{1.0}%
   \else%
-    \pgfmathdivide@{\pgf@ya}{\pgf@xa}%
+    \pgfmathdivide@{\pgf@sys@tonumber\pgf@ya}{\pgf@sys@tonumber\pgf@xa}%
   \fi%
   \pgf@x\pgfmathresult pt\relax%
   \expandafter\pgfsysanim@splitter\the\pgf@x%
@@ -971,7 +971,7 @@
       % Interval too small: Goto end of interval
       \def\pgfmathresult{1.0}%
     \else%
-      \pgfmathdivide@{\pgf@ya}{\pgf@xa}%
+      \pgfmathdivide@{\pgf@sys@tonumber\pgf@ya}{\pgf@sys@tonumber\pgf@xa}%
     \fi%
     \pgf@x\pgfmathresult pt\relax%
     \expandafter\pgfsysanim@splitter\the\pgf@x%
@@ -1001,7 +1001,8 @@
     % Interval too small: Goto end of interval
     \def\pgfmathresult{1.0}%
   \else%
-    \pgfmathdivide@{\pgfsysanim@snap@repeat@arg}{\pgf@xa}%
+    % `\pgfsysanim@snap@repeat@arg` is a macro storing a dimen value, eg "4.0pt"
+    \pgfmathdivide@{\pgf@sys@tonumber\dimexpr\pgfsysanim@snap@repeat@arg}{\pgf@sys@tonumber\pgf@xa}%
   \fi%
   \pgf@x\pgfmathresult pt\relax%
   \expandafter\pgfsysanim@splitter\the\pgf@x%
@@ -1823,7 +1824,7 @@
       \def\pgfsysanim@frac@b{1}%
     \else%
       \let\pgfsysanim@divby\pgfmathresult%
-      \pgfmathsubtract@{\pgf@xc}{\pgfsysanim@prev@time}%
+      \pgfmathsubtract@{\pgf@sys@tonumber\pgf@xc}{\pgfsysanim@prev@time}%
       \pgfmathdivide@{\pgfmathresult}{\pgfsysanim@divby}%
       \ifdim\pgfmathresult pt<0pt\def\pgfmathresult{0}\fi%
       \ifdim\pgfmathresult pt>1pt\def\pgfmathresult{1}\fi%
@@ -1875,7 +1876,7 @@
       \pgf@ya\pgfsysanim@ft%
       \advance\pgf@ya by-\pgfsysanim@frac@a pt%
       \pgf@yb\pgf@x
-      \pgfmathreciprocal@{\pgf@yb}%
+      \pgfmathreciprocal@{\pgf@sys@tonumber\pgf@yb}%
       \ifdim\pgfmathresult pt>2.5pt%
         \def\pgfmathresult{2.5}%
       \fi%
@@ -1906,7 +1907,7 @@
       \pgf@ya\pgfsysanim@ft%
       \advance\pgf@ya by-\pgfsysanim@frac@a pt%
       \pgf@yb\pgf@x
-      \pgfmathreciprocal@{\pgf@yb}%
+      \pgfmathreciprocal@{\pgf@sys@tonumber\pgf@yb}%
       \ifdim\pgfmathresult pt>2.5pt%
         \def\pgfmathresult{2.5}%
       \fi%
@@ -1938,7 +1939,7 @@
       \pgf@ya\pgfsysanim@ft%
       \advance\pgf@ya by-\pgfsysanim@frac@a pt%
       \pgf@yb\pgf@x
-      \pgfmathreciprocal@{\pgf@yb}%
+      \pgfmathreciprocal@{\pgf@sys@tonumber\pgf@yb}%
       \ifdim\pgfmathresult pt>2.5pt%
         \def\pgfmathresult{2.5}%
       \fi%


### PR DESCRIPTION
**Motivation for this change**

Resolve all `Missing character` reports in building `pgfmanual` and promote such reports to errors.

Most of these changes are simple, but please especially review https://github.com/pgf-tikz/pgf/commit/bfc3545189cf36355510e9488a69a2c2ab685a8f about which I'm not sure.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
