### PR TITLE
Correct several typos.

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-base-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-scopes.tex
@@ -799,7 +799,7 @@ command:
     before each object.
 
     Besides the \meta{name} (or, more precisely, besides the system layer
-    identifier is refers to), the current \emph{identifier type} is also
+    identifier it refers to), the current \emph{identifier type} is also
     important: Actually, a graphic object is not referenced by a system layer
     identifier, but by the combination of the identifier and a type. You can
     use the following commands for modifying the type used for the creation of
@@ -817,7 +817,7 @@ command:
         |\pgfuseid| and the type of the part.
 
         As an example, this system is used to give you access to the different
-        parts of a node: When use say |\pgfuseid{mynode}| and then create a
+        parts of a node: When you say |\pgfuseid{mynode}| and then create a
         node, you can use |mynode| with the empty type to reference the
         graphics scope that encompasses the whole node, but also |mynode|
         together with the type |background| to access the background path of

--- a/doc/generic/pgf/pgfmanual-en-dv-introduction.tex
+++ b/doc/generic/pgf/pgfmanual-en-dv-introduction.tex
@@ -79,7 +79,7 @@ automatic fitting of the data into a given area. In the main pass over the
 data, called the \emph{visualization phase}, the data points are actually
 visualized, for instance in the form of lines or points.
 
-Like as for data points, the visualized pipeline makes no assumptions
+Like as for data points, the visualization pipeline makes no assumptions
 concerning what kind of visualization is desired. Indeed, one could even use it
 to produce a plain-text table. This flexibility is achieved by extensive use of
 objects and signals: When a data visualization starts, a number of signals (see
@@ -100,7 +100,8 @@ computed position.
 The whole idea behind the rendering pipeline is that new kinds of data
 visualizations can be implemented, ideally, just by adding one or two new
 objects to the visualization pipeline. Furthermore, different kinds of plots
-can be combined in novel ways in this manner, which is usually very hard to do.
+can be combined in novel ways in this manner, which is usually very
+hard to do otherwise.
 For instance, the visualization pipeline makes it easy to create, say,
 polar-semilog-box-plots. At first sight, such new kinds of plots may seem
 frivolous, but data visualization is all about gaining insights into the data

--- a/doc/generic/pgf/pgfmanual-en-dv-main.tex
+++ b/doc/generic/pgf/pgfmanual-en-dv-main.tex
@@ -111,7 +111,7 @@ Data visualizations typically demand a much higher accuracy and range of values
 than \TeX\ provides: \TeX\ numbers are limited to 13 bits for the integer part
 and 16 bits for the fractional part. Because of this, the data visualization
 engine does not use \pgfname's standard representation of numbers and \TeX\
-dimensions and is does not use the standard parser when reading numbers in a
+dimensions and does not use the standard parser when reading numbers in a
 data point. Instead, the |fpu| library, described in
 Section~\ref{section-library-fpu}, is used to handle numbers.
 
@@ -119,7 +119,7 @@ This use of the |fpu| library has several effects that users of the data
 visualization system should be aware of:
 %
 \begin{enumerate}
-    \item You can use numbers like |100000000000000| or |0.00000000001| in a
+    \item You can use numbers like |100000000000000| or |0.00000000001| in
         data points.
     \item Since the |fpu| library does not support advanced parsing, you
         currently \emph{cannot} write things like |3+2| in a data point number.

--- a/doc/generic/pgf/pgfmanual-en-guidelines.tex
+++ b/doc/generic/pgf/pgfmanual-en-guidelines.tex
@@ -351,7 +351,7 @@ that went wrong with the 3D-bar diagram:
     \item The third dimension adds complexity to the graphic without adding
         information.
     \item The three dimensional setup makes it much harder to gauge the
-        height of the bars correctly. Consider the ``bad'' bar. It the number
+        height of the bars correctly. Consider the ``bad'' bar. Is the number
         this bar stands for more than 20 or less? While the front of the bar
         is below the 20 line, the back of the bar (which counts) is above.
     \item It is impossible to tell which  numbers are represented by the

--- a/doc/generic/pgf/pgfmanual-en-installation.tex
+++ b/doc/generic/pgf/pgfmanual-en-installation.tex
@@ -82,7 +82,8 @@ at the Debian page or the MiK\TeX\ page first.
 
 \subsubsection{Debian}
 
-The command ``|aptitude install pgf|'' should do the trick. Sit back and relax.
+The command ``|apt-get install texlive-pictures|'' should do the trick.
+Sit back and relax.
 
 
 \subsubsection{MiKTeX}

--- a/doc/generic/pgf/pgfmanual-en-library-calendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-calendar.tex
@@ -160,7 +160,7 @@ say, the |\draw| command).
     at the origin. Sometimes, additional spacing rules get in the way. There
     are different ways of addressing this problem: First, you can just ignore
     it. Since calendars are often placed in their own |{tikzpicture}| and since
-    their size if computed automatically, the exact position of the origin
+    their size is computed automatically, the exact position of the origin
     often does not matter at all. Second, you can put the calendar inside a
     node as in |...node {\tikz \calendar...}|. This allows you to position the
     node in the normal ways using the node's anchors. Third, you can be very

--- a/doc/generic/pgf/pgfmanual-en-library-rdf.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-rdf.tex
@@ -25,7 +25,7 @@ automaton like the following:
 This description of the automaton carries a lot of ``semantic information''
 like the information that the node |a| is not just some node, but actually the
 initial state of the automaton, while |c| is a final state. Unfortunately, in
-the output produced \tikzname, this information is normally ``lost'': In the
+the output produced by \tikzname, this information is normally ``lost'': In the
 output, |a| is only a short text, possibly with a circle drawn around it; but
 there is no information that \emph{this} text and \emph{this} circle together
 form the state of an automaton.
@@ -70,7 +70,7 @@ annotations; currently \tikzname\ only supports \textsc{svg}.
     node, at the beginning of the node's scope). Depending on which keys are
     used, semantic information gets to be added to the output.
 
-    Note that you cannot simply the keys with path prefix |/tikz/rdf engine|
+    Note that you cannot simply use the keys with path prefix |/tikz/rdf engine|
     directly since they need to be executed at very specific times during
     \tikzname's processing of scopes. Always call those keys via this key.
 \end{key}
@@ -179,7 +179,7 @@ You add an \textsc{rdf} statement to the output file using the following key:
 \end{codeexample}
 
     The statements are normally  added at the beginning of the scope where the
-    |rdf enging| command is used (except when the |object| is |scope content|,
+    |rdf engine| command is used (except when the |object| is |scope content|,
     which is explained later). This means that when you use |prefix| inside an
     |rdf engine| command, it will apply to all statements, regardless of the
     order.
@@ -346,7 +346,7 @@ Each of the above problems is solved by a special keys:
 \tikz [ name = my automaton,
         rdf engine = {
           get new resource curie = \statecurie,
-          get new resource curie = \transitiocurie,
+          get new resource curie = \transitioncurie,
           statement = {
             subject   = (my automaton),
             predicate = automata:hasStateSet,
@@ -357,9 +357,9 @@ Each of the above problems is solved by a special keys:
           statement = {
             subject   = (my automaton),
             predicate = automata:hasTransitionSet,
-            object    = \transitiocurie },
+            object    = \transitioncurie },
           statement = {
-            subject   = \transitiocurie,
+            subject   = \transitioncurie,
             hat type  = automata:transitionSet } } ] { ... }
 \end{codeexample}
     %
@@ -378,7 +378,7 @@ Each of the above problems is solved by a special keys:
 \begin{codeexample}[code only]
 \tikz [ rdf engine = {
           get new resource curie = \statecurie,
-          get new resource curie = \transitiocurie,
+          get new resource curie = \transitioncurie,
           get scope curie = \automatoncurie,
           statement = {
             subject   = \automatoncurie,
@@ -390,9 +390,9 @@ Each of the above problems is solved by a special keys:
           statement = {
             subject   = \automatoncurie,
             predicate = automata:hasTransitionSet,
-            object    = \transitiocurie },
+            object    = \transitioncurie },
           statement = {
-            subject   = \transitiocurie,
+            subject   = \transitioncurie,
             hat type  = automata:transitionSet } } ] { ... }
 \end{codeexample}
     %

--- a/doc/generic/pgf/pgfmanual-en-main-body.tex
+++ b/doc/generic/pgf/pgfmanual-en-main-body.tex
@@ -855,6 +855,5 @@ work.
 
 %%% Local Variables:
 %%% mode: latex
-%%% TeX-master: "~/pgf/doc/generic/pgf/version-for-luatex/en/pgfmanual"
-%%% coding: iso-latin-1-unix
+%%% TeX-master: "pgfmanual"
 %%% End:

--- a/doc/generic/pgf/pgfmanual-en-main-preamble.tex
+++ b/doc/generic/pgf/pgfmanual-en-main-preamble.tex
@@ -379,6 +379,5 @@
 
 %%% Local Variables:
 %%% mode: latex
-%%% TeX-master: "~/pgf/doc/generic/pgf/version-for-luatex/en/pgfmanual"
-%%% coding: iso-latin-1-unix
+%%% TeX-master: "pgfmanual"
 %%% End:

--- a/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex
@@ -1033,7 +1033,7 @@ of a great number of the many different possible parts of a node.
 \begin{command}{\pgfsys@begin@idscope}
     Starts a (graphics) scope whose sole purpose is to assign it an
     id-type-pair so that it can be referenced later. Note that this command
-    does not always produce a graphics scope: If not id is currently in use or
+    does not always produce a graphics scope: If no id is currently in use or
     if the id-type-pair has already been used, a graphic scope may or may not
     be created as defined by the driver (but always a \TeX\ scope). This allows
     drivers to minimize the number of graphic scopes created.

--- a/doc/generic/pgf/pgfmanual-en-tikz-animations.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-animations.tex
@@ -459,7 +459,7 @@ Section~\ref{section-anim-syntax-obj}.
     animate the node named |myself| by placing the |animate| key inside the
     options of this node; you only cannot ``remotely'' add an animation to it).
 
-    The \meta{object} may be followed by a dot and a \emph{type}. This is need
+    The \meta{object} may be followed by a dot and a \emph{type}. This is needed
     in rare cases where you want to animate only a special ``part'' of an
     object that is not accessible in other ways. Normally, \tikzname\ takes
     care of choosing these types automatically, you only need to set these ``if

--- a/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
@@ -739,7 +739,7 @@ the following command:
     path operation. It works a little bit like a |\part| command in \LaTeX. It
     will stop the typesetting of whatever node part was typeset until now and
     then start putting all following text into the node part named \meta{part
-    name} -- until another |\partname| is encountered or until the node
+    name} -- until another |\nodepart| is encountered or until the node
     \meta{text} ends. The \meta{options} will be local to this part.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{shapes.multipart}}]


### PR DESCRIPTION
**Motivation for this change**

Most of the changes are correction to misspelled, missing or extra words.  Other changes:

1. Correct name of Debian package.
2. Fix some Emacs specific information in some of the files:
encoding and main file.

**Checklist**

Commits are signed off, but haven't found working instructions to build the manual.  E.g., `texlua buid.lua manual luatex` does nothing.  I've tried `luatex pgfmanual` but it complains about missing images unrelated to the changes here.