### PR TITLE
fix(docs): unswap x/y coordinates in description

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial.tex
@@ -168,9 +168,9 @@ providing a simpler syntax.
 
 Inside the environment there are two |\draw| commands. They mean: ``The path,
 which is specified following the command up to the semicolon, should be
-drawn.'' The first path is specified as |(-1.5,0) -- (0,1.5)|, which means ``a
+drawn.'' The first path is specified as |(-1.5,0) -- (1.5,0)|, which means ``a
 straight line from the point at position $(-1.5,0)$ to the point at position
-$(0,1.5)$''. Here, the positions are specified within a special coordinate
+$(1.5,0)$''. Here, the positions are specified within a special coordinate
 system in which, initially, one unit is 1cm.
 
 Karl is quite pleased to note that the environment automatically reserves


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz where we coordinate larger
    changes and rebases. -->

**Motivation for this change**

There's a typo in the manual. An example shows a line drawn with `\draw (-1.5,0) -- (1.5,0);`, but the description swaps the X and Y coordinates of the end point to `(0,1.5)`.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
