### PR TITLE
style(ci): Use descriptive job ids

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Test suite
 on: [push, pull_request]
 
 jobs:
-  build:
+  test-suite:
     runs-on: ubuntu-latest
     container:
       image: registry.gitlab.com/islandoftex/images/texlive:latest

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,7 +3,7 @@ name: "Check commits"
 on: pull_request
 
 jobs:
-  build:
+  check-commits:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,7 +3,7 @@ name: Manual
 on: [push, pull_request]
 
 jobs:
-  build:
+  manual:
     runs-on: ubuntu-latest
     container:
       image: registry.gitlab.com/islandoftex/images/texlive:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - '**'
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     container:
       image: registry.gitlab.com/islandoftex/images/texlive:latest

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -65,6 +65,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Promote `Missing character` to errors in building manual
 - Flatten the doc tree
 - Ensure `\tracinglostchars<3` in `\pgf@picture`
+- Use descriptive workflow job ids
 
 ### Contributors
 


### PR DESCRIPTION
**Motivation for this change**

Somehow Github shows only job ids (currently all `build`), without the belonging workflow name, in the end-of-merged-PR stat, for example
![image](https://user-images.githubusercontent.com/6376638/146642453-8183c80a-5858-4b50-b81b-e92023f3314b.png)
from the end of page #1100 (if it's folded, click "View details"). This makes me confusing about which check belongs to which workflow, especially when the build matrix is now removed. <details>
<summary>See a screenshot when we had a build matrix</summary>

![image](https://user-images.githubusercontent.com/6376638/146642621-edb208d7-38ea-42ad-8def-1ec8ebaa8efe.png)
</details>

Therefore this PR gives each job a unique descriptive id. Since currently we have only one job per workflow, this seems a little silly. Not sure if this is the best way.

Reference
 -  Workflow Syntax - [`jobs.<job_id>`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_id) | GitHub Docs

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
