### PR TITLE
feat(ci): Archive failed test output

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,3 +25,10 @@ jobs:
     - name: Run test suite
       run: |
         l3build check -q --show-log-on-error
+    
+    - name: Archive failed test output
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-diff-files
+        path: build/test/*.diff


### PR DESCRIPTION
**Motivation for this change**

Upload failed test output (`*.diff` files) as artifacts, to help contributors know how and where do the tests fails. This would be especially helpful when the differences coming from different engine/package versions or the underlying OS.

This is an imitation of what `latex2e` does, see corresponding lines in its [`main.yaml`](https://github.com/latex3/latex2e/blob/b109c61b6e5e1752c473cf4cc62c727f13febd04/.github/workflows/main.yaml#L76-L85).

Check [this action run](https://github.com/muzimuzhi/pgf/actions/runs/1597382842) in my forked repo to see the effect of this PR.

 - [ ] Changelog entry added

Related GitHub Actions docs:
 - Workflow syntax - [`jobs.<job_id>.if`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idif)
 - Job status check functions - [`failure`](https://docs.github.com/en/actions/learn-github-actions/expressions#failure)

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
