### PR TITLE
fix(dv): Suppress white space at line end

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -55,6 +55,8 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Add empty Pattern dictionary to Resources dictionary
 - Spelling and typo fixes in the manual
 - Update Debian installation instructions
+- Suppress white space at line end when `datavisualization` reads from a file 
+  #1112
 
 ### Changed
 

--- a/tex/generic/pgf/modules/pgfmoduledatavisualization.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduledatavisualization.code.tex
@@ -721,6 +721,7 @@
 
 \def\pgf@partext{\par}%
 \def\pgf@datagroup@readline{%
+  \endlinechar=-1 % suppress white space at end; this is local to `\pgfdata`
   \immediate\read\r@pgf@reada to \pgf@temp%
   \ifx\pgf@temp\pgf@partext%
     \pgf@dv@format@emptyline%


### PR DESCRIPTION
**Motivation for this change**

See analysis in https://github.com/pgf-tikz/pgf/issues/1112#issuecomment-997513216. I prefer to not support irregular usage `read from file={x, y }, ...` which results in a trailing space at the end of key `/pgf/data/headline`.

TODO: Add `dv` tests that actually use `read from file`.
@hmenke Should I add tests here or to an existing test file after #1116 is merged?

Fixes #1112

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
