### PR TITLE
Wrap node name in `\tikz@pp@name` when passed to pgf gd

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,4 +31,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-diff-files
-        path: build/test/*.diff
+        path: build/test*/*.diff

--- a/build.lua
+++ b/build.lua
@@ -40,6 +40,9 @@ specialformats["latex"] = specialformats["latex"] or
   }
 checkengines = {"pdftex", "latexdvips", "latexdvisvgm", "luatex", "xetex"}
 
+-- Use multiple sets of tests
+checkconfigs = { "build", "config-gd" }
+
 --- Keep all \special data (may one day be the l3build default)
 maxprintline = 9999
 

--- a/config-gd.lua
+++ b/config-gd.lua
@@ -1,0 +1,5 @@
+-- Tests for graph drawing (gd) library
+
+stdengine    = "luatex"
+checkengines = {"luatex"}
+testfiledir  = "testfiles-gd"

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -23,6 +23,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Add Matrix chat to README
 - Add rhombic polihedra #1022
 - Add Developer Certificate of Origin (DCO) to Pull Request template and enforce
+- Add test set for `graphdrawing` (gd) 
 
 ### Fixed
 
@@ -57,6 +58,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Update Debian installation instructions
 - Suppress white space at line end when `datavisualization` reads from a file 
   #1112
+- Make `graphdrawing` work with `name prefix` and `name suffix` options #1087
 
 ### Changed
 

--- a/testfiles-gd/support/pgfgd-debug.lua
+++ b/testfiles-gd/support/pgfgd-debug.lua
@@ -2,7 +2,7 @@ local InterfaceToDisplay = assert(pgf.gd.interface.InterfaceToDisplay)
 
 -- helper
 local function typeout(...)
-  texio.write_nl(17, string.format(...))
+  texio.write_nl(17, "Gd Lua layer Info: " .. string.format(...))
 end
 
 local createVertex = assert(InterfaceToDisplay.createVertex)

--- a/testfiles-gd/support/pgfgd-debug.lua
+++ b/testfiles-gd/support/pgfgd-debug.lua
@@ -1,39 +1,32 @@
-local InterfaceToDisplay = pgf.gd.interface.InterfaceToDisplay
-
---- Wrap InterfaceToDisplay functions to prepend debugging code
-local createVertex = InterfaceToDisplay.createVertex
--- here `...` is a vararg expression, 
--- see https://www.lua.org/manual/5.3/manual.html#3.4.11
-function InterfaceToDisplay.createVertex(...)
-  local name = ...
-  debug("Create vertex '%s'", name)
-  createVertex(...)
-end
-
-local createEdge = InterfaceToDisplay.createEdge
-function InterfaceToDisplay.createEdge(...)
-  local tail, head, direction = ...
-  debug("Create edge '%s' from '%s' to '%s'", direction, tail, head)
-  createEdge(...)
-end
-
--- this generates too many debugging lines
--- local createEvent = InterfaceToDisplay.createEvent
--- function InterfaceToDisplay.createEvent(...)
---   local kind = ...
---   debug("Create event '%s'", kind)
---   return createEvent(...)
--- end
-
-local addToVertexOptions = InterfaceToDisplay.addToVertexOptions
-function InterfaceToDisplay.addToVertexOptions(...)
-  local name = ...
-  debug("Add options to vertex '%s'", name)
-  addToVertexOptions(...)
-end
-
+local InterfaceToDisplay = assert(pgf.gd.interface.InterfaceToDisplay)
 
 -- helper
-function debug(format_str, ...)
-  tex.sprint(string.format("\\pgfgdluainfo{" .. format_str .. "}", ...))
+local function typeout(...)
+  texio.write_nl(17, string.format(...))
+end
+
+local createVertex = assert(InterfaceToDisplay.createVertex)
+function InterfaceToDisplay.createVertex(name, ...)
+  typeout("Create vertex '%s'", name)
+  createVertex(name, ...)
+end
+
+local createEdge = assert(InterfaceToDisplay.createEdge)
+function InterfaceToDisplay.createEdge(tail, head, direction, ...)
+  typeout("Create edge '%s' from '%s' to '%s'", direction, tail, head)
+  createEdge(tail, head, direction, ...)
+end
+
+--[[ this generates too many debugging lines
+local createEvent = assert(InterfaceToDisplay.createEvent)
+function InterfaceToDisplay.createEvent(kind, ...)
+  typeout("Create event '%s'", kind)
+  return createEvent(kind, ...)
+end
+--]]
+
+local addToVertexOptions = assert(InterfaceToDisplay.addToVertexOptions)
+function InterfaceToDisplay.addToVertexOptions(name, ...)
+  typeout("Add options to vertex '%s'", name)
+  addToVertexOptions(name, ...)
 end

--- a/testfiles-gd/support/pgfgd-debug.lua
+++ b/testfiles-gd/support/pgfgd-debug.lua
@@ -1,0 +1,39 @@
+local InterfaceToDisplay = pgf.gd.interface.InterfaceToDisplay
+
+--- Wrap InterfaceToDisplay functions to prepend debugging code
+local createVertex = InterfaceToDisplay.createVertex
+-- here `...` is a vararg expression, 
+-- see https://www.lua.org/manual/5.3/manual.html#3.4.11
+function InterfaceToDisplay.createVertex(...)
+  local name = ...
+  debug("Create vertex '%s'", name)
+  createVertex(...)
+end
+
+local createEdge = InterfaceToDisplay.createEdge
+function InterfaceToDisplay.createEdge(...)
+  local tail, head, direction = ...
+  debug("Create edge '%s' from '%s' to '%s'", direction, tail, head)
+  createEdge(...)
+end
+
+-- this generates too many debugging lines
+-- local createEvent = InterfaceToDisplay.createEvent
+-- function InterfaceToDisplay.createEvent(...)
+--   local kind = ...
+--   debug("Create event '%s'", kind)
+--   return createEvent(...)
+-- end
+
+local addToVertexOptions = InterfaceToDisplay.addToVertexOptions
+function InterfaceToDisplay.addToVertexOptions(...)
+  local name = ...
+  debug("Add options to vertex '%s'", name)
+  addToVertexOptions(...)
+end
+
+
+-- helper
+function debug(format_str, ...)
+  tex.sprint(string.format("\\pgfgdluainfo{" .. format_str .. "}", ...))
+end

--- a/testfiles-gd/support/pgfgd-regression-test.tex
+++ b/testfiles-gd/support/pgfgd-regression-test.tex
@@ -1,18 +1,5 @@
 \input regression-test.tex
 
-\catcode`\@=11 % \makeatletter
-
-% this macro should be used _after_ graphdrawing library is loaded
-\def\pgfgdBeforeBeginDocument{
-  % redirect error
-  \def\pgfutil@packageerror#1#2#3{\immediate\write17{Package #1 Error: #2.}}
-
-  % new message type "info"
-  \def\pgftest@genericinfo#1#2{\immediate\write17{#1 Info: #2.}}
-  \def\pgfgdluainfo{\pgftest@genericinfo{Gd Lua layer}}
-
-  % insert debugging code
+\ifdefined\directlua
   \directlua{dofile('pgfgd-debug.lua')}
-}
-
-\catcode`\@=12 % \makeatother
+\fi

--- a/testfiles-gd/support/pgfgd-regression-test.tex
+++ b/testfiles-gd/support/pgfgd-regression-test.tex
@@ -1,0 +1,18 @@
+\input regression-test.tex
+
+\catcode`\@=11 % \makeatletter
+
+% this macro should be used _after_ graphdrawing library is loaded
+\def\pgfgdBeforeBeginDocument{
+  % redirect error
+  \def\pgfutil@packageerror#1#2#3{\immediate\write17{Package #1 Error: #2.}}
+
+  % new message type "info"
+  \def\pgftest@genericinfo#1#2{\immediate\write17{#1 Info: #2.}}
+  \def\pgfgdluainfo{\pgftest@genericinfo{Gd Lua layer}}
+
+  % insert debugging code
+  \directlua{dofile('pgfgd-debug.lua')}
+}
+
+\catcode`\@=12 % \makeatother

--- a/testfiles-gd/support/pgfgd-regression-test.tex
+++ b/testfiles-gd/support/pgfgd-regression-test.tex
@@ -1,5 +1,5 @@
 \input regression-test.tex
 
 \ifdefined\directlua
-  \directlua{dofile('pgfgd-debug.lua')}
+  \AtBeginDocument{\directlua{dofile('pgfgd-debug.lua')}}
 \fi

--- a/testfiles-gd/tikz-gd-gh1087.lvt
+++ b/testfiles-gd/tikz-gd-gh1087.lvt
@@ -5,7 +5,6 @@
 \usetikzlibrary{graphs, graphdrawing}
 \usegdlibrary{layered}
 
-\pgfgdBeforeBeginDocument
 \begin{document}
 
 \START

--- a/testfiles-gd/tikz-gd-gh1087.lvt
+++ b/testfiles-gd/tikz-gd-gh1087.lvt
@@ -1,0 +1,64 @@
+\documentclass{minimal}
+\input{pgfgd-regression-test}
+
+\RequirePackage{tikz}
+\usetikzlibrary{graphs, graphdrawing}
+\usegdlibrary{layered}
+
+\pgfgdBeforeBeginDocument
+\begin{document}
+
+\START
+
+% use all five edge kinds
+% make node names variable, to prevent false negative results
+\def\testgraph#1{ a#1 -> {b#1, c#1 <-> d#1} -- e#1 <- f#1; a#1 -!- f#1; }
+\SEPARATOR
+\TYPE{Base graph: \testgraph{}}
+\SEPARATOR
+
+\BEGINTEST{Empty `name prefix`}
+\tikzpicture
+  \graph[layered layout] { [parse/.expand once=\testgraph{1}] };
+  \path (b1);
+  \path[name prefix=z-] (b1);
+\endtikzpicture
+\ENDTEST
+
+\BEGINTEST{Non-empty `name prefix`}
+\tikzpicture[name prefix=x-]
+  \graph[layered layout] { [parse/.expand once=\testgraph{2}] };
+
+  % works
+  \path (b2) (x-b2);
+  \path[name prefix=]   (x-b2);
+  \path[name prefix=y-] (x-b2);
+
+  % should throw errors
+  \path[name prefix=] (b2);
+\endtikzpicture
+\ENDTEST
+
+\BEGINTEST{Simple non-gd graph + Empty `name suffix`}
+\tikzpicture
+  \graph { [parse/.expand once=\testgraph{3}] };
+  \path (b3);
+  \path[name suffix=-z] (b3);
+\endtikzpicture
+\ENDTEST
+
+\BEGINTEST{Simple non-gd graph + Non-empty `name suffix`}
+\tikzpicture[name suffix=-x]
+  \graph { [parse/.expand once=\testgraph{4}] };
+
+  % works
+  \path (b4) (b4-x);
+  \path[name suffix=]   (b4-x);
+  \path[name suffix=-y] (b4-x);
+
+  % throws errors
+  \path[name suffix=] (b4);
+\endtikzpicture
+\ENDTEST
+
+\END

--- a/testfiles-gd/tikz-gd-gh1087.lvt
+++ b/testfiles-gd/tikz-gd-gh1087.lvt
@@ -5,6 +5,9 @@
 \usetikzlibrary{graphs, graphdrawing}
 \usegdlibrary{layered}
 
+\makeatletter
+\def\pgfutil@packageerror#1#2#3{\immediate\write17{Package #1 Error: #2.}}
+\makeatother
 \begin{document}
 
 \START

--- a/testfiles-gd/tikz-gd-gh1087.tlg
+++ b/testfiles-gd/tikz-gd-gh1087.tlg
@@ -1,0 +1,57 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+Base graph:  a -> {b, c <-> d} -- e <- f; a -!- f; 
+============================================================
+============================================================
+TEST 1: Empty `name prefix`
+============================================================
+Gd Lua layer Info: Create vertex 'a1'.
+Gd Lua layer Info: Create vertex 'b1'.
+Gd Lua layer Info: Create vertex 'c1'.
+Gd Lua layer Info: Create vertex 'd1'.
+Gd Lua layer Info: Create edge '<->' from 'c1' to 'd1'.
+Gd Lua layer Info: Create edge '->' from 'a1' to 'b1'.
+Gd Lua layer Info: Create edge '->' from 'a1' to 'c1'.
+Gd Lua layer Info: Create vertex 'e1'.
+Gd Lua layer Info: Create edge '--' from 'b1' to 'e1'.
+Gd Lua layer Info: Create edge '--' from 'd1' to 'e1'.
+Gd Lua layer Info: Create vertex 'f1'.
+Gd Lua layer Info: Create edge '<-' from 'e1' to 'f1'.
+Gd Lua layer Info: Add options to vertex 'a1'.
+Gd Lua layer Info: Add options to vertex 'a1'.
+Gd Lua layer Info: Add options to vertex 'f1'.
+Gd Lua layer Info: Add options to vertex 'f1'.
+Gd Lua layer Info: Create edge '-!-' from 'a1' to 'f1'.
+============================================================
+============================================================
+TEST 2: Non-empty `name prefix`
+============================================================
+Gd Lua layer Info: Create vertex 'x-a2'.
+Gd Lua layer Info: Create vertex 'x-b2'.
+Gd Lua layer Info: Create vertex 'x-c2'.
+Gd Lua layer Info: Create vertex 'x-d2'.
+Gd Lua layer Info: Create edge '<->' from 'x-c2' to 'x-d2'.
+Gd Lua layer Info: Create edge '->' from 'x-a2' to 'x-b2'.
+Gd Lua layer Info: Create edge '->' from 'x-a2' to 'x-c2'.
+Gd Lua layer Info: Create vertex 'x-e2'.
+Gd Lua layer Info: Create edge '--' from 'x-b2' to 'x-e2'.
+Gd Lua layer Info: Create edge '--' from 'x-d2' to 'x-e2'.
+Gd Lua layer Info: Create vertex 'x-f2'.
+Gd Lua layer Info: Create edge '<-' from 'x-e2' to 'x-f2'.
+Gd Lua layer Info: Add options to vertex 'x-a2'.
+Gd Lua layer Info: Add options to vertex 'x-a2'.
+Gd Lua layer Info: Add options to vertex 'x-f2'.
+Gd Lua layer Info: Add options to vertex 'x-f2'.
+Gd Lua layer Info: Create edge '-!-' from 'x-a2' to 'x-f2'.
+Package pgf Error: No shape named `b2' is known.
+============================================================
+============================================================
+TEST 3: Simple non-gd graph + Empty `name suffix`
+============================================================
+============================================================
+============================================================
+TEST 4: Simple non-gd graph + Non-empty `name suffix`
+============================================================
+Package pgf Error: No shape named `b4' is known.
+============================================================

--- a/testfiles-gd/tikz-gd-gh1087.tlg
+++ b/testfiles-gd/tikz-gd-gh1087.tlg
@@ -6,44 +6,44 @@ Base graph:  a -> {b, c <-> d} -- e <- f; a -!- f;
 ============================================================
 TEST 1: Empty `name prefix`
 ============================================================
-Gd Lua layer Info: Create vertex 'a1'.
-Gd Lua layer Info: Create vertex 'b1'.
-Gd Lua layer Info: Create vertex 'c1'.
-Gd Lua layer Info: Create vertex 'd1'.
-Gd Lua layer Info: Create edge '<->' from 'c1' to 'd1'.
-Gd Lua layer Info: Create edge '->' from 'a1' to 'b1'.
-Gd Lua layer Info: Create edge '->' from 'a1' to 'c1'.
-Gd Lua layer Info: Create vertex 'e1'.
-Gd Lua layer Info: Create edge '--' from 'b1' to 'e1'.
-Gd Lua layer Info: Create edge '--' from 'd1' to 'e1'.
-Gd Lua layer Info: Create vertex 'f1'.
-Gd Lua layer Info: Create edge '<-' from 'e1' to 'f1'.
-Gd Lua layer Info: Add options to vertex 'a1'.
-Gd Lua layer Info: Add options to vertex 'a1'.
-Gd Lua layer Info: Add options to vertex 'f1'.
-Gd Lua layer Info: Add options to vertex 'f1'.
-Gd Lua layer Info: Create edge '-!-' from 'a1' to 'f1'.
+Gd Lua layer Info: Create vertex 'a1'
+Gd Lua layer Info: Create vertex 'b1'
+Gd Lua layer Info: Create vertex 'c1'
+Gd Lua layer Info: Create vertex 'd1'
+Gd Lua layer Info: Create edge '<->' from 'c1' to 'd1'
+Gd Lua layer Info: Create edge '->' from 'a1' to 'b1'
+Gd Lua layer Info: Create edge '->' from 'a1' to 'c1'
+Gd Lua layer Info: Create vertex 'e1'
+Gd Lua layer Info: Create edge '--' from 'b1' to 'e1'
+Gd Lua layer Info: Create edge '--' from 'd1' to 'e1'
+Gd Lua layer Info: Create vertex 'f1'
+Gd Lua layer Info: Create edge '<-' from 'e1' to 'f1'
+Gd Lua layer Info: Add options to vertex 'a1'
+Gd Lua layer Info: Add options to vertex 'a1'
+Gd Lua layer Info: Add options to vertex 'f1'
+Gd Lua layer Info: Add options to vertex 'f1'
+Gd Lua layer Info: Create edge '-!-' from 'a1' to 'f1'
 ============================================================
 ============================================================
 TEST 2: Non-empty `name prefix`
 ============================================================
-Gd Lua layer Info: Create vertex 'x-a2'.
-Gd Lua layer Info: Create vertex 'x-b2'.
-Gd Lua layer Info: Create vertex 'x-c2'.
-Gd Lua layer Info: Create vertex 'x-d2'.
-Gd Lua layer Info: Create edge '<->' from 'x-c2' to 'x-d2'.
-Gd Lua layer Info: Create edge '->' from 'x-a2' to 'x-b2'.
-Gd Lua layer Info: Create edge '->' from 'x-a2' to 'x-c2'.
-Gd Lua layer Info: Create vertex 'x-e2'.
-Gd Lua layer Info: Create edge '--' from 'x-b2' to 'x-e2'.
-Gd Lua layer Info: Create edge '--' from 'x-d2' to 'x-e2'.
-Gd Lua layer Info: Create vertex 'x-f2'.
-Gd Lua layer Info: Create edge '<-' from 'x-e2' to 'x-f2'.
-Gd Lua layer Info: Add options to vertex 'x-a2'.
-Gd Lua layer Info: Add options to vertex 'x-a2'.
-Gd Lua layer Info: Add options to vertex 'x-f2'.
-Gd Lua layer Info: Add options to vertex 'x-f2'.
-Gd Lua layer Info: Create edge '-!-' from 'x-a2' to 'x-f2'.
+Gd Lua layer Info: Create vertex 'x-a2'
+Gd Lua layer Info: Create vertex 'x-b2'
+Gd Lua layer Info: Create vertex 'x-c2'
+Gd Lua layer Info: Create vertex 'x-d2'
+Gd Lua layer Info: Create edge '<->' from 'x-c2' to 'x-d2'
+Gd Lua layer Info: Create edge '->' from 'x-a2' to 'x-b2'
+Gd Lua layer Info: Create edge '->' from 'x-a2' to 'x-c2'
+Gd Lua layer Info: Create vertex 'x-e2'
+Gd Lua layer Info: Create edge '--' from 'x-b2' to 'x-e2'
+Gd Lua layer Info: Create edge '--' from 'x-d2' to 'x-e2'
+Gd Lua layer Info: Create vertex 'x-f2'
+Gd Lua layer Info: Create edge '<-' from 'x-e2' to 'x-f2'
+Gd Lua layer Info: Add options to vertex 'x-a2'
+Gd Lua layer Info: Add options to vertex 'x-a2'
+Gd Lua layer Info: Add options to vertex 'x-f2'
+Gd Lua layer Info: Add options to vertex 'x-f2'
+Gd Lua layer Info: Create edge '-!-' from 'x-a2' to 'x-f2'
 Package pgf Error: No shape named `b2' is known.
 ============================================================
 ============================================================

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/graphs/tikzlibrarygraphs.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/graphs/tikzlibrarygraphs.code.tex
@@ -1208,7 +1208,7 @@
   %
   % Handle late options and operators
   \tikzgraphsset{source,target,.unknown/.code=,#1}%
-  \tikzgdlatenodeoptionacallback{\tikz@lib@graph@name}%
+  \tikzgdlatenodeoptionacallback{\tikz@pp@name\tikz@lib@graph@name}%
   \node also[graphs/redirect unknown to tikz,/tikz/graphs/.cd,#1](\tikz@lib@graph@name);%
   \pgfkeysvalueof{/tikz/graphs/@operators}%
 }%

--- a/tex/generic/pgf/graphdrawing/tex/tikzlibrarygraphdrawing.code.tex
+++ b/tex/generic/pgf/graphdrawing/tex/tikzlibrarygraphdrawing.code.tex
@@ -83,14 +83,19 @@
     %
     % Setup for the graphs syntax
     %
-    /tikz/graphs/new ->/.code n args={4}{\pgfgdedge{##1}{##2}{->}{/tikz,##3}{##4}},
-    /tikz/graphs/new <-/.code n args={4}{\pgfgdedge{##1}{##2}{<-}{/tikz,##3}{##4}},
-    /tikz/graphs/new --/.code n args={4}{\pgfgdedge{##1}{##2}{--}{/tikz,##3}{##4}},
-    /tikz/graphs/new <->/.code n args={4}{\pgfgdedge{##1}{##2}{<->}{/tikz,##3}{##4}},
-    /tikz/graphs/new -!-/.code n args={4}{\pgfgdedge{##1}{##2}{-!-}{/tikz,##3}{##4}},
+    /tikz/graphs/new ->/.code n args={4}{\tikz@lib@gd@edge{##1}{##2}{->}{/tikz,##3}{##4}},
+    /tikz/graphs/new <-/.code n args={4}{\tikz@lib@gd@edge{##1}{##2}{<-}{/tikz,##3}{##4}},
+    /tikz/graphs/new --/.code n args={4}{\tikz@lib@gd@edge{##1}{##2}{--}{/tikz,##3}{##4}},
+    /tikz/graphs/new <->/.code n args={4}{\tikz@lib@gd@edge{##1}{##2}{<->}{/tikz,##3}{##4}},
+    /tikz/graphs/new -!-/.code n args={4}{\tikz@lib@gd@edge{##1}{##2}{-!-}{/tikz,##3}{##4}},
     /tikz/graphs/placement/compute position/.code=,%
   }
 }%
+
+% wrapper for \pgfgdedge
+\def\tikz@lib@gd@edge#1#2{%
+  \pgfgdedge{\tikz@pp@name{#1}}{\tikz@pp@name{#2}}%
+}
 
 \pgfgdaddprepareedgehook{
   \tikz@enable@edge@quotes%
@@ -130,11 +135,11 @@
 }%
 
 \def\tikz@gd@edge@from@parent@macro#1#2{
-  [/utils/exec=\pgfgdedge{\tikzparentnode}{\tikzchildnode}{--}{/tikz,#1}{#2}]
+  [/utils/exec=\tikz@lib@gd@edge{\tikzparentnode}{\tikzchildnode}{--}{/tikz,#1}{#2}]
 }%
 
 \def\tikz@gd@plain@edge@macro#1#2{
-  \pgfgdedge{\tikztostart}{\tikztotarget}{--}{/tikz,#1}{#2}
+  \tikz@lib@gd@edge{\tikztostart}{\tikztotarget}{--}{/tikz,#1}{#2}
 }%
 
 


### PR DESCRIPTION
**Motivation for this change**

This PR consists of several parts, all `gd` related:
 - a fix for #1087
 - a new test set for `gd` which only runs on LuaTeX and may overlap with (final development of) #1116
 - a test case which aims to check only the just fixed problem, not the whole `gd`

To me, checking internal states and more human-readable generated log lines (here `.tlg`) is preferable to seeing lengthy box content, so I introduce the `pgfgd-debug.lua` which adds debugging code to Lua functions in `InterfaceToDisplay`.

Todo or possible improvements:
 - Fully expand `\tikz@pp@name{<node name>}` before being passed to macros. Again a call for pgf's `\exp_args:Nx` and `\exp_args:Nxx`.
 - In `pgfgd-regression-test.tex`, how to input `pgf-regression-test.tex` which resides in `support` sub-directory of another test set?
 - Allow test files selectively turning on/off wrappers in `pgfgd-debug.lua`. Can be achieved with some higher-order functions written in Lua, is it?

Fixes #1087

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
