### PR TITLE
`declare function`: Strip spaces around each function arg

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -57,7 +57,9 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Update Debian installation instructions
 - Suppress white space at line end when `datavisualization` reads from a file 
   #1112
-- Form-only patterns have no specified color #1122 
+- Form-only patterns have no specified color #1122
+- Functions defined by `/pgf/declare function` now allow spaces in their arg 
+  list #1123
 
 ### Changed
 

--- a/testfiles/pgfmath-gh1123.lvt
+++ b/testfiles/pgfmath-gh1123.lvt
@@ -21,9 +21,9 @@
 \BEGINTEST{/pgf/declare function, space(s) in arg list}
   \pgfkeys{
     /pgf/declare function={
-      funcA( \x,\y) = sqrt(\x^2 + \y^2);
-      funcB( \x, \y) = sqrt(\x^2 + \y^2);
-      funcX(\x,\y) = sqrt(\x^2 + \y^2);
+      funcA( \x,\y) = sqrt((\x)^2 + (\y)^2);
+      funcB( \x, \y) = sqrt((\x)^2 + (\y)^2);
+      funcX(\x,\y) = sqrt((\x)^2 + (\y)^2);
     }
   }
   \ASSERTPGFMATHFUNCTIONS{funcA}{funcX}

--- a/testfiles/pgfmath-gh1123.lvt
+++ b/testfiles/pgfmath-gh1123.lvt
@@ -1,0 +1,33 @@
+\documentclass{minimal}
+\input{pgf-regression-test}
+
+\RequirePackage{pgfmath}
+
+\makeatletter
+\csname protected\endcsname\long\def\ASSERTPGFMATHFUNCTIONS#1#2{%
+  \pgfexpl@tl@if@eq@@ccTF{pgfmath#1@}{pgfmath#2@}{%
+    \TYPE{PASSED}%
+    \TYPE{\pgfexpl@cs@meaning@@c{pgfmath#1@}}%
+  }{%
+    \TYPE{FAILED}%
+    \TYPE{\pgfexpl@cs@meaning@@c{pgfmath#1@}}%
+    \TYPE{\pgfexpl@cs@meaning@@c{pgfmath#2@}}%
+  }%
+}
+\makeatother
+
+\START
+
+\BEGINTEST{/pgf/declare function, space(s) in arg list}
+  \pgfkeys{
+    /pgf/declare function={
+      funcA( \x,\y) = sqrt(\x^2 + \y^2);
+      funcB( \x, \y) = sqrt(\x^2 + \y^2);
+      funcX(\x,\y) = sqrt(\x^2 + \y^2);
+    }
+  }
+  \ASSERTPGFMATHFUNCTIONS{funcA}{funcX}
+  \ASSERTPGFMATHFUNCTIONS{funcB}{funcX}
+\ENDTEST
+
+\END

--- a/testfiles/pgfmath-gh1123.tlg
+++ b/testfiles/pgfmath-gh1123.tlg
@@ -1,0 +1,10 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: /pgf/declare function, space(s) in arg list
+============================================================
+PASSED
+macro:#1#2->\pgfmathparse {sqrt(#1^2+#2^2)}
+PASSED
+macro:#1#2->\pgfmathparse {sqrt(#1^2+#2^2)}
+============================================================

--- a/testfiles/pgfmath-gh1123.tlg
+++ b/testfiles/pgfmath-gh1123.tlg
@@ -4,7 +4,7 @@ Don't change this file in any respect.
 TEST 1: /pgf/declare function, space(s) in arg list
 ============================================================
 PASSED
-macro:#1#2->\pgfmathparse {sqrt(#1^2+#2^2)}
+macro:#1#2->\pgfmathparse {sqrt((#1)^2+(#2)^2)}
 PASSED
-macro:#1#2->\pgfmathparse {sqrt(#1^2+#2^2)}
+macro:#1#2->\pgfmathparse {sqrt((#1)^2+(#2)^2)}
 ============================================================

--- a/tex/generic/pgf/math/pgfmathfunctions.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.code.tex
@@ -205,7 +205,7 @@
 \def\pgfmath@local@function@@body@trimspaces#1,{%
   % strip spaces on both sides of #1 in case it starts with a space,
   % e.g., #1 is ` \y` which comes from `func(\x, \y)=...;`
-  \expandafter\pgfmath@local@function@@body\expanded{{\pgfutil@trimspaces@noexp{#1}}}%
+  \pgfexpl@exp@args@@Ne\pgfmath@local@function@@body{\pgfutil@trimspaces@noexp{#1}}%
 }
 
 \def\pgfmath@local@function@@body#1{%

--- a/tex/generic/pgf/math/pgfmathfunctions.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.code.tex
@@ -184,7 +184,7 @@
             \expandafter\pgfmath@toks\expandafter=\expandafter{\pgfmath@local@body}%
         \else%
             \pgfmath@toks={}%
-            \expandafter\pgfmath@local@function@@body\pgfmath@local@args,,%
+            \expandafter\pgfmath@local@function@@body@trimspaces\pgfmath@local@args,,%
         \fi%
         \xdef\pgfmath@local@temp{%
             \noexpand\pgfmathnotifynewdeclarefunction{\pgfmath@local@name}{\the\c@pgf@counta}%
@@ -202,7 +202,13 @@
     \pgfmathdeclarefunction{#1}{#2}{\pgfmathparse{#3}}%
 }%
 
-\def\pgfmath@local@function@@body#1,{%
+\def\pgfmath@local@function@@body@trimspaces#1,{%
+  % strip spaces on both sides of #1 in case it starts with a space,
+  % e.g., #1 is ` \y` which comes from `func(\x, \y)=...;`
+  \expandafter\pgfmath@local@function@@body\expanded{{\pgfutil@trimspaces@noexp{#1}}}%
+}
+
+\def\pgfmath@local@function@@body#1{%
     \def\pgfmath@local@test{#1}%
     \ifx\pgfmath@local@test\pgfutil@empty%
         \let\pgfmath@local@next=\relax%
@@ -215,7 +221,7 @@
         \pgfmath@toks={}%
         \expandafter\pgfmath@local@function@@@body\pgfmath@local@body @%
         \edef\pgfmath@local@body{\the\pgfmath@toks}%
-        \let\pgfmath@local@next=\pgfmath@local@function@@body%
+        \let\pgfmath@local@next=\pgfmath@local@function@@body@trimspaces%
     \fi%
     \pgfmath@local@next%
 }

--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -55,7 +55,7 @@
 % original text unexpanded in the input stream. Same as \trim@spaces@noexp
 % in trimspaces.sty
 \def\pgfutil@trimspaces@noexp#1{%
-  \unexpanded\expandafter\expandafter\expandafter{\pgfutil@trimspaces{#1}}%
+  \pgfutil@unexpanded\expandafter\expandafter\expandafter{\pgfutil@trimspaces{#1}}%
 }
 
 % \pgfutil@ifx{<token 1>}{<token 2>}{<true code>}{<false code>}
@@ -979,7 +979,7 @@
 
 % \exp_args:Ne
 \long\def\pgfexpl@exp@args@@Ne#1#2{%
-  \expandafter#1\expanded{{#2}}%
+  \expandafter#1\pgfutil@expanded{{#2}}%
 }
 
 % \exp_args:Ncc

--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -918,6 +918,77 @@
         \pgfmath@smuggleone#1%
     \endgroup
 }%
+
+%
+% Utility commands that are drop-in replacements for expl3 macros
+%
+% Naming conventions:
+%   pgf_cs = "pgfexpl@" + expl3_cs.replace("_", "@").replace(":", "@@")
+% For example,
+%   expl3_cs: \exp_args:Ne,          \tl_put_right:Nn
+%   pgf_cs:   \pgfexpl@exp@args@@Ne, \pgfexpl@tl@put@right@@Nn
+
+
+%
+% l3basics package
+%
+
+% \cs_meaning:c
+\long\def\pgfexpl@cs@meaning@@c#1{%
+  \ifcsname #1\endcsname
+    \expandafter\pgfutil@firstoftwo
+  \else
+    \expandafter\pgfutil@secondoftwo
+  \fi
+  {\pgfexpl@exp@args@@Nc\meaning{#1}}
+  {\detokenize{undefined}}%
+}
+
+%
+% l3tl package
+%
+
+% \tl_if_eq:NNTF
+\long\def\pgfexpl@tl@if@eq@@NNTF#1#2{%
+  \ifx#1#2\pgfexpl@@@prg@TF@true@@w\fi\pgfutil@secondoftwo
+}
+
+% \tl_if_eq:ccTF
+\long\def\pgfexpl@tl@if@eq@@ccTF{%
+  \pgfexpl@exp@args@@Ncc\pgfexpl@tl@if@eq@@NNTF
+}
+
+% \__prg_TF_true:w
+\long\def\pgfexpl@@@prg@TF@true@@w\fi\pgfutil@secondoftwo{%
+  \fi\pgfutil@firstoftwo
+}
+
+%
+% l3expan package
+%
+
+% \exp_args:Nc
+\long\def\pgfexpl@exp@args@@Nc#1#2{%
+  \expandafter#1\csname #2\endcsname
+}
+
+% \exp_args:No
+\long\def\pgfexpl@exp@args@@No#1#2{%
+  \expandafter#1\expandafter{#2}%
+}
+
+% \exp_args:Ne
+\long\def\pgfexpl@exp@args@@Ne#1#2{%
+  \expandafter#1\expanded{{#2}}%
+}
+
+% \exp_args:Ncc
+\long\def\pgfexpl@exp@args@@Ncc#1#2#3{%
+  \expandafter#1\csname #2\expandafter\endcsname\csname #3\endcsname
+}
+
+% End of pgfexpl staff
+
 \input pgfutil-common-lists.tex
 
 \endinput

--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -49,6 +49,15 @@
 \def\pgfutil@trimspaces@@#1Q#2{#1}
 \catcode`\Q=11
 
+% \pgfutil@trimspaces@noexp{<token list>}
+%
+% Variant of \pgfutil@trimspaces that after full expansion leaves stripped
+% original text unexpanded in the input stream. Same as \trim@spaces@noexp
+% in trimspaces.sty
+\def\pgfutil@trimspaces@noexp#1{%
+  \unexpanded\expandafter\expandafter\expandafter{\pgfutil@trimspaces{#1}}%
+}
+
 % \pgfutil@ifx{<token 1>}{<token 2>}{<true code>}{<false code>}
 %
 % This macro is expandable.

--- a/tex/generic/pgf/utilities/pgfutil-context.def
+++ b/tex/generic/pgf/utilities/pgfutil-context.def
@@ -365,9 +365,10 @@
 
 \def\pgfutil@translate#1{#1} % \translate works very different in ConTeXt
 
-% e-TeX primitives
+% e-TeX primitives and beyond
 
 \let\pgfutil@protected\normalprotected
 \let\pgfutil@unexpanded\normalunexpanded
+\let\pgfutil@expanded\normalexpanded
 
 \endinput

--- a/tex/generic/pgf/utilities/pgfutil-latex.def
+++ b/tex/generic/pgf/utilities/pgfutil-latex.def
@@ -209,9 +209,10 @@
   \def\pgfutil@translate#1{\translate{#1}}
 \fi
 
-% e-TeX primitives
+% e-TeX primitives and beyond
 
 \let\pgfutil@protected\protected
 \let\pgfutil@unexpanded\unexpanded
+\let\pgfutil@expanded\expanded
 
 \endinput

--- a/tex/generic/pgf/utilities/pgfutil-plain.def
+++ b/tex/generic/pgf/utilities/pgfutil-plain.def
@@ -335,9 +335,10 @@
 
 \def\pgfutil@translate#1{#1} % is there a translator package for plain?
 
-% e-TeX primitives
+% e-TeX primitives and beyond
 
 \let\pgfutil@protected\protected
 \let\pgfutil@unexpanded\unexpanded
+\let\pgfutil@expanded\expanded
 
 \endinput


### PR DESCRIPTION
**Motivation for this change**

To reduce the use of `\expandafter` and make the code more readable, some `\pgfexpl@xxx` macros are introduced.

Fixes #1123

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
