### PR TITLE
fix: Use wrapped `\pgfutil@unexpanded`

### DIFF
--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarydecorations.code.tex
@@ -20,7 +20,7 @@
     % Fully expand `\pgfkeyscurrentname' before being used in first-arg of
     % `/errors/unknown key'.
     {\pgfkeys{/errors/unknown
-        key/.expanded={/pgf/decoration/\pgfkeyscurrentname}{\unexpanded{#1}}}}},%
+        key/.expanded={/pgf/decoration/\pgfkeyscurrentname}{\pgfutil@unexpanded{#1}}}}},%
   /pgf/decoration/raise/.code={\def\tikz@dec@shift{\pgftransformyshift{#1}}\tikz@dec@trans},
   /pgf/decoration/mirror/.code={%
     \csname if#1\endcsname


### PR DESCRIPTION
**Motivation for this change**

Fixed a raw use of `\unexpanded` introduced in #1083, commit cb21347c4eb44b9ff42f50cbe9c452db9e20f455.

It is found when I am preparing `pgfexpl` changes for #1124. An appropriate call for a portable testsuite and a reminder about writing tests.

Do I need to keep a changelog entry? The code to be fixed is not released yet.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
