### PR TITLE
Add support for `RGB` color model in ConTeXt

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add `RGB` and `gray` color model support for ConTeXt #1130
+
 ### Fixed
 
 - Typo in animations `end on` key #1273
@@ -37,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rocky Zhang (@rockyzhz)
 - Yukai Chou (@muzimuzhi)
 - Alexander Grahn
+- Max Chernoff
 
 ## [3.1.10] - 2023-01-13 Henri Menke
 

--- a/tex/generic/pgf/utilities/pgfutil-context.def
+++ b/tex/generic/pgf/utilities/pgfutil-context.def
@@ -26,8 +26,17 @@
 \def\pgfutil@definecolor#1#2#3{\csname pgfutil@emu@#2\endcsname{#1}#3\@nil}
 
 \def\pgfutil@emu@rgb#1#2,#3,#4\@nil{\expandafter\def\csname\string\color@#1\endcsname{\xcolor@{}{}{rgb}{#2,#3,#4}}}
-\def\pgfutil@emu@gray#1#2\@nil{\expandafter\def\csname\string\color@#1\endcsname{\xcolor@{}{}{rgb}{#2,#2,#2}}}
+\def\pgfutil@emu@gray#1#2\@nil{\expandafter\def\csname\string\color@#1\endcsname{\xcolor@{}{}{gray}{#2}}}
 \def\pgfutil@emu@cmyk#1#2,#3,#4,#5\@nil{\expandafter\def\csname\string\color@#1\endcsname{\xcolor@{}{}{cmyk}{#2,#3,#4,#5}}}
+\def\pgfutil@emu@RGB#1#2,#3,#4\@nil{%
+    \begingroup
+    \pgfmathdivide@{#2}{255}\let\pgfutil@emu@RGB@r\pgfmathresult
+    \pgfmathdivide@{#3}{255}\let\pgfutil@emu@RGB@g\pgfmathresult
+    \pgfmathdivide@{#4}{255}\let\pgfutil@emu@RGB@b\pgfmathresult
+    \edef\pgf@marshal{\def\expandafter\noexpand\csname\string\color@#1\endcsname{%
+        \noexpand\xcolor@{}{}{rgb}{\pgfutil@emu@RGB@r,\pgfutil@emu@RGB@g,\pgfutil@emu@RGB@b}}}%
+    \expandafter\endgroup\pgf@marshal
+}
 
 
 % no need for x colors (users can load it if needed)


### PR DESCRIPTION
## Motivation for this change

According to the manual, the `RGB` color model should be supported in ConTeXt.

https://github.com/pgf-tikz/pgf/blob/21310438ae418e15ea92b2845a866554202d13d7/doc/generic/pgf/pgfmanual-en-tikz-actions.tex#L129-L134

However, using `\pgfutil@definecolor{some-color}{RGB}{127,127,127}` produces an error. [A few of the pgfplots libraries](https://github.com/pgf-tikz/pgfplots/search?q=pgfutil+definecolor+RGB) use the `RGB` color model, so they cannot currently be used with ConTeXt.

## Modifications
Plain TeX supports the `RGB` color model by internally converting to `rgb`. 

https://github.com/pgf-tikz/pgf/blob/4cba1dabaa87599962811243ffb1860ed16e4df4/tex/generic/pgf/utilities/pgfutil-plain.def#L29-L37

This PR just copies that same code over to `pgfutil-context.def`.

## Checklist
- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html