### PR TITLE
docs: fix typos

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-base-arrows.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-arrows.tex
@@ -218,7 +218,7 @@ arrows.
 
         There are, however, two cases in which the drawing code gets executed
         each time the arrow is used: First, an arrow tip kind can specify that
-        this should always happen by saying |cachable=false| in its definition.
+        this should always happen by saying |cache=false| in its definition.
         This is necessary if the drawing code contains low-level drawing
         commands that cannot be intercepted such as a use of |\pgftext| for
         arrow tips that ``contain text''. Second, when the |bend| option is
@@ -465,7 +465,7 @@ fast arrow tip management.
             low-level commands created by the drawing code (using the system
             layer protocol subsystem, see Section~\ref{section-protocols}) will
             be cached and reused later on. However, when the drawing code
-            contains ``uncachable'' code like a call to |\pgftext|, caching
+            contains ``uncacheable'' code like a call to |\pgftext|, caching
             must be switched off by saying |cache=false|.
         \item \declare{|bending mode|}|=|\meta{mode}
 

--- a/doc/generic/pgf/pgfmanual-en-gd-usage-pgf.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-usage-pgf.tex
@@ -143,7 +143,7 @@ An overview of what happens is illustrated by the following call graph:
     \draw[p] (tikz-node.east) -- (1.5,2) -- (1.5,1) -- (tex-add-edge.west);
     \draw[p] (tex-add-edge.east) -- (interface-add-edge.west);
 
-    % scope ends -- cloes graph, layouts it and draws it
+    % scope ends -- close graph, layouts it and draws it
     \node (tikz-end) at (0,0) [object node] {|};|};
     \node (tex-end) at (6,0) [object node] {|\pgfgdendscope|};
     \node (interface-draw-graph) at (13,0) [object node] {|runGraphDrawingAlgorithm()|};

--- a/doc/generic/pgf/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/pgfmanual-en-introduction.tex
@@ -42,7 +42,7 @@ that can be used both with pdf\LaTeX\ and also with the classical
 (PostScript-based) \LaTeX. In other words, I wanted to implement a ``portable
 graphics format'' for \TeX\ -- hence the name \pgfname. These early macros are
 still around and they form the ``basic layer'' of the system described in this
-manual, but most of the interaction an author has theses days is with
+manual, but most of the interaction an author has these days is with
 \tikzname\ -- which has become a whole language of its own.
 
 

--- a/doc/generic/pgf/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-external.tex
@@ -290,7 +290,7 @@ support for a) is unavailable for versions up to and including \pgfname\ 3.0.1.
             begin\{document\}} in \LaTeX.}.
     \end{enumerate}
 
-    This does also work if a |\label|/|\ref| combination is implemented itsself
+    This does also work if a |\label|/|\ref| combination is implemented itself
     by a |tikzpicture| (a feature offered by |pgfplots|).
 \end{key}
 

--- a/doc/generic/pgf/pgfmanual-en-library-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-shapes.tex
@@ -735,7 +735,7 @@ anchors.
     \begin{key}{/pgf/cylinder uses custom fill=\meta{boolean} (default true)}
       This enables the use of a custom fill for the body and the end of the
       cylinder. The background path for the shape should not be filled (e.g.,
-      in \tikzname{}, the |fill| option for the node must be implicity or
+      in \tikzname{}, the |fill| option for the node must be implicitly or
       explicitly set to |none|). Internally, this key sets the \TeX-if
       |\ifpgfcylinderusescustomfill| appropriately.
     \end{key}
@@ -1773,7 +1773,7 @@ center of the appropriate side.
         This enables the use of a custom fill for each of the node parts
         (including the area covered by the |inner sep|). The background path
         for the shape should not be filled (e.g., in \tikzname{}, the |fill|
-        option for the node must be implicity or explicitly set to |none|).
+        option for the node must be implicitly or explicitly set to |none|).
         Internally, this key sets the \TeX-if
         |\ifpgfrectanglesplitusecustomfill| appropriately.
     \end{key}

--- a/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
@@ -956,14 +956,14 @@ new ones as described in Section~\ref{section-key-handlers}.
 \end{handler}
 
 \begin{handler}{{.value required}}
-    This handler causes the error message key |/erros/value required| to be
+    This handler causes the error message key |/errors/value required| to be
     issued whenever the \meta{key} is used without a value.
 
     \example |\pgfkeys{/width/.value required}|
 \end{handler}
 
 \begin{handler}{{.value forbidden}}
-    This handler causes the error message key |/erros/value forbidden| to be
+    This handler causes the error message key |/errors/value forbidden| to be
     issued whenever the \meta{key} is used with a value.
 
     This handler works be adding code to the code of the key. This means that


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

I use codespell to find some possible typos and manually fix some typos.

And codespell prompted CHANGELOG.md have many typos, too. However, I am not sure
whether modify CHANGELOG.md is a good idea.

BTW, I advise to add a git commit hook to check spell typos automatically.

Thanks.
<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
