### PR TITLE
Fix '.search also' with /handler config=full or existing

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -28,6 +28,10 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
   case the value is undefined instead of a `\relax`ed csname. It has always been
   semantically wrong to assign to the result of `\pgfkeysgetvalueof`, but now it
   will have undesired side-effects. Therefore this change is breaking.
+- If `/handler config=full or existing` is active, `/.style={...}` assignments
+  can now fail if the style is not found in any `.search also` path. Previously,
+  the style was always set in the first search path, if it was not found in the
+  currently active path.
 
 ### Added
 
@@ -74,6 +78,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Form-only patterns have no specified color #1122 
 - Make `graphdrawing` work with `name prefix` and `name suffix` options #1087
 - pgfkeys was a bit too relaxed around `\relax` #1132
+- Fix `.search also` when `/handler config=full or existing` is active #1143
 
 ### Changed
 
@@ -90,6 +95,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 
 - 3geek14
 - BeneIII
+- Fritz Webering
 - graue70
 - Gábor Braun
 - Joel Coffman

--- a/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
@@ -810,8 +810,9 @@ There are some parameters for handled keys which prove to be useful in some
 \begin{key}{/handler config/only existing/add exception=\marg{key handler name}}
     Allows to add exceptions to the |/handler config=only existing| feature.
     Initially exceptions for the key handlers |/.cd|, |/.try|, |/.retry|,
-    |/.lastretry| and |/.unknown| are defined. The value \marg{key handler
-    name} should be the name of a key handler.
+    |/.lastretry|, |/.unknown|, |/.expand once|, |/.expand twice| and
+    |/.expanded| are defined. The value \marg{key handler name} should be
+    the name of a key handler.
 \end{key}
 
 
@@ -1249,7 +1250,7 @@ directly stored in a key.
     and, thus, |\pgfkeysnovalue| will be stored in |/my key|.
 
     To retrieve the value stored in a key, the handler |/.get| is used.
-    
+
     \medskip
     \emph{Remark:} A key can both store a value and execute commands%
     \footnote{This behavior was partially changed in \pgfname{} 3.1.6 and then
@@ -1623,10 +1624,31 @@ Key 4:& \pgfkeys{/key4}
     |/handler config=full or existing| when you use |/.search also|, that is,
     use
     %
-\begin{codeexample}[code only]
+\begin{codeexample}[]
 \pgfkeys{
-   /main path/.search also={/secondary path},
-   /handler config=full or existing}
+    /main path/.search also={/second path, /third path},
+    /handlers/.unknown/.code={Unknown key `\pgfkeyscurrentkey'},
+    /handler config=full or existing,
+    % This works, because these are a full keys:
+    /second path/key/.code={Original value},
+    /third path/other key/.code={Other value},
+}
+
+\pgfkeys{
+    /main path/.cd,
+    % This works, because the keys are found in '.search also'.
+    key/.code={value1},
+    other key/.code={value2},
+}
+\texttt{key} = \pgfkeys{/second path/key},
+\texttt{other key} = \pgfkeys{/third path/other key},
+
+\pgfkeys{
+    /main path/.cd,
+    % The '.code' handler is not executed because 'undefined key'
+    % does not exist in either of the '.search also' paths.
+    undefined key/.code={New value},
+}
 \end{codeexample}
     %
 \end{handler}

--- a/tex/generic/pgf/utilities/pgfkeys.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeys.code.tex
@@ -1006,7 +1006,13 @@
 \pgfkeys{/handlers/.expand twice/.code=\expandafter\expandafter\expandafter\pgfkeys@exp@call\expandafter\expandafter\expandafter{#1}}
 \pgfkeys{/handlers/.expanded/.code=\edef\pgfkeys@temp{#1}\expandafter\pgfkeys@exp@call\expandafter{\pgfkeys@temp}}
 
-\long\def\pgfkeys@exp@call#1{\pgfkeysalso{\pgfkeyscurrentpath={#1}}}
+\long\def\pgfkeys@exp@call#1{%
+  \ifpgfkeysaddeddefaultpath% If the original key was a relative path, do the expanded assignment also with a relative path
+    \pgfkeys@pathtoks{}%
+    \expandafter\pgfkeys@splitter\pgfkeyscurrentkeyRAW//% Removes the /.expand* component of the original relative key.
+  \fi
+  \pgfkeysalso{\pgfkeyscurrentpath={#1}}%
+}
 
 \def\pgfkeys@mathparse{%
   \pgfkeys@ifcsname{pgfmathparse}{%


### PR DESCRIPTION
Make .expand* keys use relative paths if the original path was relative.

Signed-off-by: Fritz Webering <fritz@webering.eu>


**Motivation for this change**

Fixes #1143

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
