### PR TITLE
fix: Remove spurious spaces for `3d view`

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -74,6 +74,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Form-only patterns have no specified color #1122 
 - Make `graphdrawing` work with `name prefix` and `name suffix` options #1087
 - pgfkeys was a bit too relaxed around `\relax` #1132
+- Remove spurious spaces for `3d view` #1151
 
 ### Changed
 

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryperspective.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibraryperspective.code.tex
@@ -88,21 +88,21 @@
 }
 
 \tikzset{
-  3d view/.code 2 args={
+  3d view/.code 2 args={%
     % Set elevation and azimuth angles
-    \pgfmathsetmacro\pgf@view@az{#1}
-    \pgfmathsetmacro\pgf@view@el{#2}
+    \pgfmathsetmacro\pgf@view@az{#1}%
+    \pgfmathsetmacro\pgf@view@el{#2}%
     % Calculate projections of rotation matrix
-    \pgfmathsetmacro\pgf@xvec@x{cos(\pgf@view@az)}
-    \pgfmathsetmacro\pgf@xvec@y{-sin(\pgf@view@az)*sin(\pgf@view@el)}
-    \pgfmathsetmacro\pgf@yvec@x{sin(\pgf@view@az)}
-    \pgfmathsetmacro\pgf@yvec@y{cos(\pgf@view@az)*sin(\pgf@view@el)}
-    \pgfmathsetmacro\pgf@zvec@x{+0}
-    \pgfmathsetmacro\pgf@zvec@y{cos(\pgf@view@el)}
+    \pgfmathsetmacro\pgf@xvec@x{cos(\pgf@view@az)}%
+    \pgfmathsetmacro\pgf@xvec@y{-sin(\pgf@view@az)*sin(\pgf@view@el)}%
+    \pgfmathsetmacro\pgf@yvec@x{sin(\pgf@view@az)}%
+    \pgfmathsetmacro\pgf@yvec@y{cos(\pgf@view@az)*sin(\pgf@view@el)}%
+    \pgfmathsetmacro\pgf@zvec@x{+0}%
+    \pgfmathsetmacro\pgf@zvec@y{cos(\pgf@view@el)}%
     % Set base vectors
-    \pgfsetxvec{\pgfpoint{\pgf@xvec@x cm}{\pgf@xvec@y cm}}
-    \pgfsetyvec{\pgfpoint{\pgf@yvec@x cm}{\pgf@yvec@y cm}}
-    \pgfsetzvec{\pgfpoint{\pgf@zvec@x cm}{\pgf@zvec@y cm}}
+    \pgfsetxvec{\pgfpoint{\pgf@xvec@x cm}{\pgf@xvec@y cm}}%
+    \pgfsetyvec{\pgfpoint{\pgf@yvec@x cm}{\pgf@yvec@y cm}}%
+    \pgfsetzvec{\pgfpoint{\pgf@zvec@x cm}{\pgf@zvec@y cm}}%
   },
   3d view/.default={-30}{15},
   isometric view/.style={3d view={-45}{atan(1/sqrt(2))}},


### PR DESCRIPTION
**Motivation for this change**

Fixes #1151

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
