### PR TITLE
document default-space-rule; allow line breaks

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-module-parser.tex
+++ b/doc/generic/pgf/pgfmanual-en-module-parser.tex
@@ -26,7 +26,9 @@ This module provides commands for defining a parser that scans some given text
 letter-by-letter. For each letter, some code is executed and, possibly a
 state-switch occurs. The code for each letter might take mandatory or optional
 arguments. The parsing process ends when a final state has been reached, and
-optionally some code is executed afterwards.
+optionally some code is executed afterwards. Each newly defined parser by
+default ignores space tokens, if you want to change that you'll have to
+explicitly define an action for blank spaces (with |\pgfparserdef|).
 
 \begin{command}{\pgfparserparse\marg{parser name}\meta{text}}%
   This command is used to parse the \meta{text} using the (previously defined)
@@ -86,13 +88,21 @@ There are \the\mycount\ a's.
   |\pgfparserdef{myparser}{initial}a{foo}|
   define an \meta{action} for |the letter a|. This short form works for most
   tokens, but not for a space (in which case you can use
-  |\pgfparserdef{myparser}{initial}{blank space}{foo}|), and opening braces
+  |\pgfparserdef|\allowbreak|{myparser}|\allowbreak|{initial}|\allowbreak
+  |{blank space}|\allowbreak|{foo}|%
+  ), and opening braces
   (in which case you can use
-  |\pgfparserdef{myparser}{initial}{\meaning\bgroup}{foo}|, and one might prefer
-  to use |\pgfparserdef{myparser}{initial}{\meaning\egroup}{foo}| for closing
-  braces as well). You can as well define an action for a macro's meaning (note
-  that macros with different names can have the same meaning), so things like
-  |\pgfparserdef{myparser}{initial}\texttt{foo}| are possible as well.
+  |\pgfparserdef|\allowbreak|{myparser}|\allowbreak|{initial}|\allowbreak
+  |{\meaning\bgroup}|\allowbreak|{foo}|%
+  , and one might prefer
+  to use
+  |\pgfparserdef|\allowbreak|{myparser}|\allowbreak|{initial}|\allowbreak
+  |{\meaning\egroup}|\allowbreak|{foo}|
+  for closing braces as well). You can as well define an action for a macro's
+  meaning (note that macros with different names can have the same meaning), so
+  things like
+  |\pgfparserdef|\allowbreak|{myparser}|\allowbreak|{initial}\texttt{foo}|
+  are possible as well.
 
   The \meta{action} might require arguments which you can specify in the
   optional \meta{arguments} string. The argument string can contain up to nine


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

This PR makes slight adjustments to the `pgfparser` documentation to document the default-space rule (by default spaces are ignored), and allows line breaks in some longish inline verbatim input, to keep things on page.

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
