### PR TITLE
Fix "tress" typo

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-tikz-design.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-design.tex
@@ -152,7 +152,7 @@ possible (though a bit challenging) to define new shapes.
 
 \subsection{Special Syntax for Specifying Trees}
 
-The ``node syntax'' can also be used to draw tress: A |node| can be followed by
+The ``node syntax'' can also be used to draw trees: A |node| can be followed by
 any number of children, each introduced by the keyword |child|. The children
 are nodes themselves, each of which may have children in turn.
 %


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

Hi!
I just spotted a small typo in the doc.

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->


- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
