### PR TITLE
docs: ensure `doc` v2 is loaded

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -93,6 +93,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Flatten the doc tree
 - Ensure `\tracinglostchars<3` in `\pgf@picture`
 - Use descriptive workflow job ids
+- Ensure `doc` v2 is loaded for pgfmanual
 
 ### Contributors
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -94,6 +94,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Ensure `\tracinglostchars<3` in `\pgf@picture`
 - Use descriptive workflow job ids
 - Ensure `doc` v2 is loaded for pgfmanual
+- Ensure active `^^M` is non-expandable in `codeexample`
 
 ### Contributors
 

--- a/doc/generic/pgf/pgfmanual-test.tex
+++ b/doc/generic/pgf/pgfmanual-test.tex
@@ -7,7 +7,7 @@
 %
 % See the file doc/generic/pgf/licenses/LICENSE for more details.
 
-\documentclass[a4paper]{ltxdoc}
+\documentclass[a4paper,doc2]{ltxdoc}
 
 % pgf version is defined in \pgfversion in file
 % generic/pgf/utilities/pgfrcs.code.tex 

--- a/doc/generic/pgf/pgfmanual.tex
+++ b/doc/generic/pgf/pgfmanual.tex
@@ -7,7 +7,7 @@
 %
 % See the file doc/generic/pgf/licenses/LICENSE for more details.
 
-\documentclass[a4paper]{ltxdoc}
+\documentclass[a4paper,doc2]{ltxdoc}
 
 % pgf version is defined in \pgfversion in file
 % generic/pgf/utilities/pgfrcs.code.tex

--- a/tex/latex/pgf/doc/pgfmanual-en-macros.tex
+++ b/tex/latex/pgf/doc/pgfmanual-en-macros.tex
@@ -1711,6 +1711,9 @@
       {%
         \returntospace%
         \commenthandler%
+        % ensures the active ^^M is protected thus won't be expanded in the
+        % following \xdef\code@temp{#1}
+        \obeylines%
         \xdef\code@temp{#1}% removes returns and comments
       }%
       \edef\pgfmanualmcatcode{\the\catcode`\^^M}%
@@ -1727,6 +1730,9 @@
           {%
             \returntospace%
             \commenthandler%
+            % ensures the active ^^M is protected thus won't be expanded in the
+            % following \xdef\code@temp{#1}
+            \obeylines%
             \xdef\code@temp{#1}% removes returns and comments
           }%
           \catcode`\^^M=9%


### PR DESCRIPTION
**Motivation for this change**

Closes #1171

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ ] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
