### PR TITLE
Adding timers for the `parabola`, `rectangle`, `sin` and `cos` path operators

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -82,8 +82,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - pgfkeys was a bit too relaxed around `\relax` #1132
 - Remove spurious spaces for `3d view` #1151
 - Fix incorrectly placed matrix delimiters for implicitly positioned nodes #1102
-- added timer for `parabola` path operator
-- added timer for `rectangle` path operator
+- added timer for `parabola`, `rectangle`, `sin` and `cos` path operator
 
 ### Changed
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -83,6 +83,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Remove spurious spaces for `3d view` #1151
 - Fix incorrectly placed matrix delimiters for implicitly positioned nodes #1102
 - added timer for `parabola` path operator
+- added timer for `rectangle` path operator
 
 ### Changed
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -82,6 +82,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - pgfkeys was a bit too relaxed around `\relax` #1132
 - Remove spurious spaces for `3d view` #1151
 - Fix incorrectly placed matrix delimiters for implicitly positioned nodes #1102
+- added timer for `parabola` path operator
 
 ### Changed
 
@@ -111,6 +112,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - muzimuzhi
 - PhelypeOleinik
 - QJLc
+- Qrrbrbirlbel
 - Stefan Pinnow
 
 ## [3.1.9a] - 2021-05-15 Henri Menke

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -3501,9 +3501,11 @@
 \def\tikz@parabola@semifinal#1{%
   \tikz@flush@moveto%
   % Save original start:
+  \edef\tikz@timer@start{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}% %% Timer: save start position
   \pgf@xb=\tikz@lastx%
   \pgf@yb=\tikz@lasty%
   \tikz@make@last@position{#1}%
+  \edef\tikz@timer@end{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}% %% Timer: save target position
   \pgf@xc=\tikz@lastx%
   \pgf@yc=\tikz@lasty%
   \begingroup% now calculate bend:
@@ -3516,18 +3518,61 @@
     \advance\tikz@lastxsaved by-\tikz@parabola@bend@factor\pgf@xb%
     \advance\tikz@lastysaved by-\tikz@parabola@bend@factor\pgf@yb%
     \expandafter\tikz@make@last@position\expandafter{\tikz@parabola@bend}%
+    \edef\tikz@timer@middle{{\the\tikz@lastx}{\the\tikz@lasty}}% %% Timer: save bend postion
     % Calculate delta from bend
     \advance\pgf@xc by-\tikz@lastx%
     \advance\pgf@yc by-\tikz@lasty%
     % Ok, now calculate delta to bend
     \advance\tikz@lastx by-\pgf@xb%
     \advance\tikz@lasty by-\pgf@yb%
-    \xdef\tikz@parabola@b{{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}{\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@yc}}}%
+    \edef\tikz@marshall{%
+      \noexpand\let\noexpand\tikz@timer\noexpand\tikz@timer@parabola
+      \noexpand\edef\noexpand\tikz@timer@middle{\noexpand\pgfqpoint\tikz@timer@middle}%
+      \noexpand\pgfpathparabola{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}{\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@yc}}%
+    }%
   \expandafter\endgroup%
-  \expandafter\expandafter\expandafter\pgfpathparabola\expandafter\tikz@parabola@b%
+  \tikz@marshall
   \expandafter\tikz@scan@next@command\tikz@after@path%
 }%
 
+\def\tikz@timer@parabola{% following calculations, see \def of \pgfpathparabola in pgfcorepathconstruct.code.tex (l. 1261)
+\ifdim\tikz@time pt<.5pt\relax % first part
+    \pgf@process{\tikz@timer@middle}%
+    \pgf@xc\pgf@x\pgf@yc\pgf@y
+    \pgf@xb\pgf@x\pgf@yb\pgf@y
+    \pgf@process{\tikz@timer@start}%
+    \advance\pgf@xc-\pgf@x\pgf@xc.1125\pgf@xc
+    \advance\pgf@xc\pgf@x                 % = start_x + .1125 (middle_x - start_x)
+    \advance\pgf@yc-\pgf@y\pgf@yc.225\pgf@yc
+    \advance\pgf@yc\pgf@y                 % = start_y + .225 (middle_y - start_y)
+    \advance\pgf@xb\pgf@x\pgf@xb.5\pgf@xb % = .5 (middle_x + start_x) = start_x + .5 (middle_x - start_x)
+    \pgf@xa=\tikz@time pt%
+    \pgf@xa=2\pgf@xa                      % = 2 * \tikz@time
+    \edef\tikz@marshall{\noexpand\pgftransformcurveattime{\strip@pt\pgf@xa}{\noexpand\tikz@timer@start}%
+      {\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@yc}}%
+      {\noexpand\pgfqpoint{\the\pgf@xb}{\the\pgf@yb}}%
+      {\noexpand\tikz@timer@middle}}%
+  \else % second part
+    \pgf@process{\tikz@timer@end}%
+    \pgf@xc\pgf@x
+    \pgf@xb\pgf@x
+    \pgf@yb\pgf@y
+    \pgf@process{\tikz@timer@middle}%
+    \advance\pgf@xc\pgf@x\pgf@xc.5\pgf@xc % = .5 (end_x + middle_x) = middle_x + .5 (end_x - middle_x)
+    \advance\pgf@xb-\pgf@x\pgf@xb.8875\pgf@xb
+    \advance\pgf@xb\pgf@x                 % = middle_x + .8875 (end_x - middle_x)
+    \advance\pgf@yb-\pgf@y\pgf@yb.775\pgf@yb
+    \advance\pgf@yb\pgf@y                 % = middle_y + .775 (end_y - middle_y)
+    \pgf@xa=\tikz@time pt%
+    \advance\pgf@xa-.5pt%
+    \pgf@xa=2\pgf@xa                      % = 2 (\tikz@zime - .5)
+    \edef\tikz@marshall{\noexpand\pgftransformcurveattime{\strip@pt\pgf@xa}{\noexpand\tikz@timer@middle}%
+      {\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@y}}%
+      {\noexpand\pgfqpoint{\the\pgf@xb}{\the\pgf@yb}}%
+      {\noexpand\tikz@timer@end}}%
+  \fi
+  \tikz@marshall
+}
 
 % Syntax for circles:
 % circle [options] % where options should set, at least, radius

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -3272,8 +3272,8 @@
 \def\tikz@rectB#1{%
   \tikz@make@last@position{#1}%
   \edef\tikz@timer@end{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}%
-  \let\tikz@timer=\tikz@timer@line%
-          \tikz@@movetosave{\pgfqpoint{\pgf@xa}{\pgf@ya}}%
+  \let\tikz@timer=\tikz@timer@rectangle
+  \tikz@@movetosave{\pgfqpoint{\pgf@xa}{\pgf@ya}}%
   \tikz@path@lineto{\pgfqpoint{\pgf@xa}{\tikz@lasty}}%
   \tikz@path@lineto{\pgfqpoint{\tikz@lastx}{\tikz@lasty}}%
   \tikz@path@lineto{\pgfqpoint{\tikz@lastx}{\pgf@ya}}%
@@ -3534,45 +3534,6 @@
   \tikz@marshall
   \expandafter\tikz@scan@next@command\tikz@after@path%
 }%
-
-\def\tikz@timer@parabola{% following calculations, see \def of \pgfpathparabola in pgfcorepathconstruct.code.tex (l. 1261)
-\ifdim\tikz@time pt<.5pt\relax % first part
-    \pgf@process{\tikz@timer@middle}%
-    \pgf@xc\pgf@x\pgf@yc\pgf@y
-    \pgf@xb\pgf@x\pgf@yb\pgf@y
-    \pgf@process{\tikz@timer@start}%
-    \advance\pgf@xc-\pgf@x\pgf@xc.1125\pgf@xc
-    \advance\pgf@xc\pgf@x                 % = start_x + .1125 (middle_x - start_x)
-    \advance\pgf@yc-\pgf@y\pgf@yc.225\pgf@yc
-    \advance\pgf@yc\pgf@y                 % = start_y + .225 (middle_y - start_y)
-    \advance\pgf@xb\pgf@x\pgf@xb.5\pgf@xb % = .5 (middle_x + start_x) = start_x + .5 (middle_x - start_x)
-    \pgf@xa=\tikz@time pt%
-    \pgf@xa=2\pgf@xa                      % = 2 * \tikz@time
-    \edef\tikz@marshall{\noexpand\pgftransformcurveattime{\strip@pt\pgf@xa}{\noexpand\tikz@timer@start}%
-      {\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@yc}}%
-      {\noexpand\pgfqpoint{\the\pgf@xb}{\the\pgf@yb}}%
-      {\noexpand\tikz@timer@middle}}%
-  \else % second part
-    \pgf@process{\tikz@timer@end}%
-    \pgf@xc\pgf@x
-    \pgf@xb\pgf@x
-    \pgf@yb\pgf@y
-    \pgf@process{\tikz@timer@middle}%
-    \advance\pgf@xc\pgf@x\pgf@xc.5\pgf@xc % = .5 (end_x + middle_x) = middle_x + .5 (end_x - middle_x)
-    \advance\pgf@xb-\pgf@x\pgf@xb.8875\pgf@xb
-    \advance\pgf@xb\pgf@x                 % = middle_x + .8875 (end_x - middle_x)
-    \advance\pgf@yb-\pgf@y\pgf@yb.775\pgf@yb
-    \advance\pgf@yb\pgf@y                 % = middle_y + .775 (end_y - middle_y)
-    \pgf@xa=\tikz@time pt%
-    \advance\pgf@xa-.5pt%
-    \pgf@xa=2\pgf@xa                      % = 2 (\tikz@zime - .5)
-    \edef\tikz@marshall{\noexpand\pgftransformcurveattime{\strip@pt\pgf@xa}{\noexpand\tikz@timer@middle}%
-      {\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@y}}%
-      {\noexpand\pgfqpoint{\the\pgf@xb}{\the\pgf@yb}}%
-      {\noexpand\tikz@timer@end}}%
-  \fi
-  \tikz@marshall
-}
 
 % Syntax for circles:
 % circle [options] % where options should set, at least, radius
@@ -4939,6 +4900,18 @@
   \pgftransformlineattime{\tikz@time}{\tikz@timer@start}{\tikz@timer@end}%
 }%
 
+\def\tikz@timer@rectangle{%
+  \pgfutil@tempdima\tikz@time pt
+  \ifdim\pgfutil@tempdima<.5pt\else % if we're at the return pos-ition we switch start and end
+    \advance\pgfutil@tempdima-.5pt
+    \let\pgf@tempa\tikz@timer@start
+    \let\tikz@timer@start\tikz@timer@end
+    \let\tikz@timer@end\pgf@tempa
+  \fi
+  \multiply\pgfutil@tempdima2
+  \edef\tikz@time{\strip@pt\pgfutil@tempdima}%
+  \tikz@timer@vhline}%
+
 \def\tikz@timer@vhline{%
   \ifdim\tikz@time pt<0.5pt% first half
     \pgf@process{\tikz@timer@start}%
@@ -5014,7 +4987,44 @@
   {\tikz@timer@start@angle}{\tikz@timer@end@angle}%
 }%
 
-
+\def\tikz@timer@parabola{% following calculations, see \def of \pgfpathparabola in pgfcorepathconstruct.code.tex (l. 1261)
+\ifdim\tikz@time pt<.5pt\relax % first part
+    \pgf@process{\tikz@timer@middle}%
+    \pgf@xc\pgf@x\pgf@yc\pgf@y
+    \pgf@xb\pgf@x\pgf@yb\pgf@y
+    \pgf@process{\tikz@timer@start}%
+    \advance\pgf@xc-\pgf@x\pgf@xc.1125\pgf@xc
+    \advance\pgf@xc\pgf@x                 % = start_x + .1125 (middle_x - start_x)
+    \advance\pgf@yc-\pgf@y\pgf@yc.225\pgf@yc
+    \advance\pgf@yc\pgf@y                 % = start_y + .225 (middle_y - start_y)
+    \advance\pgf@xb\pgf@x\pgf@xb.5\pgf@xb % = .5 (middle_x + start_x) = start_x + .5 (middle_x - start_x)
+    \pgf@xa=\tikz@time pt%
+    \pgf@xa=2\pgf@xa                      % = 2 * \tikz@time
+    \edef\tikz@marshall{\noexpand\pgftransformcurveattime{\strip@pt\pgf@xa}{\noexpand\tikz@timer@start}%
+      {\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@yc}}%
+      {\noexpand\pgfqpoint{\the\pgf@xb}{\the\pgf@yb}}%
+      {\noexpand\tikz@timer@middle}}%
+  \else % second part
+    \pgf@process{\tikz@timer@end}%
+    \pgf@xc\pgf@x
+    \pgf@xb\pgf@x
+    \pgf@yb\pgf@y
+    \pgf@process{\tikz@timer@middle}%
+    \advance\pgf@xc\pgf@x\pgf@xc.5\pgf@xc % = .5 (end_x + middle_x) = middle_x + .5 (end_x - middle_x)
+    \advance\pgf@xb-\pgf@x\pgf@xb.8875\pgf@xb
+    \advance\pgf@xb\pgf@x                 % = middle_x + .8875 (end_x - middle_x)
+    \advance\pgf@yb-\pgf@y\pgf@yb.775\pgf@yb
+    \advance\pgf@yb\pgf@y                 % = middle_y + .775 (end_y - middle_y)
+    \pgf@xa=\tikz@time pt%
+    \advance\pgf@xa-.5pt%
+    \pgf@xa=2\pgf@xa                      % = 2 (\tikz@zime - .5)
+    \edef\tikz@marshall{\noexpand\pgftransformcurveattime{\strip@pt\pgf@xa}{\noexpand\tikz@timer@middle}%
+      {\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@y}}%
+      {\noexpand\pgfqpoint{\the\pgf@xb}{\the\pgf@yb}}%
+      {\noexpand\tikz@timer@end}}%
+  \fi
+  \tikz@marshall
+}
 
 %
 % Coordinate systems

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -3272,7 +3272,7 @@
 \def\tikz@rectB#1{%
   \tikz@make@last@position{#1}%
   \edef\tikz@timer@end{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}%
-  \let\tikz@timer=\tikz@timer@rectangle
+  \let\tikz@timer\tikz@timer@rectangle
   \tikz@@movetosave{\pgfqpoint{\pgf@xa}{\pgf@ya}}%
   \tikz@path@lineto{\pgfqpoint{\pgf@xa}{\tikz@lasty}}%
   \tikz@path@lineto{\pgfqpoint{\tikz@lastx}{\tikz@lasty}}%
@@ -3450,7 +3450,9 @@
 \def\tikz@@cosine#1{%
   \let\tikz@tangent\tikz@tangent@lookup%
   \tikz@flush@moveto%
+  \edef\tikz@timer@start{\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}%
   \pgf@process{#1}%
+  \edef\tikz@timer@end{\pgfqpoint{\the\pgf@x}{\the\pgf@y}}%
   \pgf@xc=\pgf@x%
   \pgf@yc=\pgf@y%
   \advance\pgf@xc by-\tikz@lastx%
@@ -3460,6 +3462,7 @@
   \tikz@lastxsaved=\tikz@lastx%
   \tikz@lastysaved=\tikz@lasty%
   \tikz@updatecurrenttrue%
+  \let\tikz@timer=\tikz@timer@cosine
   \pgfpathcosine{\pgfqpoint{\pgf@xc}{\pgf@yc}}%
   \tikz@scan@next@command%
 }%
@@ -3470,7 +3473,9 @@
 \def\tikz@@sine#1{%
   \let\tikz@tangent\tikz@tangent@lookup%
   \tikz@flush@moveto%
+  \edef\tikz@timer@start{\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}%
   \pgf@process{#1}%
+  \edef\tikz@timer@end{\pgfqpoint{\the\pgf@x}{\the\pgf@y}}%
   \pgf@xc=\pgf@x%
   \pgf@yc=\pgf@y%
   \advance\pgf@xc by-\tikz@lastx%
@@ -3480,6 +3485,7 @@
   \tikz@lastxsaved=\tikz@lastx%
   \tikz@lastysaved=\tikz@lasty%
   \tikz@updatecurrenttrue%
+  \let\tikz@timer=\tikz@timer@sine
   \pgfpathsine{\pgfqpoint{\pgf@xc}{\pgf@yc}}%
   \tikz@scan@next@command%
 }%
@@ -3501,11 +3507,11 @@
 \def\tikz@parabola@semifinal#1{%
   \tikz@flush@moveto%
   % Save original start:
-  \edef\tikz@timer@start{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}% %% Timer: save start position
+  \edef\tikz@timer@start{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}%
   \pgf@xb=\tikz@lastx%
   \pgf@yb=\tikz@lasty%
   \tikz@make@last@position{#1}%
-  \edef\tikz@timer@end{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}% %% Timer: save target position
+  \edef\tikz@timer@end{\noexpand\pgfqpoint{\the\tikz@lastx}{\the\tikz@lasty}}%
   \pgf@xc=\tikz@lastx%
   \pgf@yc=\tikz@lasty%
   \begingroup% now calculate bend:
@@ -3518,7 +3524,7 @@
     \advance\tikz@lastxsaved by-\tikz@parabola@bend@factor\pgf@xb%
     \advance\tikz@lastysaved by-\tikz@parabola@bend@factor\pgf@yb%
     \expandafter\tikz@make@last@position\expandafter{\tikz@parabola@bend}%
-    \edef\tikz@timer@middle{{\the\tikz@lastx}{\the\tikz@lasty}}% %% Timer: save bend postion
+    \edef\tikz@timer@middle{{\the\tikz@lastx}{\the\tikz@lasty}}%
     % Calculate delta from bend
     \advance\pgf@xc by-\tikz@lastx%
     \advance\pgf@yc by-\tikz@lasty%
@@ -4910,7 +4916,7 @@
   \fi
   \multiply\pgfutil@tempdima2
   \edef\tikz@time{\strip@pt\pgfutil@tempdima}%
-  \tikz@timer@vhline}%
+  \tikz@timer@hvline}%
 
 \def\tikz@timer@vhline{%
   \ifdim\tikz@time pt<0.5pt% first half
@@ -4986,6 +4992,42 @@
   {\tikz@timer@ninety@axis}%
   {\tikz@timer@start@angle}{\tikz@timer@end@angle}%
 }%
+
+\def\tikz@timer@sine{% following calculations, see \def of \pgfpathsine in pgfcorepathconstruct.code.tex (l. 1315)
+  \pgf@process{\tikz@timer@end}%
+  \pgf@xc\pgf@x\pgf@yc\pgf@y
+  \pgf@xb\pgf@x\pgf@yb\pgf@y
+  \pgf@process{\tikz@timer@start}%
+  \advance\pgf@xc-\pgf@x\pgf@xc.3260\pgf@xc
+  \advance\pgf@xc\pgf@x                     % = start_x + .3260 (end_x - start_x)
+  \advance\pgf@yc-\pgf@y\pgf@yc.5120\pgf@yc
+  \advance\pgf@yc\pgf@y                     % = start_y + .5120 (end_y - start_y)
+  \advance\pgf@xb-\pgf@x\pgf@xb.6380\pgf@xb % = start_x + .6380 (end_x - start_x)
+  \advance\pgf@xb\pgf@x
+  \edef\tikz@marshall{\noexpand\pgftransformcurveattime{\tikz@time}{\noexpand\tikz@timer@start}%
+    {\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@yc}}%
+    {\noexpand\pgfqpoint{\the\pgf@xb}{\the\pgf@yb}}%
+    {\noexpand\tikz@timer@end}}%
+  \tikz@marshall
+}
+
+\def\tikz@timer@cosine{% following calculations, see \def of \pgfpathcosine in pgfcorepathconstruct.code.tex (l. 1345)
+  \pgf@process{\tikz@timer@end}%
+  \pgf@xc\pgf@x\pgf@yc\pgf@y
+  \pgf@xb\pgf@x\pgf@yb\pgf@y
+  \pgf@process{\tikz@timer@start}%
+  \advance\pgf@xb-\pgf@x\pgf@xb.6740\pgf@xb
+  \advance\pgf@xb\pgf@x                     % = start_x + .6740 (end_x - start_x)
+  \advance\pgf@yb-\pgf@y\pgf@yb.4880\pgf@yb
+  \advance\pgf@yb\pgf@y                     % = start_y + .4880 (end_y - start_y)
+  \advance\pgf@xc-\pgf@x\pgf@xc.3620\pgf@xc % = start_x + .3620 (end_x - start_x)
+  \advance\pgf@xc\pgf@x
+  \edef\tikz@marshall{\noexpand\pgftransformcurveattime{\tikz@time}{\noexpand\tikz@timer@start}%
+    {\noexpand\pgfqpoint{\the\pgf@xc}{\the\pgf@y}}%
+    {\noexpand\pgfqpoint{\the\pgf@xb}{\the\pgf@yb}}%
+    {\noexpand\tikz@timer@end}}%
+  \tikz@marshall
+}
 
 \def\tikz@timer@parabola{% following calculations, see \def of \pgfpathparabola in pgfcorepathconstruct.code.tex (l. 1261)
 \ifdim\tikz@time pt<.5pt\relax % first part


### PR DESCRIPTION
Adding timers for the `parabola`, `rectangle`, `sin` and `cos` path operators using the same calculations as `\pgfpathparabola`, `\pgfpathsine` and `\pgfpathcosine` in `pgfcorepathconstruct.code.tex`.

The rectangle timer uses the timer for `-|`, i.e. the timer flows anticlockwise (just like the angles from `0` to `360`).

**Motivation for this change**

* TeX.sx user [CrazyArm](https://tex.stackexchange.com/users/28347/crazyarm) wanted to [place nodes along a `rectangle` path](https://tex.stackexchange.com/q/106558/16595).

* TeX.sx user [cis](https://tex.stackexchange.com/users/46023/cis) wanted to [place nodes along a `parabola` path](https://tex.stackexchange.com/q/543251/16595).

**Example that use the new timers**
```latex
\documentclass[tikz]{standalone}
\tikzset{
  inline node/.style={sloped, fill=white, font=\tiny, inner sep=+0pt},
  dot nodes/.style args={#1:#2:#3}{
    alias=@, inner sep=+.5pt, fill=black, circle, node contents=,
    append after command={(@) edge[gray, <-] node[gray, pos=1, font=\tiny, inner sep=+0pt,anchor={#1}]{#3} ++ (#2:.3cm)}},
  mark nodes online/.style={insert path={
    foreach \pos in {#1} {node[inline node, pos=\pos/10]{\pos}}}},
  mark nodes online/.default={1,...,4,6,7,...,9},
  mark nodes/.style={insert path={
    foreach \pos in {#1} {node[inline node, style/.expand once=\pos]{\pos}}}}}
\begin{document}
\begin{tikzpicture}[scale=2]
\coordinate [label=above right:Target] (A) at (0,0);
\coordinate [label=below left:Start] (B) at (2,1);
\draw[->, help lines] ([shift=(50:.8 and .3)] 1,.5) arc[start angle=50, delta angle=340, x radius=.8, y radius=.3];
\draw (B) rectangle (A)
  foreach \pos/\ang in {at start/90, very near start/90, near start/180, pos=.375/180,
                        midway/180, pos=.625/270, near end/0, very near end/0, at end/0}{
    node[dot nodes=\ang+180:\ang:\pos, style/.expanded=\pos]{}};
\end{tikzpicture}
\begin{tikzpicture}
    \draw[help lines]  (-2.25,-1.25) grid (2.25,3.25);
    \draw              ( 2,-1) parabola bend (0,0) (-1,3);
    \draw[ultra thick] (-2,-1) parabola bend (0,0) ( 1,3) [mark nodes online];
\end{tikzpicture}
\begin{tikzpicture}
    \draw[help lines] (-2.75,-2.75) grid (1.25, .75);
    \draw                      (-2,-2) parabola (1,0)
         foreach \pos in {0,1,...,10} {node[dot nodes=-18*\pos+90:-18*\pos+270:\pos, pos=\pos/10] {}};
\end{tikzpicture}
\begin{tikzpicture}
    \draw[help lines] (-2.1,-2.1) grid (2.1,0.1);
    \draw             (-2,-2) sin (1,0) [mark nodes online={1,...,9}];
    \draw[shift=(0:1)](-2,-2) cos (1,0) [mark nodes online={1,...,9}];
\end{tikzpicture}
\end{document}
```

**Output**
![test-0](https://user-images.githubusercontent.com/4043967/180487950-2d9b9c26-1d80-4ee0-8444-7693e26f25ca.png)
![test-1](https://user-images.githubusercontent.com/4043967/180487948-3e6eae80-f973-4211-a51e-12534cb173fd.png)
![test-2](https://user-images.githubusercontent.com/4043967/180487945-ad50e0f1-3d5e-4729-b807-4e8c4609df80.png)
![test-3](https://user-images.githubusercontent.com/4043967/180487941-b3e35b71-357f-4092-98bf-94e8458bcd52.png)

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html


