### PR TITLE
Calendar

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-library-calendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-calendar.tex
@@ -261,7 +261,7 @@ say, the |\draw| command).
 \end{codeexample}
     \end{key}
 
-    \begin{stylekey}{/tikz/every day (initially anchor=base east)}
+    \begin{stylekey}{/tikz/every day (initially {anchor=base east})}
         This style is executed by the default node code for each day. The
         |every day| style is useful for changing the way days look. For
         example, let us make all days red:
@@ -324,11 +324,21 @@ say, the |\draw| command).
         Works like |month text|, only for years.
     \end{key}
 
-
-    \begin{key}{/tikz/every year}
+    \begin{stylekey}{/tikz/every year}
         Works like |every month|, only for years.
+    \end{stylekey}
+
+    \begin{key}{/tikz/weeknumber code=\meta{code}}
+        Works like |month code|, only for week numbers.
     \end{key}
 
+    \begin{key}{/tikz/weeknumber text=\meta{text}}
+      Works like |month text|, only for week numbers.
+    \end{key}
+
+    \begin{stylekey}{/tikz/every weeknumber}}
+      Works like |every month|, only for week numbers.
+    \end{stylekey}
 
     \medskip
     \textbf{Date ifs.}
@@ -958,7 +968,7 @@ The following example is a futuristic calendar that is all about circles:
 
 Next, let's us have a whole year in a tight column:
 %
-\begin{codeexample}[preamble={\usetikzlibrary{calendar}}]
+\begin{codeexample}[leave comments,preamble={\usetikzlibrary{calendar}}]
 \begin{tikzpicture}
   \small\sffamily
   \colorlet{darkgreen}{green!50!black}

--- a/doc/generic/pgf/pgfmanual-en-library-calendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-calendar.tex
@@ -274,11 +274,11 @@ say, the |\draw| command).
 
 
     \medskip
-    \textbf{Changing the appearance of month and year labels.}
-    In addition to the days of a calendar, labels for the months and even years
+    \textbf{Changing the appearance of week, month and year labels.}
+    In addition to the days of a calendar, labels for the weeks, months and even years
     (for really long calendars) can be added. These labels are only added once
-    per month or year and this is not done by default. Rather, special styles
-    starting with |month label| place these labels and make them visible:
+    per week, month or year and this is not done by default. Rather, special styles
+    starting with |week label| or |month label| place these labels and make them visible:
     %
 \begin{codeexample}[preamble={\usetikzlibrary{calendar}}]
 \tikz \calendar[dates=2000-01-01 to 2000-02-last,week list,
@@ -328,16 +328,16 @@ say, the |\draw| command).
         Works like |every month|, only for years.
     \end{stylekey}
 
-    \begin{key}{/tikz/weeknumber code=\meta{code}}
-        Works like |month code|, only for week numbers.
+    \begin{key}{/tikz/week code=\meta{code}}
+        Works like |month code|, only for weeks.
     \end{key}
 
-    \begin{key}{/tikz/weeknumber text=\meta{text}}
-      Works like |month text|, only for week numbers.
+    \begin{key}{/tikz/week text=\meta{text}}
+      Works like |month text|, only for weeks.
     \end{key}
 
-    \begin{stylekey}{/tikz/every weeknumber}}
-      Works like |every month|, only for week numbers.
+    \begin{stylekey}{/tikz/every week}
+      Works like |every month|, only for weeks.
     \end{stylekey}
 
     \medskip
@@ -863,7 +863,21 @@ labels:
     %
 \end{stylekey}
 
-
+\begin{stylekey}{/tikz/week label left}
+    Places the week label to the left of the first day of the month. (For
+    |week list| and |month list| where a week does not start on a Monday, the
+    position is chosen ``as if'' the week had started on a Monday --  which is
+    usually exactly what you want.)
+    %
+\begin{codeexample}[preamble={\usetikzlibrary{calendar}}]
+\tikz
+  \calendar [week list, month label above centered,
+             dates=2022-07-01 to 2022-07-31,
+             week label left,
+             every week/.append style={gray!50!black,font=\sffamily}];
+\end{codeexample}
+    %
+\end{stylekey}
 \subsection{Examples}
 
 In the following, some example calendars are shown that come either from real

--- a/doc/generic/pgf/pgfmanual-en-library-calendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-calendar.tex
@@ -261,7 +261,7 @@ say, the |\draw| command).
 \end{codeexample}
     \end{key}
 
-    \begin{key}{/tikz/every day (initially anchor=base east)}
+    \begin{stylekey}{/tikz/every day (initially anchor=base east)}
         This style is executed by the default node code for each day. The
         |every day| style is useful for changing the way days look. For
         example, let us make all days red:
@@ -270,7 +270,7 @@ say, the |\draw| command).
 \tikz[every day/.style=red]
   \calendar[dates=2000-01-01 to 2000-01-31,week list];
 \end{codeexample}
-    \end{key}
+    \end{stylekey}
 
 
     \medskip
@@ -958,7 +958,7 @@ The following example is a futuristic calendar that is all about circles:
 
 Next, let's us have a whole year in a tight column:
 %
-\begin{codeexample}[leave comments,preamble={\usetikzlibrary{calendar}}]
+\begin{codeexample}[preamble={\usetikzlibrary{calendar}}]
 \begin{tikzpicture}
   \small\sffamily
   \colorlet{darkgreen}{green!50!black}

--- a/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
@@ -131,6 +131,14 @@ This section describes the package |pgfcalendar|.
     \pgfcalendarjuliantoweekday{2454115}{\mycount}\the\mycount\ (it was a Sunday).
 \end{command}
 
+\begin{command}{\pgfcalendarjulianyeartoweeknumber\marg{Julian day}\marg{year}\marg{week number counter}}
+    This command calculates the weeknumber for the Julian date of \mark{year}.
+    The \marg{week number counter} must be a \TeX\ counter.
+
+    The calculation follows the rule of ISO~8601 where the first week has that
+    year's first Thursday in it.
+\end{command}
+
 \begin{command}{\pgfcalendareastersunday\marg{year}\marg{counter}}
     This command computes the date of Easter Sunday as a Julian date and stores
     it in \meta{counter}.
@@ -170,9 +178,21 @@ This section describes the package |pgfcalendar|.
         \itemcalendaroption{Saturday} as above.
         \itemcalendaroption{Sunday} as above.
         \itemcalendaroption{workday} Passed by Mondays, Tuesdays, Wednesdays,
-            Thursdays, and Fridays. \itemcalendaroption{weekend} Passed by
-            Saturdays and Sundays.
-            \itemcalendaroption{equals}|=|\meta{reference} The \meta{reference}
+            Thursdays, and Fridays.
+        \itemcalendaroption{weekend} Passed by Saturdays and Sundays.
+        \itemcalendaroption{Jan} This test is passed by all dates are in the month of January.
+        \itemcalendaroption{Feb} as above.
+        \itemcalendaroption{Mar} as above.
+        \itemcalendaroption{Apr} as above.
+        \itemcalendaroption{May} as above.
+        \itemcalendaroption{Jun} as above.
+        \itemcalendaroption{Jul} as above.
+        \itemcalendaroption{Aug} as above.
+        \itemcalendaroption{Sep} as above.
+        \itemcalendaroption{Oct} as above.
+        \itemcalendaroption{Nov} as above.
+        \itemcalendaroption{Dec} as above.
+        \itemcalendaroption{equals}|=|\meta{reference} The \meta{reference}
             can be in one of two forms: Either, it is a full ISO format date
             like |2007-01-01| or the year may be missing as in |12-31|. In the
             first case, the test is passed if \meta{date} is the same as
@@ -216,6 +236,13 @@ This section describes the package |pgfcalendar|.
             by the date of Easter, these can be accessed as well, e.g.\
             |Easter=39| for Feast of the Ascension, |Easter=49| for Pentecost,
             and |Easter=50| for Whit Monday.
+        \itemcalendaroption{leap year}\opt{|=|\meta{year}}
+            This test checks whether the given year is a leap year. If
+            \meta{year} is omitted, it checks the year of the current \meta{date}.
+        \itemcalendaroption{and}|=|\marg{tests}
+            This test passes when all \meta{tests} pass.
+        \itemcalendaroptions{not}|=|\marg{tests}
+            This test passes when \meta{tests} does not pass.
     \end{itemize}
 
     In addition to the above checks, you can also define new checks. To do so,
@@ -452,8 +479,8 @@ package for more details.
 \begin{command}{\pgfcalendarshorthand\marg{kind}\marg{representation}}
 \label{pgfcalendarshorthand}
     This command can be used inside a |\pgfcalendar|, where it will expand to a
-    representation of the current day, month, year or day of week, depending on
-    whether \meta{kind} is |d|, |m|, |y| or |w|. The \meta{representation} can
+    representation of the current day, month, year, day of week or week number, depending on
+    whether \meta{kind} is |d|, |m|, |y|, |w| or |n|. The \meta{representation} can
     be one of the following: |-|, |=|, |0|, |.|, and |t|. They have the
     following meanings:
     %
@@ -465,7 +492,7 @@ package for more details.
             months (thereby ensuring that they have the same length as other
             days).
         \item The zero digit selects a two-digit numerical representation for
-            days and months. For years it is allowed, but has no effect.
+            days, months and week numbers. For years it is allowed, but has no effect.
         \item The letter |t| selects a textual representation.
         \item The dot selects an abbreviated textual representation.
     \end{itemize}
@@ -477,7 +504,7 @@ package for more details.
 \begin{codeexample}[leave comments,preamble={\usepackage{pgfcalendar}}]
 \let\%=\pgfcalendarshorthand
 \pgfcalendar{cal}{2007-01-20}{2007-01-20}
-{ ISO form: \%y0-\%m0-\%d0, long form: \%wt, \%mt \%d-, \%y0}
+{ ISO form: \%y0-\%m0-\%d0 (W\%n0), long form: \%wt, \%mt \%d-, \%y0, Week \%n-}
 \end{codeexample}
     %
 \end{command}

--- a/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
@@ -131,9 +131,9 @@ This section describes the package |pgfcalendar|.
     \pgfcalendarjuliantoweekday{2454115}{\mycount}\the\mycount\ (it was a Sunday).
 \end{command}
 
-\begin{command}{\pgfcalendarjulianyeartoweeknumber\marg{Julian day}\marg{year}\marg{week number counter}}
-    This command calculates the weeknumber for the Julian date of \mark{year}.
-    The \marg{week number counter} must be a \TeX\ counter.
+\begin{command}{\pgfcalendarjulianyeartoweek\marg{Julian day}\marg{year}\marg{week counter}}
+    This command calculates the week for the Julian date of \mark{year}.
+    The \marg{week counter} must be a \TeX\ counter.
 
     The calculation follows the rule of ISO~8601 where the first week has that
     year's first Thursday in it.
@@ -392,6 +392,8 @@ package for more details.
             two digits with a leading zero, if necessary).
         \item |\pgfcalendarcurrentday| The day of month of the current date
             (always two digits).
+        \item |\pgfcaelndarcurrentweek| The week of the current date (always
+            two digits).
     \end{itemize}
 
 
@@ -479,7 +481,7 @@ package for more details.
 \begin{command}{\pgfcalendarshorthand\marg{kind}\marg{representation}}
 \label{pgfcalendarshorthand}
     This command can be used inside a |\pgfcalendar|, where it will expand to a
-    representation of the current day, month, year, day of week or week number, depending on
+    representation of the current day, month, year, day of week or week, depending on
     whether \meta{kind} is |d|, |m|, |y|, |w| or |n|. The \meta{representation} can
     be one of the following: |-|, |=|, |0|, |.|, and |t|. They have the
     following meanings:
@@ -492,7 +494,7 @@ package for more details.
             months (thereby ensuring that they have the same length as other
             days).
         \item The zero digit selects a two-digit numerical representation for
-            days, months and week numbers. For years it is allowed, but has no effect.
+            days, months and weeks. For years it is allowed, but has no effect.
         \item The letter |t| selects a textual representation.
         \item The dot selects an abbreviated textual representation.
     \end{itemize}

--- a/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
@@ -392,7 +392,7 @@ package for more details.
             two digits with a leading zero, if necessary).
         \item |\pgfcalendarcurrentday| The day of month of the current date
             (always two digits).
-        \item |\pgfcaelndarcurrentweek| The week of the current date (always
+        \item |\pgfcalendarcurrentweek| The week of the current date (always
             two digits).
     \end{itemize}
 

--- a/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
@@ -180,7 +180,7 @@ This section describes the package |pgfcalendar|.
         \itemcalendaroption{workday} Passed by Mondays, Tuesdays, Wednesdays,
             Thursdays, and Fridays.
         \itemcalendaroption{weekend} Passed by Saturdays and Sundays.
-        \itemcalendaroption{Jan} This test is passed by all dates are in the month of January.
+        \itemcalendaroption{Jan} This test is passed by all dates that are in the month of January.
         \itemcalendaroption{Feb} as above.
         \itemcalendaroption{Mar} as above.
         \itemcalendaroption{Apr} as above.

--- a/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
@@ -241,7 +241,7 @@ This section describes the package |pgfcalendar|.
             \meta{year} is omitted, it checks the year of the current \meta{date}.
         \itemcalendaroption{and}|=|\marg{tests}
             This test passes when all \meta{tests} pass.
-        \itemcalendaroptions{not}|=|\marg{tests}
+        \itemcalendaroption{not}|=|\marg{tests}
             This test passes when \meta{tests} does not pass.
     \end{itemize}
 

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
@@ -78,17 +78,21 @@
 \def\tikzdaycode{\node[name=\pgfcalendarsuggestedname,every day]{\tikzdaytext};}
 \def\tikzmonthcode{\node[every month]{\tikzmonthtext};}
 \def\tikzyearcode{\node[every year]{\tikzyeartext};}
-\def\tikzweeknumbercode{\node[every weeknumber]{\tikzweeknumbertext};}
+\def\tikzweekcode{\node[every week]{\tikzweektext};}
 
 \def\tikzdaytext{\%d-}
 \def\tikzmonthtext{\%mt}
 \def\tikzyeartext{\%y0}
-\def\tikzweeknumbertext{\%n=}
+\def\tikzweektext{\%n=}
 
 \tikzset{
-  weeknumber code/.code=\def\tikzweeknumbercode{#1},
-  weeknumber text/.code=\def\tikzweeknumbertext{#1},
-  every weeknumber/.style=}
+  week code/.code=\def\tikzweekcode{#1},
+  week text/.code=\def\tikzweektext{#1},
+  every week/.style=,
+  week label left/.style={
+    every week/.append style={anchor=base east, xshift=-1.25*\pgfkeysvalueof{/tikz/day xshift}},
+    execute before day scope=%
+      \ifdate{Monday, equals=\pgfcalendarbeginiso}{\tikzweekcode}{}}}
 
 % Internal option for storing the "width" of a calendar as a number of
 % days

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
@@ -78,11 +78,17 @@
 \def\tikzdaycode{\node[name=\pgfcalendarsuggestedname,every day]{\tikzdaytext};}
 \def\tikzmonthcode{\node[every month]{\tikzmonthtext};}
 \def\tikzyearcode{\node[every year]{\tikzyeartext};}
+\def\tikzweeknumbercode{\node[every weeknumber]{\tikzweeknumbertext};}
 
 \def\tikzdaytext{\%d-}
 \def\tikzmonthtext{\%mt}
 \def\tikzyeartext{\%y0}
+\def\tikzweeknumbertext{\%n=}
 
+\tikzset{
+  weeknumber code/.code=\def\tikzweeknumbercode{#1},
+  weeknumber text/.code=\def\tikzweeknumbertext{#1},
+  every weeknumber/.style=}
 
 % Internal option for storing the "width" of a calendar as a number of
 % days
@@ -99,12 +105,12 @@
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
-        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/month yshift}}%
+        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@month@yshift}%
         \pgftransformyshift{-\pgf@y}
       }%
     }{}%
   },
-  execute after day scope={\pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}\pgftransformyshift{-\pgf@y}},
+  execute after day scope={\pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}\pgftransformyshift{-\pgf@y}},
   tikz@lib@cal@width=1
 }}
 \tikzset{day list upward/.style={%
@@ -116,7 +122,7 @@
       }%
     }{}%
   },
-  execute after day scope={\pgftransformyshift\pgfkeysvalueof{/tikz/day yshift}},
+  execute after day scope={\pgftransformyshift{\pgfkeysvalueof{/tikz/day yshift}}},
   tikz@lib@cal@width=1
 }}
 \tikzset{day list right/.style={%
@@ -128,7 +134,7 @@
       }%
     }{}%
   },
-  execute after day scope={\pgftransformxshift\pgfkeysvalueof{/tikz/day xshift}},
+  execute after day scope={\pgftransformxshift{\pgfkeysvalueof{/tikz/day xshift}},
   tikz@lib@cal@width=30% not quite right, but close enough in most cases...
 }}
 
@@ -405,7 +411,13 @@ execute before day scope={\ifdate{day of month=1}{%
   \pgfutil@ifnextchar[{\tikz@lib@cal@if@else@opt{#1}{#2}}{\tikz@lib@cal@if@else@code{#1}{#2}}}%}
 \def\tikz@lib@cal@if@else@opt#1#2[#3]{\tikz@lib@cal@if@else@code{#1}{#2}{\tikzset{#3}}}
 \def\tikz@lib@cal@if@else@code#1#2#3{%
-  \expandafter\def\expandafter\tikz@lib@cal@ifs\expandafter{\tikz@lib@cal@ifs\ifdate{#1}{#2}{#3}}%
+  \iftikz@lib@cal@exec@direct
+    \expandafter\pgfutil@secondoftwo
+  \else
+    \expandafter\pgfutil@firstoftwo
+  \fi
+  {\expandafter\def\expandafter\tikz@lib@cal@ifs\expandafter{\tikz@lib@cal@ifs\ifdate{#1}{#2}{#3}}}%
+  {\ifdate{#1}{#2}{#3}}%
   \tikz@lib@cal@scanner%
 }
 \def\tikz@lib@cal@stop{%
@@ -415,6 +427,7 @@ execute before day scope={\ifdate{day of month=1}{%
       \tikz@before@day%
       \scope%
         \tikz@atbegin@day%
+        \tikz@lib@cal@exec@directtrue
         \tikz@lib@cal@ifs%
         \tikzdaycode%
         \tikz@atend@day%
@@ -430,6 +443,6 @@ execute before day scope={\ifdate{day of month=1}{%
   \tikz@lib@cal@if f#1\relax%
   \let\tikz@lib@cal@scanner=\tikz@lib@cal@scanner@orig}
 
-
+\newif\iftikz@lib@cal@exec@direct
 
 \endinput

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
@@ -101,20 +101,20 @@
 %
 
 \tikzset{day list downward/.style={%
-  execute before day scope={
+  execute before day scope={%
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@month@yshift}%
-        \pgftransformyshift{-\pgf@y}
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/month yshift}}%
+        \pgftransformyshift{-\pgf@y}%
       }%
     }{}%
   },
-  execute after day scope={\pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}\pgftransformyshift{-\pgf@y}},
+  execute after day scope={\pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}\pgftransformyshift{-\pgf@y}},
   tikz@lib@cal@width=1
 }}
 \tikzset{day list upward/.style={%
-  execute before day scope={
+  execute before day scope={%
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
@@ -126,7 +126,7 @@
   tikz@lib@cal@width=1
 }}
 \tikzset{day list right/.style={%
-  execute before day scope={
+  execute before day scope={%
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
@@ -134,12 +134,12 @@
       }%
     }{}%
   },
-  execute after day scope={\pgftransformxshift{\pgfkeysvalueof{/tikz/day xshift}},
+  execute after day scope=\pgftransformxshift{\pgfkeysvalueof{/tikz/day xshift}},
   tikz@lib@cal@width=30% not quite right, but close enough in most cases...
 }}
 
 \tikzset{day list left/.style={%
-  execute before day scope={
+  execute before day scope={%
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
@@ -148,8 +148,8 @@
       }%
     }{}%
   },
-  execute after day scope={
-    \pgfmathsetlength{\pgf@x}{\pgfkeysvalueof{/tikz/day xshift}}
+  execute after day scope={%
+    \pgfmathsetlength{\pgf@x}{\pgfkeysvalueof{/tikz/day xshift}}%
     \pgftransformxshift{-\pgf@x}%
   },
   tikz@lib@cal@width=30% not quite right, but close enough in most cases...
@@ -167,7 +167,7 @@
       {%
         % On first of month, except when first date in calendar.
         \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/month yshift}}%
-        \pgftransformyshift{-\pgf@y}
+        \pgftransformyshift{-\pgf@y}%
       }%
     }{}%
   },
@@ -179,7 +179,7 @@
   execute after day scope={%
     \ifdate{Sunday}{%
       \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
-      \pgftransformyshift{-\pgf@y}
+      \pgftransformyshift{-\pgf@y}%
     }{}%
   },
   tikz@lib@cal@width=7
@@ -197,7 +197,7 @@
       {%
         % On first of month, except when first date in calendar.
         \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/month yshift}}%
-        \pgftransformyshift{-\pgf@y}
+        \pgftransformyshift{-\pgf@y}%
       }%
     }{}%
     \ifdate{day of month=1}
@@ -269,7 +269,7 @@ execute before day scope={\ifdate{day of month=1}{%
 \tikzset{month label above centered/.style={%
   execute before day scope={%
     \ifdate{day of month=1}{%
-      {
+      {%
         \pgfmathsetlength{\pgf@xa}{\pgfkeysvalueof{/tikz/day xshift}}%
         \pgf@xb=\pgfkeysvalueof{/tikz/tikz@lib@cal@width}\pgf@xa%
         \advance\pgf@xb by-\pgf@xa%
@@ -277,9 +277,9 @@ execute before day scope={\ifdate{day of month=1}{%
         \pgftransformxshift{\pgf@xb}%
         \pgftransformxshift{-1.5ex}%
         \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
-        \pgftransformyshift{1.25\pgf@y}
+        \pgftransformyshift{1.25\pgf@y}%
         \tikzmonthcode%
-      }
+      }%
     }{}},
   every month/.append style={anchor=base}
 }}
@@ -287,12 +287,12 @@ execute before day scope={\ifdate{day of month=1}{%
 \tikzset{month label above left/.style={%
   execute before day scope={%
     \ifdate{day of month=1}{%
-      {
+      {%
         \pgftransformxshift{-3.25ex}%
         \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
-        \pgftransformyshift{1.25\pgf@y}
+        \pgftransformyshift{1.25\pgf@y}%
         \tikzmonthcode%
-      }
+      }%
     }{}},
   every month/.append style={anchor=base west}
 }}
@@ -302,7 +302,7 @@ execute before day scope={\ifdate{day of month=1}{%
 \tikzset{month label above right/.style={%
   execute before day scope={%
     \ifdate{day of month=1}{%
-      {
+      {%
         \pgfmathsetlength{\pgf@xa}{\pgfkeysvalueof{/tikz/day xshift}}%
         \pgf@xb=\pgfkeysvalueof{/tikz/tikz@lib@cal@width}\pgf@xa%
         \advance\pgf@xb by-\pgf@xa%
@@ -310,7 +310,7 @@ execute before day scope={\ifdate{day of month=1}{%
         \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
         \pgftransformyshift{1.25\pgf@y}
         \tikzmonthcode%
-      }
+      }%
     }{}},
   every month/.append style={anchor=base east}
 }}
@@ -318,7 +318,7 @@ execute before day scope={\ifdate{day of month=1}{%
 \tikzset{month label below centered/.style={%
   execute before day scope={%
     \ifdate{day of month=1}{%
-      {
+      {%
         \pgfmathsetlength{\pgf@xa}{\pgfkeysvalueof{/tikz/day xshift}}%
         \pgf@xb=\pgfkeysvalueof{/tikz/tikz@lib@cal@width}\pgf@xa%
         \advance\pgf@xb by-\pgf@xa%
@@ -326,9 +326,9 @@ execute before day scope={\ifdate{day of month=1}{%
         \pgftransformxshift{\pgf@xb}%
         \pgftransformxshift{-1.5ex}%
         \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
-        \pgftransformyshift{-1.25\pgf@y}
+        \pgftransformyshift{-1.25\pgf@y}%
         \tikzmonthcode%
-      }
+      }%
     }{}},
   every month/.append style={anchor=base}
 }}
@@ -336,12 +336,12 @@ execute before day scope={\ifdate{day of month=1}{%
 \tikzset{month label below left/.style={%
   execute before day scope={%
     \ifdate{day of month=1}{%
-      {
+      {%
         \pgftransformxshift{-3.25ex}%
         \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
         \pgftransformyshift{-1.25\pgf@y}
         \tikzmonthcode%
-      }
+      }%
     }{}},
   every month/.append style={anchor=base west}
 }}

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/tikzlibrarycalendar.code.tex
@@ -50,23 +50,15 @@
 
 % Shift between days
 
-\tikzoption{day xshift}{\def\tikz@lib@cal@xshift{#1}}
-\tikzoption{day yshift}{\def\tikz@lib@cal@yshift{#1}}
-
-\def\tikz@lib@cal@yshift{3ex}
-\def\tikz@lib@cal@xshift{3.5ex}
-
+\def\tikz@lib@cal@xshift{\pgfkeysvalueof{/tikz/day xshift}}
+\def\tikz@lib@cal@yshift{\pgfkeysvalueof{/tikz/day yshift}}
+\tikzset{day xshift/.initial=3ex,day yshift/.initial=3.5ex}
 
 % Shift between months
 
-\tikzoption{month xshift}{\def\tikz@lib@cal@month@xshift{#1}}
-\tikzoption{month yshift}{\def\tikz@lib@cal@month@yshift{#1}}
-
-\def\tikz@lib@cal@month@yshift{9ex}
-\def\tikz@lib@cal@month@xshift{9ex}
-
-
-
+\def\tikz@lib@cal@month@xshift{\pgfkeysvalueof{/tikz/month xshift}}
+\def\tikz@lib@cal@month@yshift{\pgfkeysvalueof{/tikz/month yshift}}
+\tikzset{month xshift/.initial=9ex,month yshift/.initial=9ex}
 
 % Templates for typesetting days, month, years
 
@@ -95,9 +87,8 @@
 % Internal option for storing the "width" of a calendar as a number of
 % days
 
-\tikzoption{tikz@lib@cal@width}{\def\tikz@lib@cal@width{#1}}
-
-\def\tikz@lib@cal@width{1}
+\def\tikz@lib@cal@width{\pgfkeysvalueof{/tikz/tikz@lib@cal@width}}
+\tikzset{tikz@lib@cal@width/.initial=1}
 
 %
 % Days on a line
@@ -108,12 +99,12 @@
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@month@yshift}%
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/month yshift}}%
         \pgftransformyshift{-\pgf@y}
       }%
     }{}%
   },
-  execute after day scope={\pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}\pgftransformyshift{-\pgf@y}},
+  execute after day scope={\pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}\pgftransformyshift{-\pgf@y}},
   tikz@lib@cal@width=1
 }}
 \tikzset{day list upward/.style={%
@@ -121,11 +112,11 @@
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
-        \pgftransformyshift{\tikz@lib@cal@month@yshift}%
+        \pgftransformyshift{\pgfkeysvalueof{/tikz/month yshift}}%
       }%
     }{}%
   },
-  execute after day scope={\pgftransformyshift\tikz@lib@cal@yshift},
+  execute after day scope={\pgftransformyshift\pgfkeysvalueof{/tikz/day yshift}},
   tikz@lib@cal@width=1
 }}
 \tikzset{day list right/.style={%
@@ -133,11 +124,11 @@
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
-        \pgftransformxshift{\tikz@lib@cal@month@xshift}%
+        \pgftransformxshift{\pgfkeysvalueof{/tikz/month xshift}}%
       }%
     }{}%
   },
-  execute after day scope={\pgftransformxshift\tikz@lib@cal@xshift},
+  execute after day scope={\pgftransformxshift\pgfkeysvalueof{/tikz/day xshift}},
   tikz@lib@cal@width=30% not quite right, but close enough in most cases...
 }}
 
@@ -146,13 +137,13 @@
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
-        \pgfmathsetlength{\pgf@x}{\tikz@lib@cal@month@xshift}
+        \pgfmathsetlength{\pgf@x}{\pgfkeysvalueof{/tikz/month xshift}}
         \pgftransformxshift{-\pgf@x}%
       }%
     }{}%
   },
   execute after day scope={
-    \pgfmathsetlength{\pgf@x}{\tikz@lib@cal@xshift}
+    \pgfmathsetlength{\pgf@x}{\pgfkeysvalueof{/tikz/day xshift}}
     \pgftransformxshift{-\pgf@x}%
   },
   tikz@lib@cal@width=30% not quite right, but close enough in most cases...
@@ -169,19 +160,19 @@
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@month@yshift}%
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/month yshift}}%
         \pgftransformyshift{-\pgf@y}
       }%
     }{}%
   },
   execute at begin day scope={%
-    \pgfmathsetlength\pgf@x{\tikz@lib@cal@xshift}%
+    \pgfmathsetlength\pgf@x{\pgfkeysvalueof{/tikz/day xshift}}%
     \pgf@x=\pgfcalendarcurrentweekday\pgf@x%
     \pgftransformxshift{\pgf@x}%
   },
   execute after day scope={%
     \ifdate{Sunday}{%
-      \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}%
+      \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
       \pgftransformyshift{-\pgf@y}
     }{}%
   },
@@ -199,7 +190,7 @@
     \ifdate{day of month=1}{\ifdate{equals=\pgfcalendarbeginiso}{}
       {%
         % On first of month, except when first date in calendar.
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@month@yshift}%
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/month yshift}}%
         \pgftransformyshift{-\pgf@y}
       }%
     }{}%
@@ -221,7 +212,7 @@
     }{}%
   },
   execute at begin day scope={%
-    \pgfmathsetlength\pgf@xa{\tikz@lib@cal@xshift}%
+    \pgfmathsetlength\pgf@xa{\pgfkeysvalueof{/tikz/day xshift}}%
     \pgf@xb=\pgfcalendarcurrentday\pgf@xa%
     \advance\pgf@xb by\tikz@lib@cal@month@list@start\pgf@xa%
     \advance\pgf@xb by-\pgf@xa\relax%
@@ -250,8 +241,8 @@
 \tikzset{month label right/.style={%
 execute before day scope={\ifdate{day of month=1}{%
     {%
-      \pgfmathsetlength{\pgf@xa}{\tikz@lib@cal@xshift}%
-      \pgftransformxshift{\tikz@lib@cal@width\pgf@xa}%
+      \pgfmathsetlength{\pgf@xa}{\pgfkeysvalueof{/tikz/day xshift}}%
+      \pgftransformxshift{\pgfkeysvalueof{/tikz/tikz@lib@cal@width}\pgf@xa}%
       \pgftransformxshift{-\pgf@xa}%
       \tikzmonthcode%
     }}{}},
@@ -261,8 +252,8 @@ execute before day scope={\ifdate{day of month=1}{%
 \tikzset{month label right vertical/.style={%
   execute before day scope={\ifdate{day of month=1}{%
     {%
-      \pgfmathsetlength{\pgf@xa}{\tikz@lib@cal@xshift}%
-      \pgftransformxshift{\tikz@lib@cal@width\pgf@xa}%
+      \pgfmathsetlength{\pgf@xa}{\pgfkeysvalueof{/tikz/day xshift}}%
+      \pgftransformxshift{\pgfkeysvalueof{/tikz/tikz@lib@cal@width}\pgf@xa}%
       \pgftransformxshift{-\pgf@xa}%
       \tikzmonthcode%
     }}{}},
@@ -273,13 +264,13 @@ execute before day scope={\ifdate{day of month=1}{%
   execute before day scope={%
     \ifdate{day of month=1}{%
       {
-        \pgfmathsetlength{\pgf@xa}{\tikz@lib@cal@xshift}%
-        \pgf@xb=\tikz@lib@cal@width\pgf@xa%
+        \pgfmathsetlength{\pgf@xa}{\pgfkeysvalueof{/tikz/day xshift}}%
+        \pgf@xb=\pgfkeysvalueof{/tikz/tikz@lib@cal@width}\pgf@xa%
         \advance\pgf@xb by-\pgf@xa%
         \pgf@xb=.5\pgf@xb%
         \pgftransformxshift{\pgf@xb}%
         \pgftransformxshift{-1.5ex}%
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}%
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
         \pgftransformyshift{1.25\pgf@y}
         \tikzmonthcode%
       }
@@ -292,7 +283,7 @@ execute before day scope={\ifdate{day of month=1}{%
     \ifdate{day of month=1}{%
       {
         \pgftransformxshift{-3.25ex}%
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}%
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
         \pgftransformyshift{1.25\pgf@y}
         \tikzmonthcode%
       }
@@ -306,11 +297,11 @@ execute before day scope={\ifdate{day of month=1}{%
   execute before day scope={%
     \ifdate{day of month=1}{%
       {
-        \pgfmathsetlength{\pgf@xa}{\tikz@lib@cal@xshift}%
-        \pgf@xb=\tikz@lib@cal@width\pgf@xa%
+        \pgfmathsetlength{\pgf@xa}{\pgfkeysvalueof{/tikz/day xshift}}%
+        \pgf@xb=\pgfkeysvalueof{/tikz/tikz@lib@cal@width}\pgf@xa%
         \advance\pgf@xb by-\pgf@xa%
         \pgftransformxshift{\pgf@xb}%
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}%
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
         \pgftransformyshift{1.25\pgf@y}
         \tikzmonthcode%
       }
@@ -322,13 +313,13 @@ execute before day scope={\ifdate{day of month=1}{%
   execute before day scope={%
     \ifdate{day of month=1}{%
       {
-        \pgfmathsetlength{\pgf@xa}{\tikz@lib@cal@xshift}%
-        \pgf@xb=\tikz@lib@cal@width\pgf@xa%
+        \pgfmathsetlength{\pgf@xa}{\pgfkeysvalueof{/tikz/day xshift}}%
+        \pgf@xb=\pgfkeysvalueof{/tikz/tikz@lib@cal@width}\pgf@xa%
         \advance\pgf@xb by-\pgf@xa%
         \pgf@xb=.5\pgf@xb%
         \pgftransformxshift{\pgf@xb}%
         \pgftransformxshift{-1.5ex}%
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}%
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
         \pgftransformyshift{-1.25\pgf@y}
         \tikzmonthcode%
       }
@@ -341,7 +332,7 @@ execute before day scope={\ifdate{day of month=1}{%
     \ifdate{day of month=1}{%
       {
         \pgftransformxshift{-3.25ex}%
-        \pgfmathsetlength{\pgf@y}{\tikz@lib@cal@yshift}%
+        \pgfmathsetlength{\pgf@y}{\pgfkeysvalueof{/tikz/day yshift}}%
         \pgftransformyshift{-1.25\pgf@y}
         \tikzmonthcode%
       }

--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -128,8 +128,8 @@
         {\pgfcalendarcurrentyear}{\pgfcalendarcurrentmonth}{\pgfcalendarcurrentday}%
       \pgfcalendarjuliantoweekday{\pgfcalendarcurrentjulian}{\pgfutil@tempcntb}%
       \edef\pgfcalendarcurrentweekday{\the\pgfutil@tempcntb}%
-      \pgfcalendarjulianyeartoweeknumber{\pgfcalendarcurrentjulian}{\pgfcalendarcurrentyear}{\pgfutil@tempcntb}%
-      \edef\pgfcalendarcurrentweeknumber{\ifnum\pgfutil@tempcntb<10 0\fi\the\pgfutil@tempcntb}%
+      \pgfcalendarjulianyeartoweek{\pgfcalendarcurrentjulian}{\pgfcalendarcurrentyear}{\pgfutil@tempcntb}%
+      \edef\pgfcalendarcurrentweek{\ifnum\pgfutil@tempcntb<10 0\fi\the\pgfutil@tempcntb}%
       % Render:
       #4%
       % Advance day:
@@ -146,7 +146,7 @@
   \let\pgfcalendarifdatemonth=\pgfcalendarcurrentmonth
   \let\pgfcalendarifdateday=\pgfcalendarcurrentday
   \let\pgfcalendarifdateweekday=\pgfcalendarcurrentweekday
-  \let\pgfcalendarifdateweeknumber=\pgfcalendarcurrentweeknumber
+  \let\pgfcalendarifdateweek=\pgfcalendarcurrentweek
   \pgfcalendar@launch@ifdate%
 }
 
@@ -207,8 +207,8 @@
   % Compute info about date
   \pgfcalendarjuliantoweekday{\pgfutil@tempcnta}{\pgfutil@tempcntb}%
   \edef\pgfcalendarifdateweekday{\the\pgfutil@tempcntb}%
-  \pgfcalendarjulianyeartoweeknumber{\pgfutil@tempcnta}{\pgfcalendarifdateyear}{\pgfutil@tempcntb}%
-  \edef\pgfcalendarifdateweeknumber{\the\pgfutil@tempcntb}%
+  \pgfcalendarjulianyeartoweek{\pgfutil@tempcnta}{\pgfcalendarifdateyear}{\pgfutil@tempcntb}%
+  \edef\pgfcalendarifdateweek{\the\pgfutil@tempcntb}%
   %
   \pgfcalendar@launch@ifdate{#2}{#3}{#4}%
 }
@@ -868,14 +868,14 @@
 }
 
 %
-% Weeknumbers
+% Weeks
 %
 % stored the Monday of week 1 of the year #1 as julian date number
 % and the weekday of the first of the year in a macro called
-% \pgfcalendar@weeknumber@<year> so that calculations are only done
+% \pgfcalendar@week@<year> so that calculations are only done
 % once per year
-\def\pgfcalendar@weeknumber@setup#1{%
-  \pgfutil@IfUndefined{pgfcalendar@weeknumber@#1}{%
+\def\pgfcalendar@week@setup#1{%
+  \pgfutil@IfUndefined{pgfcalendar@week@#1}{%
     \begingroup
       \pgfcalendardatetojulian{#1-01-01}\pgfutil@tempcnta
       \pgfcalendarjuliantoweekday\pgfutil@tempcnta\pgfutil@tempcntb
@@ -893,42 +893,42 @@
         \advance\pgfutil@tempcnta by 7\relax
       \fi
       %
-      \edef\pgf@cal@temp{\def\expandafter\noexpand\csname pgfcalendar@weeknumber@#1\endcsname
+      \edef\pgf@cal@temp{\def\expandafter\noexpand\csname pgfcalendar@week@#1\endcsname
         {{\the\pgfutil@tempcnta}{\the\pgfutil@tempcntb}}}%
       \expandafter\endgroup\pgf@cal@temp
   }{}%
 }
 
-% Will store the weeknumber of the Julian date count #1 of year #2 in count #3
-\def\pgfcalendarjulianyeartoweeknumber#1#2#3{\pgfcalendarjulianyeartoweeknumber@#1{#2}#3\iftrue}
+% Will store the week of the Julian date count #1 of year #2 in count #3
+\def\pgfcalendarjulianyeartoweek#1#2#3{\pgfcalendarjulianyeartoweek@#1{#2}#3\iftrue}
 
 % #1 = julian date (count)
 % #2 = year
-% #3 = count that holds the week number at the end
+% #3 = count that holds the week at the end
 % #4 = \iftrue or \iffalse: whether week 53 needs to be checked (\iffalse when determing week from next year)
-\def\pgfcalendarjulianyeartoweeknumber@#1#2#3#4{%
+\def\pgfcalendarjulianyeartoweek@#1#2#3#4{%
   \begingroup
-    \pgfcalendar@weeknumber@setup{#2}%
+    \pgfcalendar@week@setup{#2}%
     #3=#1\relax
     %
-    % calculate difference of days between current date and start of week number 1
+    % calculate difference of days between current date and start of week 1
     %
-    \advance#3 by -\expandafter\expandafter\expandafter\pgfutil@firstoftwo\csname pgfcalendar@weeknumber@#2\endcsname\relax
+    \advance#3 by -\expandafter\expandafter\expandafter\pgfutil@firstoftwo\csname pgfcalendar@week@#2\endcsname\relax
     \ifnum#3<0\relax % whoops, we are in the week of the previous year
       \expandafter\pgfutil@firstoftwo
     \else
       \expandafter\pgfutil@secondoftwo
     \fi
     {% if first day of the year is Fri, Sat or Sun
-      \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname>3\relax
+      \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@week@#2\endcsname>3\relax
         \expandafter\pgfutil@firstoftwo
       \else
         \expandafter\pgfutil@secondoftwo
       \fi
-      {% we need to check the weeknumber of the previous
+      {% we need to check the week of the previous
         #3=#2\relax
         \advance#3 by -1
-        \edef\pgf@cal@temp{\noexpand\pgfcalendarjulianyeartoweeknumber@#1{\the#3}#3\noexpand\iffalse}%
+        \edef\pgf@cal@temp{\noexpand\pgfcalendarjulianyeartoweek@#1{\the#3}#3\noexpand\iffalse}%
         \pgf@cal@temp
       }{% yeah, it's weird
         \divide#3 by 7
@@ -953,8 +953,8 @@
             % option 1: check whether we're already in week 1 of the next year
             #3=#2\relax
             \advance#3 by 1
-            \expandafter\pgfcalendar@weeknumber@setup\expandafter{\the#3}%
-            \ifnum#1<\expandafter\expandafter\expandafter\pgfutil@firstoftwo\csname pgfcalendar@weeknumber@\the#3\endcsname\relax
+            \expandafter\pgfcalendar@week@setup\expandafter{\the#3}%
+            \ifnum#1<\expandafter\expandafter\expandafter\pgfutil@firstoftwo\csname pgfcalendar@week@\the#3\endcsname\relax
               #3=53
             \else
               #3=1
@@ -962,7 +962,7 @@
             % option 2: check whether this year starts on Thursday [common/leap]
             %           or ends on a Thursday (= starts on a Wednesday) [leap]
             %   % if year starts with a Thursday (3) it has week 53
-            %   \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=3
+            %   \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@week@#2\endcsname=3
             %   \else
             %     \pgfcalendarmatchesfalse
             %     \pgfkeys{/pgf/calendar/leap year=#2}%
@@ -972,7 +972,7 @@
             %       \expandafter\pgfutil@secondoftwo
             %     \fi
             %     {% leap year that didn't start on a Thursday but maybe it started on a Wednesday
-            %       \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=2 \else
+            %       \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@week@#2\endcsname=2 \else
             %         #3=1
             %       \fi
             %     }{% not a leap year, and didn't start/end on a Thursday, must be week 1 of next year
@@ -989,20 +989,20 @@
 }
 
 %
-% shorthands for weeknumbers (n)
+% shorthands for weeks (n)
 %
 % n-: shortest
 % n=: shortest but prepends whitespace
 % n0: leading zero
 %
 \expandafter\def\csname pgfcalendar@shorthand@n-\endcsname{%
-  {\pgfutil@tempcnta=\pgfcalendarcurrentweeknumber\relax\the\pgfutil@tempcnta}}
+  {\pgfutil@tempcnta=\pgfcalendarcurrentweek\relax\the\pgfutil@tempcnta}}
 \expandafter\def\csname pgfcalendar@shorthand@n=\endcsname{%
-  {\pgfutil@tempcnta=\pgfcalendarcurrentweeknumber\relax\ifnum\pgfutil@tempcnta<10\relax\setbox0=\hbox{1}\kern\wd0\relax\fi\the\pgfutil@tempcnta}}
+  {\pgfutil@tempcnta=\pgfcalendarcurrentweek\relax\ifnum\pgfutil@tempcnta<10\relax\setbox0=\hbox{1}\kern\wd0\relax\fi\the\pgfutil@tempcnta}}
 \expandafter\def\csname pgfcalendar@shorthand@n0\endcsname{%
-  \pgfcalendarcurrentweeknumber}
+  \pgfcalendarcurrentweek}
 
-% test for week number
-\pgfqkeys{/pgf/calendar/week number}{.value required,.code={\ifnum#1=\pgfcalendarifdateweeknumber\relax\pgfcalendarmatchestrue\fi}}
+% test for week
+\pgfqkeys{/pgf/calendar/week}{.value required,.code={\ifnum#1=\pgfcalendarifdateweek\relax\pgfcalendarmatchestrue\fi}}
 
 \endinput

--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -125,9 +125,11 @@
     \ifnum\pgfcalendarcurrentjulian<\pgfcalendarendjulianplus\relax%
       % Setup information about current date
       \pgfcalendarjuliantodate{\pgfcalendarcurrentjulian}%
-      {\pgfcalendarcurrentyear}{\pgfcalendarcurrentmonth}{\pgfcalendarcurrentday}%
+        {\pgfcalendarcurrentyear}{\pgfcalendarcurrentmonth}{\pgfcalendarcurrentday}%
       \pgfcalendarjuliantoweekday{\pgfcalendarcurrentjulian}{\pgfutil@tempcntb}%
       \edef\pgfcalendarcurrentweekday{\the\pgfutil@tempcntb}%
+      \pgfcalendarjulianyeartoweeknumber{\pgfcalendarcurrentjulian}{\pgfcalendarcurrentyear}{\pgfutil@tempcntb}%
+      \edef\pgfcalendarcurrentweeknumber{\ifnum\pgfutil@tempcntb<10 0\fi\the\pgfutil@tempcntb}%
       % Render:
       #4%
       % Advance day:
@@ -139,11 +141,12 @@
 \newcount\pgfcalendarcurrentjulian
 
 \def\pgfcalendar@local@ifdate{%
-  \let\pgfcalendarifdatejulian=\pgfcalendarcurrentjulian%
-  \let\pgfcalendarifdateyear=\pgfcalendarcurrentyear%
-  \let\pgfcalendarifdatemonth=\pgfcalendarcurrentmonth%
-  \let\pgfcalendarifdateday=\pgfcalendarcurrentday%
-  \let\pgfcalendarifdateweekday=\pgfcalendarcurrentweekday%
+  \let\pgfcalendarifdatejulian=\pgfcalendarcurrentjulian
+  \let\pgfcalendarifdateyear=\pgfcalendarcurrentyear
+  \let\pgfcalendarifdatemonth=\pgfcalendarcurrentmonth
+  \let\pgfcalendarifdateday=\pgfcalendarcurrentday
+  \let\pgfcalendarifdateweekday=\pgfcalendarcurrentweekday
+  \let\pgfcalendarifdateweeknumber=\pgfcalendarcurrentweeknumber
   \pgfcalendar@launch@ifdate%
 }
 
@@ -797,5 +800,197 @@
   \fi}%
 }
 
+%
+% more tests
+%
+\pgfqkeys{/pgf/calendar}{
+  Jan/.code={\ifnum\pgfcalendarifdatemonth=1\pgfcalendarmatchestrue\fi},Jan/.value forbidden,
+  Feb/.code={\ifnum\pgfcalendarifdatemonth=2\pgfcalendarmatchestrue\fi},Feb/.value forbidden,
+  Mar/.code={\ifnum\pgfcalendarifdatemonth=3\pgfcalendarmatchestrue\fi},Mar/.value forbidden,
+  Apr/.code={\ifnum\pgfcalendarifdatemonth=4\pgfcalendarmatchestrue\fi},Apr/.value forbidden,
+  May/.code={\ifnum\pgfcalendarifdatemonth=5\pgfcalendarmatchestrue\fi},May/.value forbidden,
+  Jun/.code={\ifnum\pgfcalendarifdatemonth=6\pgfcalendarmatchestrue\fi},Jun/.value forbidden,
+  Jul/.code={\ifnum\pgfcalendarifdatemonth=7\pgfcalendarmatchestrue\fi},Jul/.value forbidden,
+  Aug/.code={\ifnum\pgfcalendarifdatemonth=8\pgfcalendarmatchestrue\fi},Aug/.value forbidden,
+  Sep/.code={\ifnum\pgfcalendarifdatemonth=9\pgfcalendarmatchestrue\fi},Sep/.value forbidden,
+  Oct/.code={\ifnum\pgfcalendarifdatemonth=10\pgfcalendarmatchestrue\fi},Oct/.value forbidden,
+  Nov/.code={\ifnum\pgfcalendarifdatemonth=11\pgfcalendarmatchestrue\fi},Nov/.value forbidden,
+  Dec/.code={\ifnum\pgfcalendarifdatemonth=12\pgfcalendarmatchestrue\fi},Dez/.value forbidden,
+  leap year/.code={%
+    \pgfutil@tempcnta=#1\relax
+    \divide\pgfutil@tempcnta4
+    \multiply\pgfutil@tempcnta4
+    \ifnum\pgfutil@tempcnta=#1\relax
+      \divide\pgfutil@tempcnta100
+      \multiply\pgfutil@tempcnta100
+      \ifnum\pgfutil@tempcnta=#1\relax
+        \divide\pgfutil@tempcnta400
+        \multiply\pgfutil@tempcnta400
+        \ifnum\pgfutil@tempcnta=#1\relax
+          \pgfcalendarmatchestrue
+        \fi
+      \else
+        \pgfcalendarmatchestrue
+      \fi
+    \fi},
+  leap year/.default=\pgfcalendarifdateyear,
+  not/.code=% true when #1 == false
+    \begingroup
+      \pgfcalendar@launch@ifdate{#1}{\let\pgf@cal@temp\pgfutil@empty}{\def\pgf@cal@temp{\pgfcalendarmatchestrue}}%
+    \expandafter\endgroup\pgf@cal@temp,
+  and/.value required,
+  and/.code=% and = {<cond 1>, <cond 2>, <cond 3>, …}
+    \begingroup
+      \pgfcalendarmatchestrue
+      \pgfqkeys{/pgf/calendar/and}{#1}%
+      \ifpgfcalendarmatches % is it still true?
+        \expandafter\pgfutil@firstoftwo
+      \else
+        \expandafter\pgfutil@secondoftwo
+      \fi
+      {\def\pgf@cal@temp{\pgfcalendarmatchestrue}}%
+      {\let\pgf@cal@temp\pgfutil@empty}%
+    \expandafter\endgroup\pgf@cal@temp,
+  and/.unknown/.code=% only inside the group of and/.code
+    \ifpgfcalendarmatches
+      \expandafter\pgfutil@firstofone
+    \else
+      \expandafter\pgfutil@gobble
+    \fi
+    {%
+      \begingroup
+        \pgfcalendar@launch@ifdate{\pgfkeyscurrentname={#1}}%
+        {\let\pgf@cal@temp\pgfutil@empty}{\def\pgf@cal@temp{\pgfcalendarmatchesfalse}}
+      \expandafter\endgroup\pgf@cal@temp
+    }%
+}
 
+%
+% Weeknumbers
+%
+% stored the Monday of week 1 of the year #1 as julian date number
+% and the weekday of the first of the year in a macro called
+% \pgfcalendar@weeknumber@<year> so that calculations are only done
+% once per year
+\def\pgfcalendar@weeknumber@setup#1{%
+  \pgfutil@IfUndefined{pgfcalendar@weeknumber@#1}{%
+    \begingroup
+      \pgfcalendardatetojulian{#1-01-01}\pgfutil@tempcnta
+      \pgfcalendarjuliantoweekday\pgfutil@tempcnta\pgfutil@tempcntb
+      %
+      % tempcnta holds the julian number for first day of the current year
+      % tempcntb holds the weekday for the first day of the current year
+      %
+      % set tempcnta to the Monday of the week with first day of current year
+      %
+      \advance\pgfutil@tempcnta by -\pgfutil@tempcntb
+      %
+      % if the first week starts at Fri, Sat or Sun, next week is the 1st week
+      %
+      \ifnum\pgfutil@tempcntb>3\relax
+        \advance\pgfutil@tempcnta by 7\relax
+      \fi
+      %
+      \edef\pgf@cal@temp{\def\expandafter\noexpand\csname pgfcalendar@weeknumber@#1\endcsname
+        {{\the\pgfutil@tempcnta}{\the\pgfutil@tempcntb}}}%
+      \expandafter\endgroup\pgf@cal@temp
+  }{}%
+}
+
+% Will store the weeknumber of the Julian date count #1 of year #2 in count #3
+\def\pgfcalendarjulianyeartoweeknumber#1#2#3{\pgfcalendarjulianyeartoweeknumber@#1{#2}#3\iftrue}
+
+% #1 = julian date (count)
+% #2 = year
+% #3 = count that holds the week number at the end
+% #4 = \iftrue or \iffalse: whether week 53 needs to be checked (\iffalse when determing week from next year)
+\def\pgfcalendarjulianyeartoweeknumber@#1#2#3#4{%
+  \begingroup
+    \pgfcalendar@weeknumber@setup{#2}%
+    #3=#1\relax
+    %
+    % calculate difference of days between current date and start of week number 1
+    %
+    \advance#3 by -\expandafter\expandafter\expandafter\pgfutil@firstoftwo\csname pgfcalendar@weeknumber@#2\endcsname\relax
+    \ifnum#3<0\relax % whoops, we are in the week of the previous year
+      \expandafter\pgfutil@firstoftwo
+    \else
+      \expandafter\pgfutil@secondoftwo
+    \fi
+    {% if first day of the year is Fri, Sat or Sun
+      \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname>3\relax
+        \expandafter\pgfutil@firstoftwo
+      \else
+        \expandafter\pgfutil@secondoftwo
+      \fi
+      {% we need to check the weeknumber of the previous
+        #3=#2\relax
+        \advance#3 by -1\relax
+        \edef\pgf@cal@temp{\noexpand\pgfcalendarjulianyeartoweeknumber@#1{\the#3}#3\noexpand\iffalse}%
+        \pgf@cal@temp
+      }{% yeah, it's weird
+        \divide#3 by 7\relax
+        \advance#3 by 1\relax        
+      }
+    }{%
+      \divide#3 by 7\relax
+      \advance#3 by 1\relax
+      #4%
+        \expandafter\pgfutil@firstofone
+      \else
+        \expandafter\pgfutil@gobble
+      \fi
+      {%
+        \ifnum#3=53\relax % whoops, we are possibly in the week of the next year
+            \expandafter\pgfutil@firstofone
+        \else
+            \expandafter\pgfutil@gobble
+        \fi
+        {%
+          \begingroup
+            \pgfcalendarmatchesfalse
+            \pgfkeys{/pgf/calendar/leap year=#2}%
+            \ifpgfcalendarmatches
+                \expandafter\pgfutil@firstoftwo
+            \else
+                \expandafter\pgfutil@secondoftwo
+            \fi
+            {% leap year
+                \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=3\relax
+                \else % must be week 1 from the next year
+                \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=2\relax\else
+                  #3=1\relax
+                \fi
+                \fi
+            }{% not a leap year, only week 53 possible when it starts and ends on a Thursday
+                \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=3\relax
+                \else % must be week 1 from the next year
+                  #3=1\relax
+                \fi
+            }
+            \expandafter
+          \endgroup\expandafter#3\the#3\relax
+        }
+      }%
+    }%
+    \expandafter\endgroup\expandafter
+  #3\the#3\relax
+}
+
+%
+% shorthands for weeknumbers (n)
+%
+% n-: shortest
+% n=: shortest but prepends whitespace
+% n0: leading zero
+%
+\expandafter\def\csname pgfcalendar@shorthand@n-\endcsname{%
+  {\pgfutil@tempcnta=\pgfcalendarcurrentweeknumber\relax\the\pgfutil@tempcnta}}
+\expandafter\def\csname pgfcalendar@shorthand@n=\endcsname{%
+  {\pgfutil@tempcnta=\pgfcalendarcurrentweeknumber\relax\ifnum\pgfutil@tempcnta<10\relax\setbox0=\hbox{1}\kern\wd0\relax\fi\the\pgfutil@tempcnta}}
+\expandafter\def\csname pgfcalendar@shorthand@n0\endcsname{%
+  \pgfcalendarcurrentweeknumber}
+
+% test for week number
+\pgfqkeys{/pgf/calendar/week number}{.value required,.code={\ifnum#1=\pgfcalendarifdateweeknumber\relax\pgfcalendarmatchestrue\fi}}
 \endinput

--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -207,6 +207,8 @@
   % Compute info about date
   \pgfcalendarjuliantoweekday{\pgfutil@tempcnta}{\pgfutil@tempcntb}%
   \edef\pgfcalendarifdateweekday{\the\pgfutil@tempcntb}%
+  \pgfcalendarjulianyeartoweeknumber{\pgfutil@tempcnta}{\pgfcalendarifdateyear}{\pgfutil@tempcntb}%
+  \edef\pgfcalendarifdateweeknumber{\the\pgfutil@tempcntb}%
   %
   \pgfcalendar@launch@ifdate{#2}{#3}{#4}%
 }
@@ -925,16 +927,16 @@
       \fi
       {% we need to check the weeknumber of the previous
         #3=#2\relax
-        \advance#3 by -1\relax
+        \advance#3 by -1
         \edef\pgf@cal@temp{\noexpand\pgfcalendarjulianyeartoweeknumber@#1{\the#3}#3\noexpand\iffalse}%
         \pgf@cal@temp
       }{% yeah, it's weird
-        \divide#3 by 7\relax
-        \advance#3 by 1\relax        
+        \divide#3 by 7
+        \advance#3 by 1        
       }
     }{%
-      \divide#3 by 7\relax
-      \advance#3 by 1\relax
+      \divide#3 by 7
+      \advance#3 by 1
       #4%
         \expandafter\pgfutil@firstofone
       \else
@@ -948,26 +950,35 @@
         \fi
         {%
           \begingroup
-            \pgfcalendarmatchesfalse
-            \pgfkeys{/pgf/calendar/leap year=#2}%
-            \ifpgfcalendarmatches
-                \expandafter\pgfutil@firstoftwo
+            % option 1: check whether we're already in week 1 of the next year
+            #3=#2\relax
+            \advance#3 by 1
+            \expandafter\pgfcalendar@weeknumber@setup\expandafter{\the#3}%
+            \ifnum#1<\expandafter\expandafter\expandafter\pgfutil@firstoftwo\csname pgfcalendar@weeknumber@\the#3\endcsname\relax
+              #3=53
             \else
-                \expandafter\pgfutil@secondoftwo
+              #3=1
             \fi
-            {% leap year
-                \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=3\relax
-                \else % must be week 1 from the next year
-                \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=2\relax\else
-                  #3=1\relax
-                \fi
-                \fi
-            }{% not a leap year, only week 53 possible when it starts and ends on a Thursday
-                \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=3\relax
-                \else % must be week 1 from the next year
-                  #3=1\relax
-                \fi
-            }
+            % option 2: check whether this year starts on Thursday [common/leap]
+            %           or ends on a Thursday (= starts on a Wednesday) [leap]
+            %   % if year starts with a Thursday (3) it has week 53
+            %   \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=3
+            %   \else
+            %     \pgfcalendarmatchesfalse
+            %     \pgfkeys{/pgf/calendar/leap year=#2}%
+            %     \ifpgfcalendarmatches
+            %       \expandafter\pgfutil@firstoftwo
+            %     \else
+            %       \expandafter\pgfutil@secondoftwo
+            %     \fi
+            %     {% leap year that didn't start on a Thursday but maybe it started on a Wednesday
+            %       \ifnum\expandafter\expandafter\expandafter\pgfutil@secondoftwo\csname pgfcalendar@weeknumber@#2\endcsname=2 \else
+            %         #3=1
+            %       \fi
+            %     }{% not a leap year, and didn't start/end on a Thursday, must be week 1 of next year
+            %       #3=1
+            %     }%
+            %   \fi
             \expandafter
           \endgroup\expandafter#3\the#3\relax
         }
@@ -993,4 +1004,5 @@
 
 % test for week number
 \pgfqkeys{/pgf/calendar/week number}{.value required,.code={\ifnum#1=\pgfcalendarifdateweeknumber\relax\pgfcalendarmatchestrue\fi}}
+
 \endinput

--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -695,13 +695,13 @@
 
 \def\pgfcalendarshorthand#1#2{\csname pgfcalendar@shorthand@#1#2\endcsname}
 \expandafter\def\csname pgfcalendar@shorthand@d-\endcsname{%
-  {\pgfutil@tempcnta=\pgfcalendarcurrentday\relax\the\pgfutil@tempcnta}}
+  \if0\pgfcalendarcurrentday\else\pgfcalendarcurrentday\fi}
 \expandafter\def\csname pgfcalendar@shorthand@d=\endcsname{%
   {\pgfutil@tempcnta=\pgfcalendarcurrentday\relax\ifnum\pgfutil@tempcnta<10\relax\setbox0=\hbox{1}\kern\wd0\relax\fi\the\pgfutil@tempcnta}}
 \expandafter\def\csname pgfcalendar@shorthand@d0\endcsname{%
   \pgfcalendarcurrentday}
 \expandafter\def\csname pgfcalendar@shorthand@m-\endcsname{%
-  {\pgfutil@tempcnta=\pgfcalendarcurrentmonth\relax\the\pgfutil@tempcnta}}
+  \if0\pgfcalendarcurrentmonth\else\pgfcalendarcurrentmonth\fi}
 \expandafter\def\csname pgfcalendar@shorthand@m=\endcsname{%
   {\pgfutil@tempcnta=\pgfcalendarcurrentmonth\relax\ifnum\pgfutil@tempcnta<10\relax\setbox0=\hbox{1}\kern\wd0\relax\fi\the\pgfutil@tempcnta}}
 \expandafter\def\csname pgfcalendar@shorthand@m0\endcsname{%
@@ -996,7 +996,7 @@
 % n0: leading zero
 %
 \expandafter\def\csname pgfcalendar@shorthand@n-\endcsname{%
-  {\pgfutil@tempcnta=\pgfcalendarcurrentweek\relax\the\pgfutil@tempcnta}}
+  \if0\pgfcalendarcurrentweek\else\pgfcalendarcurrentweek\fi}
 \expandafter\def\csname pgfcalendar@shorthand@n=\endcsname{%
   {\pgfutil@tempcnta=\pgfcalendarcurrentweek\relax\ifnum\pgfutil@tempcnta<10\relax\setbox0=\hbox{1}\kern\wd0\relax\fi\the\pgfutil@tempcnta}}
 \expandafter\def\csname pgfcalendar@shorthand@n0\endcsname{%

--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -900,7 +900,7 @@
 }
 
 % Will store the week of the Julian date count #1 of year #2 in count #3
-\def\pgfcalendarjulianyeartoweek#1#2#3{\pgfcalendarjulianyeartoweek@#1{#2}#3\iftrue}
+\def\pgfcalendarjulianyeartoweek#1#2#3{\pgfcalendarjulianyeartoweek@{#1}{#2}{#3}{\iftrue}}
 
 % #1 = julian date (count)
 % #2 = year

--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -817,7 +817,7 @@
   Sep/.code={\ifnum\pgfcalendarifdatemonth=9\pgfcalendarmatchestrue\fi},Sep/.value forbidden,
   Oct/.code={\ifnum\pgfcalendarifdatemonth=10\pgfcalendarmatchestrue\fi},Oct/.value forbidden,
   Nov/.code={\ifnum\pgfcalendarifdatemonth=11\pgfcalendarmatchestrue\fi},Nov/.value forbidden,
-  Dec/.code={\ifnum\pgfcalendarifdatemonth=12\pgfcalendarmatchestrue\fi},Dez/.value forbidden,
+  Dec/.code={\ifnum\pgfcalendarifdatemonth=12\pgfcalendarmatchestrue\fi},Dec/.value forbidden,
   leap year/.code={%
     \pgfutil@tempcnta=#1\relax
     \divide\pgfutil@tempcnta4


### PR DESCRIPTION
## TikZ
* Changed the keys
  * `/tikz/day xshift`,
  * `/tikz/day yshift`,
  * `/tikz/month xshift`,
  * `/tikz/month yshift`
  * `/tikz/tikz@lib@cal@width`
 
  to actual value keys ( `.initial`) so that they can easily be accessed via `\pgfkeysvalueof{/tikz/[day|month] [x|y]shift}` and one doesn't need `\makeatletter` to use `\tikz@lib@cal@[month@][x|y]shift` in their own calendar style. (The macros are still available of course.)
* Added keys/styles `week code`, `week text`, `every week`, `week label left` (see PGF) and `week label left`.
* Added `\tikzweekcode` and `\tikzweektext` (see PGF).
* Made `/tikz/if` nestable. This uses a `\newif` that gets toggled when inside the `\scope` of `\tikzdaycode`. I can also see a solution where `\tikz@lib@cal@if@else@code` uses a `\pgfutil@addto#1#2` that just gets `\let` to `\pgfutil@secondoftwo`.

## PGF
* Added week numbering per [ISO 8601](https://en.wikipedia.org/wiki/Week#Numbering):
  *  `\pgfcalendarcurrentweek`, `\pgfcalendarifdateweek`, shorthands `n-`, `n=` and `n0`.
  * `\pgfcalendarjulianyeartoweek{<julian count>}{<current year>}{<week number count>}`.
  * `/pgf/calendar/week=<num>` test.
* More tests:
  * `Jan`, `Feb`, …, `Dec` to check for a month (can be done with `between` but this is much easier and faster), could be changed to full names `January`, `February`, …, `December`.
  * `leap year` tests whether current (or given) year is a leap year (does not use `<year>-02-last`).
  * `not={tests}` sets `\ifcalendarmatches` to true if `tests` fail.
  * `and={tests}` sets `\ifcalendarmatches` to true only if all `tests` match.
  * `week=<num>` (see above).
* Made shorthands `d-`, `m-` and the new `n-` expandable so that it can be used in PGFmath (`08` and `09` break because the parser interprets them as illegal octal numbers). Uses `\if`, could also be done using `\the\numexpr`.

## Manual

### TikZ
* Fix: `/tikz/every day` was falsely defined as a `key` even though it is `stylekey`, `=` wasn't protected by the key parser.
* Added the keys `/tikz/week code`, `/tikz/week text` as well as the styles `/tikz/every week` and `/tikz/week label left` (see above).

### PGF
* Added the tests as mentioned above.
* Added macros as mentioned above.
* Added `n` shorthands as mentioned above.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
