### PR TITLE
fix: additional braces in description of key handler `.append code`

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
@@ -1107,7 +1107,7 @@ There are also handlers for modifying existing keys.
 
 \begin{handler}{{.append code}|=|\meta{append code}}
     This handler is a shortcut for \meta{key}|/.add code={}{|\meta{append
-    code}|}{}|.
+    code}|}|.
 \end{handler}
 
 
@@ -1249,7 +1249,7 @@ directly stored in a key.
     and, thus, |\pgfkeysnovalue| will be stored in |/my key|.
 
     To retrieve the value stored in a key, the handler |/.get| is used.
-    
+
     \medskip
     \emph{Remark:} A key can both store a value and execute commands%
     \footnote{This behavior was partially changed in \pgfname{} 3.1.6 and then


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

The documentation states `.append code` to be a shortcut for `<key>/.add code={}{<append code>}{}` with an unnecessary additional closing brace at the end. This PR removes theses braces.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [X] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
