### PR TITLE
docs: correct/add `subgraph` preamble comments (fixes #1194)

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
@@ -40,7 +40,7 @@ following:
 };
 \end{codeexample}
 
-\begin{codeexample}[preamble={\usetikzlibrary{graphs}}]
+\begin{codeexample}[preamble={\usetikzlibrary{graphs.standard}}]
 \tikz
   \graph [nodes={draw, circle}, clockwise, radius=.5cm, empty nodes, n=5] {
     subgraph I_n [name=inner] --[complete bipartite]
@@ -49,7 +49,7 @@ following:
 \end{codeexample}
 
 \begin{codeexample}[
-    preamble={\usetikzlibrary{graphs}},
+    preamble={\usetikzlibrary{graphs.standard}},
     pre={\definecolor{graphicbackground}{rgb}{0.96,0.96,0.8}},
 ]
 \tikz
@@ -410,7 +410,7 @@ saying |complete bipartite={red}{green}| will cause edges to be added between
 all red and all green nodes. More advanced connectors, like the |butterfly|
 connector, allow you to add edges between color classes in a fancy manner.
 %
-\begin{codeexample}[preamble={\usetikzlibrary{graphs}}]
+\begin{codeexample}[preamble={\usetikzlibrary{graphs.standard}}]
 \tikz [x=8mm, y=6mm, circle]
   \graph [nodes={fill=blue!70}, empty nodes, n=8] {
     subgraph I_n [name=A] --[butterfly={level=4}]
@@ -3471,7 +3471,7 @@ following two keys:
 %  The names of the two shores |V| and |W| can be changed as described in
 %  the documentation of the keys |/tikz/graphs/name shore V| and
 %  |/tikz/graphs/name shore W|.
-%  \begin{codeexample}[preamble={\usetikzlibrary{graphs}}]
+%  \begin{codeexample}[preamble={\usetikzlibrary{graphs.standard}}]
 %\tikz \graph [grid placement] { subgraph Grid_nm [V={1,2,3}, W={4, 5, 6}] };
 %  \end{codeexample}
 %\end{graph}

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/control/library.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/control/library.lua
@@ -53,11 +53,16 @@ declare {
     This behavior can be changed using this option. When the key is
     invoked, nodes are placed \emph{behind} the edges.
   "]],
-  examples = [["
-    \tikz \graph [simple necklace layout, nodes={draw,fill=white},
-                  nodes behind edges]
-      { subgraph K_n [n=7], 1 [regardless at={(0,-1)}] };
-  "]]
+  examples = {
+    {
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{circular}}"]],
+      code = [["
+        \tikz \graph [simple necklace layout, nodes={draw,fill=white},
+                      nodes behind edges]
+          { subgraph K_n [n=7], 1 [regardless at={(0,-1)}] };
+      "]]
+    }
+  }
 }
 
 
@@ -72,11 +77,16 @@ declare {
   summary = [["
     This is the default placement of edges: Behind the nodes.
   "]],
-  examples = [["
-    \tikz \graph [simple necklace layout, nodes={draw,fill=white},
-                  edges behind nodes]
-      { subgraph K_n [n=7], 1 [regardless at={(0,-1)}] };
- "]]
+  examples = {
+    {
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{circular}}"]],
+      code = [["
+        \tikz \graph [simple necklace layout, nodes={draw,fill=white},
+                      edges behind nodes]
+          { subgraph K_n [n=7], 1 [regardless at={(0,-1)}] };
+      "]]
+    }
+  }
 }
 
 ---
@@ -193,4 +203,3 @@ declare {
   key = InterfaceCore.subgraph_node_kind,
   layer = 0
 }
-

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlCoarsening.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlCoarsening.lua
@@ -95,15 +95,20 @@ declare {
     in the two graphs, the nodes are placed at exactly two and four
     coordinates in the final drawing.
   "]],
-  examples = [["
-    \tikz \graph [spring layout, iterations=0,
-                  minimum coarsening size=2]
-      { subgraph C_n [n=8] };
+  examples = {
+    {
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{force}}"]],
+      code = [["
+        \tikz \graph [spring layout, iterations=0,
+                      minimum coarsening size=2]
+          { subgraph C_n [n=8] };
 
-    \tikz \graph [spring layout, iterations=0,
-                  minimum coarsening size=4]
-      { subgraph C_n [n=8] };
-  "]]
+        \tikz \graph [spring layout, iterations=0,
+                      minimum coarsening size=4]
+          { subgraph C_n [n=8] };
+      "]]
+    }
+  }
 }
 
 ---
@@ -145,4 +150,3 @@ declare {
       { { [clique] 1, 2 } -- 3 -- 4 -- { 5, 6, 7 } };
   "]]
 }
-

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlElectric.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlElectric.lua
@@ -41,17 +41,19 @@ declare {
   "]],
   examples = {
     {
-      options = [["preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force}}"]],
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{force}}"]],
       code = [["
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { 0 [electric charge=1] -- subgraph C_n [n=10] };
       "]]
     },{
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{force}}"]],
       code = [["
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { 0 [electric charge=5] -- subgraph C_n [n=10] };
       "]]
     },{
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{force}}"]],
       code = [["
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { [clique] 1 [electric charge=5], 2, 3, 4 };
@@ -102,4 +104,3 @@ declare {
     least the results are somewhat strange when this key is used.
   "]]
   }
-

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlIteration.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlIteration.lua
@@ -47,17 +47,30 @@ declare {
     The examples shows two drawings generated using two
     different |iteration| limits.
   "]],
-  examples = {[["
-    \tikz \graph [spring layout, iterations=10]  { subgraph K_n [n=4] };
-  "]],[["
-    \tikz \graph [spring layout, iterations=500] { subgraph K_n [n=4] };
-  "]],[["
-    \tikz \graph [spring electrical layout, iterations=10]
-      { subgraph K_n [n=4] };
-  "]],[["
-    \tikz \graph [spring electrical layout, iterations=500]
-      { subgraph K_n [n=4] };
-  "]]
+  examples = {
+    {
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{force}}"]],
+      code = [["
+        \tikz \graph [spring layout, iterations=10]  { subgraph K_n [n=4] };
+      "]]
+    },{
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{force}}"]],
+      code = [["
+        \tikz \graph [spring layout, iterations=500] { subgraph K_n [n=4] };
+      "]]
+    },{
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{force}}"]],
+      code = [["
+        \tikz \graph [spring electrical layout, iterations=10]
+          { subgraph K_n [n=4] };
+      "]]
+    },{
+      options = [["preamble={\usetikzlibrary{graphs.standard,graphdrawing} \usegdlibrary{force}}"]],
+      code = [["
+        \tikz \graph [spring electrical layout, iterations=500]
+          { subgraph K_n [n=4] };
+      "]]
+    }
   }
 }
 
@@ -129,8 +142,3 @@ declare {
   "]]
   }
 }
-
-
-
-
-


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

---

Remaining instances are

https://github.com/pgf-tikz/pgf/blob/0280303d03594e1ea13f95f116234a803591b4af/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc/ogdf/energybased/FMMMLayout.lua#L108-L123

but since these are not part of the current manual and I couldn't make this part of the manual run, I decided not to fix them.

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
