### PR TITLE
docs: use handler `/.append`

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -82,6 +82,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - pgfkeys was a bit too relaxed around `\relax` #1132
 - Remove spurious spaces for `3d view` #1151
 - Fix incorrectly placed matrix delimiters for implicitly positioned nodes #1102
+- Use `/.append` to fix a wrong usage of `/.add` in pgfmanual #1201
 
 ### Changed
 

--- a/doc/generic/pgf/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-external.tex
@@ -1088,8 +1088,7 @@ with |pdflatex|, I can define the following style:
     % This style is not pre-defined, you may need to copy-paste and
     % adjust it.
     png export/.style={
-        external/system call/.add=
-            {}
+        external/system call/.append=
             {; convert -density 300 -transparent white "\image.pdf" "\image.png"},
         %
         /pgf/images/external info,


### PR DESCRIPTION
**Motivation for this change**

to avoid a subtle constraint of `/.add` that
```tex
    /.add={<arg1>}{<arg2>}  % and
    /.add={<arg1>} {<arg2>}
```
are different and the second is, in most cases, wrong usage.

Fixes #1201

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
