### PR TITLE
fix: allow XOR and XNOR gates to have more than 2 inputs

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -83,6 +83,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Remove spurious spaces for `3d view` #1151
 - Fix incorrectly placed matrix delimiters for implicitly positioned nodes #1102
 - Use `/.append` to fix a wrong usage of `/.add` in pgfmanual #1201
+- Allow XOR and XNOR gates to have more than 2 inputs #376
 
 ### Changed
 
@@ -113,6 +114,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - PhelypeOleinik
 - QJLc
 - Stefan Pinnow
+- Erin Cold
 
 ## [3.1.9a] - 2021-05-15 Henri Menke
 

--- a/doc/generic/pgf/pgfmanual-en-library-circuits.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-circuits.tex
@@ -1281,9 +1281,9 @@ Let us begin with the base library that defines the handling of inputs.
         \item |nand gate US|, two or more inputs
         \item |nand gate CDH|, two or more inputs
         \item |or gate US|, two or more inputs
-        \item |nor gate US|, two or more Inputs
-        \item |xor gate US|, two inputs
-        \item |xnor gate US|, two inputs
+        \item |nor gate US|, two or more inputs
+        \item |xor gate US|, two or more inputs
+        \item |xnor gate US|, two or more inputs
         \item |not gate US|, one input
         \item |buffer gate US|, one input
     \end{itemize}
@@ -1428,8 +1428,8 @@ Let us begin with the base library that defines the handling of inputs.
         \item |nand gate IEC|, two or more inputs
         \item |or gate IEC|, two or more inputs
         \item |nor gate IEC|, two or more inputs
-        \item |xor gate IEC|, two inputs
-        \item |xnor gate IEC|, two inputs
+        \item |xor gate IEC|, two or more inputs
+        \item |xnor gate IEC|, two or more inputs
         \item |not gate IEC|, one input
         \item |buffer gate IEC|, one input
     \end{itemize}

--- a/tex/generic/pgf/libraries/shapes/circuits/pgflibraryshapes.gates.logic.IEC.code.tex
+++ b/tex/generic/pgf/libraries/shapes/circuits/pgflibraryshapes.gates.logic.IEC.code.tex
@@ -484,7 +484,7 @@
 %
 \pgfdeclareshape{xor gate IEC}{%
   \expandafter\pgfutil@g@addto@macro\csname pgf@sh@s@xor gate IEC\endcsname{%
-    \pgf@lib@sh@logicgate@parseinputs{2}% Maximum 1024 (!) inputs.
+    \pgf@lib@sh@logicgate@parseinputs{1024}% Maximum 1024 (!) inputs.
     %
     \pgfmathloop%
     \ifnum\pgfmathcounter>\pgf@lib@sh@logicgate@numinputs%
@@ -496,7 +496,7 @@
       }{}%
     \repeatpgfmathloop%
     \ifnum\pgf@lib@sh@logicgate@numinputs<2\relax%
-      \pgferror{An xor gate must have two inputs}%
+      \pgferror{An xor gate must have at least two inputs}%
     \fi%
   }%
   \savedmacro\numinputs{\let\numinputs\pgf@lib@sh@logicgate@numinputs}%
@@ -564,7 +564,7 @@
       }{}%
     \repeatpgfmathloop%
     \ifnum\pgf@lib@sh@logicgate@numinputs<2\relax%
-      \pgferror{A xnor gate must have two inputs}%
+      \pgferror{A xnor gate must have at least two inputs}%
     \fi%
   }%
   \savedmacro\numinputs{\let\numinputs\pgf@lib@sh@logicgate@numinputs}%
@@ -625,7 +625,7 @@
       \pgf@lib@sh@logicgate@IEC@inputanchor{1}%
     }%
     \ifnum\pgf@lib@sh@logicgate@numinputs=0\relax%
-      \pgferror{A buffer gate must have one inputs}%
+      \pgferror{A buffer gate must have one input}%
     \fi%
   }%
   \savedmacro\numinputs{\let\numinputs\pgf@lib@sh@logicgate@numinputs}%

--- a/tex/generic/pgf/libraries/shapes/circuits/pgflibraryshapes.gates.logic.US.code.tex
+++ b/tex/generic/pgf/libraries/shapes/circuits/pgflibraryshapes.gates.logic.US.code.tex
@@ -1154,7 +1154,7 @@
 %
 \pgfdeclareshape{xor gate US}{%
     \expandafter\pgfutil@g@addto@macro\csname pgf@sh@s@xor gate US\endcsname{%
-        \pgf@lib@sh@logicgate@parseinputs{2}%
+        \pgf@lib@sh@logicgate@parseinputs{1024}% Maximum 1024 (!) inputs.
         %
         \pgfmathloop%
         \ifnum\pgfmathcounter>\pgf@lib@sh@logicgate@numinputs%
@@ -1166,7 +1166,7 @@
             }{}%
         \repeatpgfmathloop%
         \ifnum\pgf@lib@sh@logicgate@numinputs<2\relax%
-            \pgferror{An xor gate must have at two inputs}%
+            \pgferror{An xor gate must have at least two inputs}%
         \fi%
     }%
     \savedmacro\numinputs{\let\numinputs\pgf@lib@sh@logicgate@numinputs}%
@@ -1485,7 +1485,7 @@
 %
 \pgfdeclareshape{xnor gate US}{%
     \expandafter\pgfutil@g@addto@macro\csname pgf@sh@s@xnor gate US\endcsname{%
-        \pgf@lib@sh@logicgate@parseinputs{2}%
+        \pgf@lib@sh@logicgate@parseinputs{1024}% Maximum 1024 (!) inputs.
         %
         \pgfmathloop%
         \ifnum\pgfmathcounter>\pgf@lib@sh@logicgate@numinputs%
@@ -1497,7 +1497,7 @@
             }{}%
         \repeatpgfmathloop%
         \ifnum\pgf@lib@sh@logicgate@numinputs<2\relax%
-            \pgferror{An xnor gate must have two inputs}%
+            \pgferror{An xnor gate must have at least two inputs}%
         \fi%
     }%
     \savedmacro\numinputs{\let\numinputs\pgf@lib@sh@logicgate@numinputs}%


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

There have been several requests for XOR and XNOR gates to allow more than 2 inputs [#376]  [[1](https://tex.stackexchange.com/q/284430/)] [[2](https://tex.stackexchange.com/q/155487)]. This PR fixes that and updates the docs.

As far as I can see, the previous concern was a potentially ambiguous IEC symbol [ **= 1** ]. However, extended gates are widely interpreted to represent the cascade of such binary operations and there is clear demand to display such symbols (from me too).

As a weird quirk, ICE XNOR gates have always been able to accept more than 2 inputs - in opposition to the docs.

Fixes #376 

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
