### PR TITLE
chore: add dependabot to keep actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -43,6 +43,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Add Developer Certificate of Origin (DCO) to Pull Request template and enforce
 - Add test set for `graphdrawing` (gd) 
 - pgfkeys gained support for loading libraries
+- Add dependabot to keep GitHub Actions up to date
 
 ### Fixed
 


### PR DESCRIPTION
**Motivation for this change**

Some of the actions used by pgf is outdated and throwing warnings, see https://github.com/pgf-tikz/pgf/actions/runs/3242834076.
![image](https://user-images.githubusercontent.com/6376638/197071556-6c8116d8-6b30-43b9-8d77-2ae0b47506ec.png)

With an `dependabot.yml` config file and the dependabot enabled in [Insights](https://github.com/pgf-tikz/pgf/network/updates) (already enabled when I checked it), dependabot will open PR(s) to update outdated actions, periodically. Hope this would ease the effort to manually check and do necessary action updates.

The committed `dependabot.yml` is copied from section "Example `dependabot.yml` ..." in doc page referred below.

Reference:
- [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) | GitHub Docs

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
