### PR TITLE
Resolve large-enough overfull hboxes

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,10 +29,31 @@ jobs:
       run: |
         l3build doc -q
 
-    - uses: actions/upload-artifact@v4
+    - name: Analyze manual log
+      run: |
+        # set a notice message
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions?tool=bash#setting-a-notice-message
+        # create multiline annotations by using URL-encoded newline "%0A"
+        # https://github.com/actions/toolkit/issues/193#issuecomment-605394935
+        OVERFULL_HBOX=$(
+          grep -r '^Overfull \\hbox' build/doc/pgfmanual.log |
+          awk 'BEGIN {RS=""}{gsub(/\n/,"%0A",$0); print $0}'
+        )
+        echo "::notice file=build/doc/pgfmanual.log,title=Overfull hbox(es)::$OVERFULL_HBOX"
+
+    - name: Upload manual
+      uses: actions/upload-artifact@v4
       with:
         name: pgfmanual
         path: build/doc/pgfmanual.pdf
+
+    - name: Upload manual with aux
+      uses: actions/upload-artifact@v4
+      with:
+        name: pgfmanual-with-aux
+        path: |
+          build/doc/pgfmanual.*
+          !build/doc/pgfmanual.tex
 
     - name: Deploy tlcontrib
       env:

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Typo fixes in the manual
 - Simplify short verb `|...|` or add required preamble for it
 - Harden parser for math expressions against active chars
+- Resolve overfull hboxes >=20pt in the manual
 
 ### Contributors
 

--- a/doc/generic/pgf/pgfmanual-en-gd-usage-pgf.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-usage-pgf.tex
@@ -410,9 +410,9 @@ drawing engine, while for edges a command has to be called explicitly:
     |(10pt,20pt)--(30pt,40pt)| in \tikzname-syntax and may include the path
     commands |--|,  |..| (followed by Bézier coordinates), and |--cycle|.
 
-    The parameter \meta{animations} contains algorithmically-generated
-    animation commands (calls to |\pgfanimateattribute|. The |whom| will be set
-    to |pgf@gd|.
+    The last parameter \meta{animations} contains algorithmically-generated
+    animation commands (calls to |\pgfanimateattribute|). The |whom|
+    will be set to |pgf@gd|.
 
     The default \meta{macro} simply draws a line between the nodes. When the
     |graphdrawing| library of the \tikzname\ layer is loaded, a more fancy

--- a/doc/generic/pgf/pgfmanual-en-library-automata.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-automata.tex
@@ -284,10 +284,11 @@ state: Initial states are red, accepting states are green, and normal states
 are orange. Then, we must find a path from a red state to a green state.
 %
 \begin{codeexample}[preamble={\usetikzlibrary{arrows.meta,automata,positioning,shadows}}]
-\begin{tikzpicture}[shorten >=1pt,node distance=2cm,on grid,>={Stealth[round]},thick,
-    every state/.style={fill,draw=none,orange,text=white,circular drop shadow},
-    accepting/.style  ={green!50!black,text=white},
-    initial/.style    ={red,text=white}]
+\begin{tikzpicture}
+  [shorten >=1pt,node distance=2cm,on grid,>={Stealth[round]},thick,
+   every state/.style={fill,draw=none,orange,text=white,circular drop shadow},
+   accepting/.style  ={green!50!black,text=white},
+   initial/.style    ={red,text=white}]
 
   \node[state,initial]  (q_0)                      {$q_0$};
   \node[state]          (q_1) [above right=of q_0] {$q_1$};
@@ -306,7 +307,7 @@ are orange. Then, we must find a path from a red state to a green state.
 The next example is the current candidate for the five-state busiest beaver:
 %
 \begin{codeexample}[preamble={\usetikzlibrary{arrows.meta,automata,positioning}}]
-\begin{tikzpicture}[->,>={Stealth[round]},shorten >=1pt,%
+\begin{tikzpicture}[->,>={Stealth[round]},shorten >=1pt,
                     auto,node distance=2cm,on grid,semithick,
                     inner sep=2pt,bend angle=45]
   \node[initial,state] (A)                    {$q_a$};

--- a/doc/generic/pgf/pgfmanual-en-library-circuits.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-circuits.tex
@@ -90,7 +90,7 @@ automatically by default. Here is the graphic once more, generated from
 \emph{exactly the same source code}, with only the options of the
 |{tikzpicture}| environment replaced by
 |[rotate=-90,circuit ee IEC,x=3.25cm,y=2.25cm]|:
-%
+
 \begin{tikzpicture}[rotate=-90,circuit ee IEC,x=3cm,y=2.25cm]
   % Let us start with some contacts:
   \foreach \contact/\y in {1/1,2/2,3/3.5,4/4.5,5/5.5}

--- a/doc/generic/pgf/pgfmanual-en-library-patterns.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-patterns.tex
@@ -221,8 +221,9 @@ applied \emph{before} the rotation.  If you want to rotate before shifting,
 just rotate in the drawing code.
 
 \begin{pattern}{Lines}
-    The |Lines| pattern replaces the |horizontal lines|, |vertical lines|,
-    |north east lines|, and |north west lines| patterns. Unfortunately, due to
+    The |Lines| pattern replaces four patterns: |horizontal lines|,
+    |vertical lines|, |north east lines|, and |north west lines|.
+    Unfortunately, due to
     the way the old patterns are constructed, namely that they are not simply
     related to each other by rotation, the |Lines| pattern cannot be used as a
     drop-in replacement.

--- a/doc/generic/pgf/pgfmanual-en-library-rdf.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-rdf.tex
@@ -254,16 +254,16 @@ You add an \textsc{rdf} statement to the output file using the following key:
             \item As for |subject| and |predicate|, you can use the syntax
                 |(|\meta{name of node or scope}|)| to create and use a curie
                 for the node or scope.
-            \item If the \meta{object} starts with |"|, it must have the syntax
-                |"|\meta{literals}|"|. In this case, the object of the
+            \item If the \meta{object} starts with |"| and is of the form
+                |"|\meta{literals}|"|, the object of the
                 statement is not a curie (not a normal ``resource'') but the
                 string of \meta{literals} given.
             \item If the \meta{object} is the text ``|scope content|'', the
                 object of the statement is actually the whole contents of the
                 scope to which this statement is attached.
-            \item The two previous cases can be combined in the form of an
-                object of the form |"|\meta{literals}|" and scope content|. In
-                this case, the contents of the scope is ``normally'' the
+            \item Finally if the \meta{object} is of the form
+                |"|\meta{literals}|" and scope content|, the contents of the
+                scope is ``normally'' the
                 object, but this gets ``overruled'' by the \meta{literals}.
                 Formally, this means that the object is the \meta{literals},
                 but the intended semantics is that the object is the scope

--- a/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex
@@ -922,10 +922,14 @@ ifs, which must be set before the above command is called:
     transformation should not apply to the following graphics, however.
 \end{command}
 
+\pagebreak[2]
 \begin{command}{\pgfsys@clipfading}
     This command has a default implementation and need not be implemented by
     driver files other than |pgfsys-dvips.def|. The macro is called
-    in |\pgfsetfadingforcurrentpath| and |\pgfsetfadingforcurrentpathstroked|
+    in
+    \begin{quote}
+      |\pgfsetfadingforcurrentpath| and |\pgfsetfadingforcurrentpathstroked|
+    \end{quote}
     of the basic layer, where it invokes the current path for clipping the
     shading just before installing it as an opacity mask for fading. The
     default implementation is actually a non-operation, but with |dvips| it

--- a/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
@@ -455,9 +455,9 @@ commands, which are \emph{only defined in the library}, namely the library
     %
 \begin{codeexample}[preamble={\usetikzlibrary{fadings,patterns}}]
 \begin{tikzfadingfrompicture}[name=tikz]
-  \node [text=transparent!20]
-  {\fontencoding{T1}\fontfamily{ptm}\fontsize{45}{45}\bfseries\selectfont
-    Ti\emph{k}Z};
+  \node [text=transparent!20,
+         font=\fontencoding{T1}\fontfamily{ptm}\fontsize{45}{45}\bfseries]
+    {Ti\emph{k}Z};
 \end{tikzfadingfrompicture}
 
 % Now we use the fading in another picture:
@@ -856,8 +856,9 @@ Transparency groups are used to render them correctly:
   \shade [left color=red,right color=blue] (-2,-1) rectangle (2,1);
   \begin{scope}[transparency group=knockout]
     \fill [white] (-1.9,-.9) rectangle (1.9,.9);
-    \node [opacity=0,font=\fontencoding{T1}\fontfamily{ptm}\fontsize{45}{45}\bfseries]
-          {Ti\emph{k}Z};
+    \node [opacity=0,
+           font=\fontencoding{T1}\fontfamily{ptm}\fontsize{45}{45}\bfseries]
+      {Ti\emph{k}Z};
   \end{scope}
 \end{tikzpicture}
 \end{codeexample}


### PR DESCRIPTION
**Motivation for this change**

Resolve large overfull hboxes that will exceed beyond the page and add some sort of monitor to workflow `doc.yml`.
- Main body has h-margin `* h-part:(L,W,R)=(64.01869pt, 469.47049pt, 64.01869pt)`.

Fixes #1208

### List of all the overfull hboxes >=10pt

Before: pgfmanual 3.1.10
After: pgfmanual from https://github.com/pgf-tikz/pgf/actions/runs/7294523405

- [x] 25.78838pt, [`pgfmanual-en-tikz-transparency.tex`](https://github.com/pgf-tikz/pgf/blob/55d0e441f0ee2a1ca9ee751ab7d81b67995e170a/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex#L854-L863), p. 364
  - Before <img width="802" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/f38a8a66-4145-45c4-bb7d-6638f3e27aa7">
  - After <img width="802" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/1aa33253-ab7c-4e7f-8c99-418b787c9194">

- [x] 64.95732pt, [`pgfmanual-en-gd-usage-pgf.tex`](https://github.com/pgf-tikz/pgf/blob/55d0e441f0ee2a1ca9ee751ab7d81b67995e170a/doc/generic/pgf/pgfmanual-en-gd-usage-pgf.tex#L413-L415), p. 454
  - Before <img width="865" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/81796e77-d298-48db-92ff-e796ccff9b76">
  - After <img width="865" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/e4596cff-d0fc-45c7-9922-d338c2593c7b">

- [x] 23.36453pt, [`pgfmanual-en-library-automata.tex`](https://github.com/pgf-tikz/pgf/blob/55d0e441f0ee2a1ca9ee751ab7d81b67995e170a/doc/generic/pgf/pgfmanual-en-library-automata.tex#L286-L304), p. 575
  - Before <img width="808" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/de9228bb-94f3-4369-8804-624492026bed">
  - After <img width="808" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/e850f76e-c058-433c-b802-968a0cd762a7">

- [x] 226.97084pt, [`pgfmanual-en-library-circuits.tex`](https://github.com/pgf-tikz/pgf/blob/55d0e441f0ee2a1ca9ee751ab7d81b67995e170a/doc/generic/pgf/pgfmanual-en-library-circuits.tex#L92-L94), p. 608
  - Before <img width="866" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/7f7d71a2-fcdd-4ba3-a05d-6027bba976fb">
  - After <img width="866" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/9a333a3b-3b1b-4011-8379-7c8f1d0f6298">

- [x] 45.27551pt, [`pgfmanual-en-library-patterns.tex`](https://github.com/pgf-tikz/pgf/blob/55d0e441f0ee2a1ca9ee751ab7d81b67995e170a/doc/generic/pgf/pgfmanual-en-library-patterns.tex#L225-L229), p. 733
  - Before <img width="866" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/021848a6-9171-4b60-a457-954e6c09ed20">
  - After <img width="866" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/4ddb0d93-3408-4a77-b134-6d6b9c4919b2">

- [x] 57.3973pt, [`pgfmanual-en-library-rdf.tex`](https://github.com/pgf-tikz/pgf/blob/55d0e441f0ee2a1ca9ee751ab7d81b67995e170a/doc/generic/pgf/pgfmanual-en-library-rdf.tex#L264-L266), p. 765
  - Before <img width="866" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/611d0292-e557-46f2-b75b-7f3f0105eac2">
  - After <img width="866" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/83130650-4aa4-4e9f-8c11-80a1a1251e0c">

- [x] 77.25952pt, [`pgfmanual-en-pgfsys-commands.tex`](https://github.com/pgf-tikz/pgf/blob/55d0e441f0ee2a1ca9ee751ab7d81b67995e170a/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex#L925-L933), p. 1243
  - Before <img width="866" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/5944a03a-3c67-4182-b903-066588d055fe">
  - After <img width="866" alt="image" src="https://github.com/pgf-tikz/pgf/assets/6376638/8beb8057-3e4c-4541-b7f8-ef50c21829fd">

### Remaining small overfull boxes

Copied from annotations of https://github.com/pgf-tikz/pgf/actions/runs/7294523405
```
Overfull \hbox (7.2846pt too wide) in paragraph at lines 471--471
Overfull \hbox (2.65257pt too wide) in paragraph at lines 526--526
Overfull \hbox (1.54848pt too wide) in paragraph at lines 526--526
Overfull \hbox (2.07652pt too wide) in paragraph at lines 526--526
Overfull \hbox (1.26045pt too wide) in paragraph at lines 526--526
Overfull \hbox (11.46152pt too wide) in paragraph at lines 2666--2670
Overfull \hbox (9.64151pt too wide) in paragraph at lines 81--106
```

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
