### PR TITLE
IEC symbols: do not rotate content of ac source, dc source

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -83,6 +83,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Remove spurious spaces for `3d view` #1151
 - Fix incorrectly placed matrix delimiters for implicitly positioned nodes #1102
 - Use `/.append` to fix a wrong usage of `/.add` in pgfmanual #1201
+- Do not rotate content of ac/dc source symbols in IEC circuit library
 
 ### Changed
 

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/circuits/tikzlibrarycircuits.ee.IEC.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/circuits/tikzlibrarycircuits.ee.IEC.code.tex
@@ -416,10 +416,16 @@
     circuit symbol size=width 2 height 2,
     shape=generic circle IEC,
     /pgf/generic circle IEC/before background={
-      \pgfpathmoveto{\pgfqpoint{0.7pt}{0pt}}
-      \pgfpathquadraticcurveto{\pgfqpoint{ 0.35pt}{-0.5pt}}{\pgfqpoint{0pt}{0pt}}
-      \pgfpathquadraticcurveto{\pgfqpoint{-0.35pt}{ 0.5pt}}{\pgfqpoint{-0.7pt}{0pt}}
-      \pgfusepathqstroke
+      {
+        % First cancel rotation to have straight sine wave
+        \pgfgettransformentries{\a}{\b}{\c}{\d}{\x}{\y}
+        \pgfmathatantwo{\c}{\a}
+        \pgftransformrotate{\pgfmathresult}
+        \pgfpathmoveto{\pgfqpoint{0.7pt}{0pt}}
+        \pgfpathquadraticcurveto{\pgfqpoint{ 0.35pt}{-0.5pt}}{\pgfqpoint{0pt}{0pt}}
+        \pgfpathquadraticcurveto{\pgfqpoint{-0.35pt}{ 0.5pt}}{\pgfqpoint{-0.7pt}{0pt}}
+        \pgfusepathqstroke
+      }
     },
     transform shape,
   },
@@ -428,12 +434,18 @@
     circuit symbol size=width 2 height 2,
     shape=generic circle IEC,
     /pgf/generic circle IEC/before background={
-      \pgfpathmoveto{\pgfqpoint{ 0.7pt}{ 0.2pt}}
-      \pgfpathlineto{\pgfqpoint{-0.7pt}{ 0.2pt}}
-      \pgfusepathqstroke
-      \pgfpathmoveto{\pgfqpoint{ 0.7pt}{-0.2pt}}
-      \pgfpathlineto{\pgfqpoint{-0.7pt}{-0.2pt}}
-      \pgfusepathqstroke
+      {
+        % First cancel rotation to have straight equal sign
+        \pgfgettransformentries{\a}{\b}{\c}{\d}{\x}{\y}
+        \pgfmathatantwo{\c}{\a}
+        \pgftransformrotate{\pgfmathresult}
+        \pgfpathmoveto{\pgfqpoint{ 0.7pt}{ 0.2pt}}
+        \pgfpathlineto{\pgfqpoint{-0.7pt}{ 0.2pt}}
+        \pgfusepathqstroke
+        \pgfpathmoveto{\pgfqpoint{ 0.7pt}{-0.2pt}}
+        \pgfpathlineto{\pgfqpoint{-0.7pt}{-0.2pt}}
+        \pgfusepathqstroke
+      }
     },
     transform shape,
   },


### PR DESCRIPTION
**Motivation for this change**

This PR fixes the `ac source` and `dc source` circuit graphics to draw their content without rotation (see for example [here](https://www.google.com/search?q=ac+source+diagram&tbm=isch): the sine wave is always straight).

Currently these symbols work well when drawn on a horizontal wire:

```latex
\begin{tikzpicture}[circuit ee IEC]
  \draw (0,0) to [ac source={direction info={volt=3}}] (1,0)
              to [dc source={direction info={volt=3}}] (2,0);
\end{tikzpicture}
```

![image](https://user-images.githubusercontent.com/2412819/197771129-c5587d71-1079-4ad0-97fe-4570df966032.png)

However, the common usage is to draw voltage sources on vertical wires, and in this case they look wrong:

```latex
\begin{tikzpicture}[circuit ee IEC]
  \draw (0,0) to [ac source={direction info={volt=3}}] (0,1)
              to [dc source={direction info={volt=3}}] (0,2);
\end{tikzpicture}
```

![image](https://user-images.githubusercontent.com/2412819/197771184-d10bdee5-259a-49fc-8e0e-60ba9898f070.png)


Adding a manual rotation can fix the content of the nodes, but messes with the annotations:

```latex
\begin{tikzpicture}[circuit ee IEC]
  \draw (0,0) to [ac source={point up,direction info={volt=3}}] (0,1)
              to [dc source={point up,direction info={volt=3}}] (0,2);
  % Trying with manual rotation of both symbol and annotation:
  \draw (2,0) to [ac source={point up,direction info={point up,volt=3}}] (2,1)
              to [dc source={point up,direction info={point up,volt=3}}] (2,2);
\end{tikzpicture}
```

![image](https://user-images.githubusercontent.com/2412819/197771257-88e2a8e7-e4a5-494c-9473-198f65c24fed.png)

A workaround was [proposed](https://tex.stackexchange.com/questions/28016/rotationally-correct-ac-source-symbol-in-tikz) on tex.stackexchange but it would be nice to have this fixed in TikZ, especially since these symbols are generally used on vertical wires.

With this PR it looks like this:

```latex
\begin{tikzpicture}[circuit ee IEC]
  \draw (0,0) to [ac source={direction info={volt=3}}] (0,1)
              to [dc source={direction info={volt=3}}] (0,2);
\end{tikzpicture}
```

![image](https://user-images.githubusercontent.com/2412819/197771340-5c490b9f-45e7-49c7-b8d4-d6276f69d969.png)


**Checklist**

[x] Changelog updated
[x] Commit signed-off
