### PR TITLE
Fix shadings on LuaMetaTeX

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -83,6 +83,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Remove spurious spaces for `3d view` #1151
 - Fix incorrectly placed matrix delimiters for implicitly positioned nodes #1102
 - Use `/.append` to fix a wrong usage of `/.add` in pgfmanual #1201
+- Fix shadings under LuaMetaTeX
 
 ### Changed
 

--- a/tex/generic/pgf/systemlayer/pgfsys-luatex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-luatex.def
@@ -80,11 +80,17 @@
   \immediate\saveimageresource attr \pgf@attr {\pgf@filename}%
   \edef\pgf@mask{/SMask \the\lastsavedimageresourceindex\space 0 R}%
 }
+
+\ifnum\luatexversion<200
+  \def\pgfsys@TLT{dir TLT}%
+\else
+  \def\pgfsys@TLT{direction 0}%
+\fi
 \def\pgfsys@horishading#1#2#3{%
   {%
     \pgf@parsefunc{#3}%
     \pgfmathparse{#2}%
-    \setbox\pgfutil@tempboxa=\hbox dir TLT to\pgf@max{\vbox to\pgfmathresult pt{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgf@max{\vbox to\pgfmathresult pt{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{\pgfpoint{\pgf@max}{#2}}%
     \immediate\saveboxresource resources {%
       /Shading << /Sh << /ShadingType 2
@@ -101,7 +107,7 @@
   {%
     \pgf@parsefunc{#3}%
     \pgfmathparse{#2}%
-    \setbox\pgfutil@tempboxa=\hbox dir TLT to\pgfmathresult pt{\vbox to\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgfmathresult pt{\vbox to\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{\pgfpoint{#2}{\pgf@max}}%
     \immediate\saveboxresource resources {%
       /Shading << /Sh << /ShadingType 2
@@ -117,7 +123,7 @@
 \def\pgfsys@radialshading#1#2#3{%
   {%
     \pgf@parsefunc{#3}%
-    \setbox\pgfutil@tempboxa=\hbox dir TLT to2\pgf@max{\vbox to2\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to2\pgf@max{\vbox to2\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{#2}%
     \pgf@xa=\pgf@x%
     \pgf@ya=\pgf@y%
@@ -149,7 +155,7 @@
     \pgf@yb=\pgf@y%
     \advance\pgf@x by-\pgf@xa%
     \advance\pgf@y by-\pgf@ya%
-    \setbox\pgfutil@tempboxa=\hbox dir TLT to\pgf@x{\vbox to\pgf@y{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgf@x{\vbox to\pgf@y{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@sys@bp@correct{\pgf@xa}%
     \pgf@sys@bp@correct{\pgf@ya}%
     \pgf@sys@bp@correct{\pgf@xb}%


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

Under [LuaMetaLaTeX](https://github.com/zauguin/luametalatex) shadings are broken because they use `dir` specifiers on boxes which use a different syntax in LuaMetaTeX.

Fix this by using equivalent `direction`s instead if running under LuaMetaTeX.
<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ ] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
