### PR TITLE
Harden pgfmathparser against active chars

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -97,6 +97,7 @@ lot of contributed changes. Thanks to everyone who volunteered their time!
 - Use descriptive workflow job ids
 - Ensure `doc` v2 is loaded for pgfmanual
 - Ensure active `^^M` is non-expandable in `codeexample`
+- Harden parser for math expressions against active chars
 
 ### Contributors
 

--- a/tex/generic/pgf/math/pgfmathparser.code.tex
+++ b/tex/generic/pgf/math/pgfmathparser.code.tex
@@ -428,7 +428,7 @@
     \expandafter\pgfmath@stack@push@operand\expandafter{\pgfmath@number}%
     \let\pgfmath@parse@next=\pgfmath@parse@@@operator%
   \else%
-    \expandafter\ifcat\pgfmath@token\relax% A CS?
+    \expandafter\ifcat\expandafter\noexpand\pgfmath@token\relax% A CS?
       \expandafter\ifx\csname pgfmath@token@dimexpr@\expandafter\string\pgfmath@token\endcsname\relax%
         \expandafter\ifx\pgfmath@token\numexpr%
           \let\pgfmath@parse@next=\pgfmath@parse@numexpr%
@@ -448,7 +448,7 @@
               \else% A count register.
                 \pgfmath@count=\pgfmath@token%
                 \expandafter\def\expandafter\pgfmath@number\expandafter{\the\pgfmath@count}%
-                \expandafter\ifcat\pgfmath@token@next\relax%
+                \expandafter\ifcat\expandafter\noexpand\pgfmath@token@next\relax%
                   % A CS following a count register should be \wd, \ht or \dp.
                   \let\pgfmath@parse@next=\pgfmath@parse@number%
                 \else%
@@ -475,15 +475,15 @@
       \expandafter\ifx\csname pgfmath@token@numeric@\expandafter\string\pgfmath@token\endcsname\relax%
         % It isn't numeric (i.e., 012345679.), so it might be units...
         % first double-character units...
-        \expandafter\ifx\csname pgfmath@token@unit@\pgfmath@token\expandafter\string\pgfmath@token@next\endcsname\relax%
+        \expandafter\ifx\csname pgfmath@token@unit@\expandafter\string\pgfmath@token\expandafter\string\pgfmath@token@next\endcsname\relax%
         % then single-character units...
-        \expandafter\ifx\csname pgfmath@token@unit@\pgfmath@token\endcsname\relax%
+        \expandafter\ifx\csname pgfmath@token@unit@\expandafter\string\pgfmath@token\endcsname\relax%
           % ...or the exponent characters...
-          \expandafter\ifx\csname pgfmath@token@exponent@\pgfmath@token\endcsname\relax%
+          \expandafter\ifx\csname pgfmath@token@exponent@\expandafter\string\pgfmath@token\endcsname\relax%
             % ...or a base prefix...
-            \expandafter\ifx\csname pgfmath@base@\pgfmath@number\pgfmath@token\endcsname\relax%
+            \expandafter\ifx\csname pgfmath@base@\expandafter\pgfmath@number\expandafter\string\pgfmath@token\endcsname\relax%
               % ...or a math unit...
-              \expandafter\ifx\csname pgfmath@token@mathunit@\pgfmath@token\expandafter\string\pgfmath@token@next\endcsname\relax%
+              \expandafter\ifx\csname pgfmath@token@mathunit@\expandafter\string\pgfmath@token\expandafter\string\pgfmath@token@next\endcsname\relax%
                 % ...none of the above...
                   \ifx\pgfmath@base\pgfmath@empty%
                     \let\pgfmathresult=\pgfmath@number%
@@ -509,7 +509,7 @@
             \else%
               % ...here, it is a base prefix 0x, 0X, 0b or 0B
               \expandafter\let\expandafter\pgfmath@base\expandafter=%
-                \csname pgfmath@base@\pgfmath@number\pgfmath@token\endcsname%
+                \csname pgfmath@base@\expandafter\pgfmath@number\expandafter\string\pgfmath@token\endcsname%
               \let\pgfmath@parse@next=\pgfmath@parse@base%
             \fi%
           \else% ... and here, it is the exponent characters.
@@ -583,7 +583,7 @@
 \def\pgfmath@parse@numexpr@#1{%
   \expandafter\def\expandafter\pgfmath@number\expandafter{\the\pgfmath@count}%
   \def\pgfmath@token@next{#1}%
-  \expandafter\ifcat\pgfmath@token@next\relax%
+  \expandafter\ifcat\expandafter\noexpand\pgfmath@token@next\relax%
     % A CS following a count register should be \wd, \ht or \dp.
     \let\pgfmath@parse@next=\pgfmath@parse@number%
   \else%
@@ -715,9 +715,9 @@
   \pgfmath@parse@@@operator}
 
 \def\pgfmath@parse@@@operator{%
-  \expandafter\ifx\csname pgfmath@operator@\pgfmath@token\expandafter\string\pgfmath@token@next\endcsname\relax%
+  \expandafter\ifx\csname pgfmath@operator@\expandafter\string\pgfmath@token\expandafter\string\pgfmath@token@next\endcsname\relax%
     % Not a double character operator.
-    \expandafter\ifx\csname pgfmath@operator@\pgfmath@token\endcsname\relax%
+    \expandafter\ifx\csname pgfmath@operator@\expandafter\string\pgfmath@token\endcsname\relax%
       % Not a single character operator.
       \pgfmath@error{Unknown operator `\pgfmath@token' or `\pgfmath@token\pgfmath@token@next'}{}%
       \def\pgfmathresult{0}%
@@ -727,7 +727,7 @@
       \ifx\pgfmath@token\pgfmath@text@@%
         \let\pgfmath@parse@next=\pgfmath@parse@end%
       \else%
-        \expandafter\ifx\csname pgfmath@operation@\pgfmath@token @postfix\endcsname\pgfmath@token%
+        \expandafter\ifx\csname pgfmath@operation@\expandafter\string\pgfmath@token @postfix\endcsname\pgfmath@token%
           % Postfix operators are followed by an operator.
           \ifx\pgfmath@token@next\pgfmath@char@leftbracket% Except [.
             \let\pgfmath@parse@next=\pgfmath@parse@operand%

--- a/tex/generic/pgf/math/pgfmathparser.code.tex
+++ b/tex/generic/pgf/math/pgfmathparser.code.tex
@@ -352,7 +352,7 @@
           \expandafter\ifx\csname pgfmath@token@functional@\string#1\endcsname\relax%
             \let\pgfmath@base=\pgfmath@empty%
             \let\pgfmath@token@next=\pgfmath@token%
-            \if#10% Check for octal prefix.
+            \if\noexpand#10% Check for octal prefix.
               \ifpgfmath@octalparsing%
                 \def\pgfmath@base{8}%
               \fi%


### PR DESCRIPTION
In general, the grabbed token could always be active, so precautions are needed. Here, the places that the grabbed token is tested and those where it's used in a csname are addressed. The tests need \noexpand, the csname usage \string, with appropriate expansion.