### PR TITLE
Fixing typos

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-base-arrows.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-arrows.tex
@@ -484,7 +484,7 @@ fast arrow tip management.
             these ways is use can be configured by setting \meta{mode} to
             either |orthogonal| or to |polar|. It is best to try simply try out
             both when designing an arrow tip to see which works better. Since
-            |orthogonal| is quicker and often gives good oder even better
+            |orthogonal| is quicker and often gives good or even better
             results, it is the default. Some arrow tips, however, profit from
             saying |bending mode=polar|.
         \item \declare{|defaults|}|=|\meta{arrow keys}

--- a/doc/generic/pgf/pgfmanual-en-base-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-scopes.tex
@@ -278,7 +278,7 @@ Hello \begin{pgfpicture}
 
     Sometimes, you may need more fine-grained control over the size of the
     bounding box. For example, the computed bounding box may be too large or
-    you intensionally wish the box to be ``too small''. In these cases, you can
+    you intentionally wish the box to be ``too small''. In these cases, you can
     use the command |\pgfusepath{use as bounding box}|, as described in
     Section~\ref{section-using-bb}.
 

--- a/doc/generic/pgf/pgfmanual-en-gd-algorithm-layer.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-algorithm-layer.tex
@@ -494,7 +494,7 @@ summary       "Specifies the radius of a circle on which the nodes are placed."
 documentation
 [[
 This key can be used together with |very simple example layout|. An
-important feature ist that...
+important feature is that...
 ]]
 example
 [[

--- a/doc/generic/pgf/pgfmanual-en-guidelines.tex
+++ b/doc/generic/pgf/pgfmanual-en-guidelines.tex
@@ -645,7 +645,7 @@ Here is a non-exhaustive list of things that can distract readers:
     \item Background patterns filling an area using  diagonal lines or
         horizontal and vertical lines or just dots are almost always
         distracting and, usually, serve no real purpose.
-    \item Background images and shadings distract and only seldomly add
+    \item Background images and shadings distract and only seldom add
         anything of importance to a graphic.
     \item Cute little clip arts can easily draw attention away from the data.
 \end{itemize}

--- a/doc/generic/pgf/pgfmanual-en-library-fpu.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-fpu.tex
@@ -184,7 +184,7 @@ by \pgfname.
 \end{key}
 
 
-\subsection{Comparison to the fixed point arithmetics library}
+\subsection{Comparison to the fixed point arithmetic library}
 
 There are other ways to increase the data range and/or the precision of
 \pgfname's math parser. One of them is the |fp| package, preferable combined
@@ -618,7 +618,7 @@ been activated -- it is sufficient to load the library.
 \begin{command}{\pgfmathfloatmultiplyfixed\marg{float}\marg{fixed}}
     Defines |\pgfmathresult| to be $\meta{float} \cdot \meta{fixed}$ where
     \meta{float} is a floating point number and \meta{fixed} is a fixed point
-    number. The computation is performed in floating point arithmetics, that
+    number. The computation is performed in floating point arithmetic, that
     means we compute $m \cdot \meta{fixed}$ and renormalize the result where
     $m$ is the mantissa of \meta{float}.
 
@@ -674,7 +674,7 @@ been activated -- it is sufficient to load the library.
 \begin{command}{\pgfmathlog{\marg{x}}}
     Defines |\pgfmathresult| to be the natural logarithm of \meta{x},
     $\ln(\meta{x})$. This method is logically the same as |\pgfmathln|, but it
-    applies floating point arithmetics to read number \meta{x} and employs the
+    applies floating point arithmetic to read number \meta{x} and employs the
     logarithm identity \[ \ln(m \cdot 10^e) = \ln(m) + e \cdot \ln(10) \] to
     get the result. The factor $\ln(10)$ is a constant, so only $\ln(m)$ with
     $1 \le m < 10$ needs to be computed. This is done using standard pgf math

--- a/doc/generic/pgf/pgfmanual-en-math-numberprinting.tex
+++ b/doc/generic/pgf/pgfmanual-en-math-numberprinting.tex
@@ -184,7 +184,7 @@ precision.
     \paragraph{Second use-case:}
 
     improve rounding in the presence of \emph{inaccurate} numbers. Let us
-    suppose that some limited-precision arithmetics resulted in the result
+    suppose that some limited-precision arithmetic resulted in the result
     |123456999| (like the |fpu| of \pgfname). You know that its precision is
     about five or six significant digits. And you want to provide a fixed point
     output. In this case, the trailing digits |....999| are a numerical
@@ -398,7 +398,7 @@ precision.
     \begin{key}{/pgf/number format/frac shift=\marg{integer} (initially 4)}
         In case you experience problems because of stability problems, try
         experimenting with a different |frac shift|. Higher shift values $k$
-        yield higher sensitivity to inaccurate data or inaccurate arithmetics.
+        yield higher sensitivity to inaccurate data or inaccurate arithmetic.
 
         Technically, the following happens. If $r < 1$ is the fractional part
         of the mantissa, then a scale $i = 1/r \cdot 10^k$ is computed where

--- a/doc/generic/pgf/pgfmanual-en-math-parsing.tex
+++ b/doc/generic/pgf/pgfmanual-en-math-parsing.tex
@@ -809,8 +809,8 @@ some notable exceptions.
 \end{math-function}
 
 
-\subsubsection{Integer arithmetics functions}
-\label{pgfmath-functions-integerarithmetics}
+\subsubsection{Integer arithmetic functions}
+\label{pgfmath-functions-integerarithmetic}
 
 \begin{math-function}{gcd(\mvar{x},\mvar{y})}
 \mathcommand

--- a/doc/generic/pgf/pgfmanual-en-tikz-actions.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-actions.tex
@@ -1296,7 +1296,7 @@ the following two options:
 \end{tikzpicture}
 \end{codeexample}
 
-    Note that when the preactions are preformed, then the path is already
+    Note that when the preactions are performed, then the path is already
     ``finished''. In particular, applying a coordinate transformation to the
     path has no effect. By comparison, applying a canvas transformation does
     have an effect. Let us use this to add a ``shadow'' to a path. For this, we

--- a/doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
@@ -2773,7 +2773,7 @@ The following keys place nodes in a $N\times M$ grid.
     rows needed to lay out the graph in a grid with $M$ columns.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{graphs.standard}}]
-% An example with 6 nodes, 3 columns and therefor 2 rows
+% An example with 6 nodes, 3 columns and therefore 2 rows
 \tikz \graph [grid placement] { subgraph I_n[n=6, wrap after=3] };
 \end{codeexample}
     %

--- a/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
@@ -59,7 +59,7 @@ the node. Then, you can optionally \emph{name} the node by providing a name in
 parentheses. Lastly, for the |node| operation you must provide some label text
 for the node in curly braces, while for the |coordinate| operation you may not.
 The node is placed at the current position of the path either \emph{after the
-path has been drawn} or (more seldomly and only if you add the |behind path|
+path has been drawn} or (more seldom and only if you add the |behind path|
 option) \emph{just before the path is drawn.} Thus, all nodes are drawn ``on
 top'' or ``behind'' the path and are retained until the path is complete. If
 there are several nodes on a path, perhaps some behind and some on top of the

--- a/source/generic/pgf/c/graphdrawing/pgf/gd/interface/c/InterfaceFromC.c
+++ b/source/generic/pgf/c/graphdrawing/pgf/gd/interface/c/InterfaceFromC.c
@@ -225,7 +225,7 @@ static char* make_string_from(lua_State* L, const char* name)
 {
   lua_getfield(L, -1, name);
   if (lua_isnil(L, -1)) {
-    // Field not set; return emtpy string.
+    // Field not set; return empty string.
     lua_pop(L, 1);
     return (char*) calloc(1, sizeof(char));
   }

--- a/tex/generic/pgf/basiclayer/pgfcorepathprocessing.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcorepathprocessing.code.tex
@@ -70,10 +70,10 @@
 
 \def\pgfprocesssplitsubpath#1{%
   % First, we need to find the end:
-  \let\pgf@tempa\pgfutil@emtpy%
-  \let\pgf@tempb\pgfutil@emtpy%
-  \let\pgf@tempc\pgfutil@emtpy%
-  \let\pgf@tempd\pgfutil@emtpy%
+  \let\pgf@tempa\pgfutil@empty%
+  \let\pgf@tempb\pgfutil@empty%
+  \let\pgf@tempc\pgfutil@empty%
+  \let\pgf@tempd\pgfutil@empty%
   \let\pgfprocessresultsubpathprefix\pgfutil@empty%
   \let\pgfprocessresultsubpathsuffix\pgfutil@empty%
   \let\pgf@next\pgf@split@subpath%

--- a/tex/generic/pgf/basiclayer/pgfcoreshade.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcoreshade.code.tex
@@ -723,7 +723,7 @@
 }
 
 \def\pgffuncshadingcmyktorgb{%
-  % covert to CMY
+  % convert to CMY
   dup 3 1 roll add
   1.0 2 copy gt { exch } if pop
   4 1 roll
@@ -733,7 +733,7 @@
   add
   1.0 2 copy gt { exch } if pop
   3 1 roll
-  % covert to RGB
+  % convert to RGB
   1.0 exch sub
   3 1 roll
   1.0 exch sub

--- a/tex/generic/pgf/frontendlayer/tikz/libraries/graphs/tikzlibrarygraphs.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/libraries/graphs/tikzlibrarygraphs.code.tex
@@ -2053,7 +2053,7 @@
 % it resets the length and normal counters. It will setup a completely
 % new counting of lengths and counters inside the current scope.
 %
-% The placmenet/place key is executed automatically whenever a new
+% The placement/place key is executed automatically whenever a new
 % node is automatically created. Furthermore, placement strategies
 % will call this key.
 

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2497,7 +2497,7 @@
     \global\let\tikz@expand@last@token=\pgf@let@token
     \tikz@finish%
     %
-    % To be combatible with `scopes` lib, which uses a redefined 
+    % To be compatible with `scopes` lib, which uses a redefined 
     % \tikz@lib@scope@check to check the next token, the reinsertion is done
     % here, not at the end of (every) \tikz@finish.
     %

--- a/tex/generic/pgf/libraries/datavisualization/pgflibrarydatavisualization.barcharts.code.tex
+++ b/tex/generic/pgf/libraries/datavisualization/pgflibrarydatavisualization.barcharts.code.tex
@@ -85,7 +85,7 @@
           \pgfkeyssetvalue{/data point/\pgf@lib@attribute}\pgf@lib@low
           \pgfcanvaspositionofdatapoint%
           \pgfsettocanvasposition\pgf@dv@lib@lowpoint%
-          % Ok, compute hight point
+          % Ok, compute high point
           \pgfkeyssetvalue{/data point/\pgf@lib@attribute}\pgf@lib@high
           \pgfcanvaspositionofdatapoint%
           \pgfsettocanvasposition\pgf@dv@lib@highpoint%

--- a/tex/generic/pgf/libraries/pgflibraryarrows.code.tex
+++ b/tex/generic/pgf/libraries/pgflibraryarrows.code.tex
@@ -617,7 +617,7 @@
 
 
 
-% The halfs of the $\to$ arrow reversed
+% The halves of the $\to$ arrow reversed
 
 \pgfarrowsdeclare{left to reversed}{left to reversed}
 {

--- a/tex/generic/pgf/libraries/pgflibraryfpu.code.tex
+++ b/tex/generic/pgf/libraries/pgflibraryfpu.code.tex
@@ -2097,7 +2097,7 @@
     \pgfmathfloatshift@{\pgfmathfloat@loc@TMPa}{\pgfmathfloat@k}%
 }%
 % determine 'k'. This is a heuristics. The exponential series
-% converges best for |x| <= 1. However, the fixed point arithmetics
+% converges best for |x| <= 1. However, the fixed point arithmetic
 % for tex results in best results for large |x|. Well, I'll need to
 % tune this here.
 \def\pgfmathfloatexp@@toint#1.#2\relax{%

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
@@ -1087,7 +1087,7 @@
         \edef\outersep{\the\pgf@x}%
         %
         % The \externalradius is a length that is
-        % guarenteed to produce a point outside the trapezium.
+        % guaranteed to produce a point outside the trapezium.
         %
         \advance\pgf@xc2.0\pgf@x%
         \pgf@yc\halfheight\relax%
@@ -1099,7 +1099,7 @@
             \edef\externalradius{\the\pgf@xc}%
         \fi%
         %
-        % Calculate the centre base and mid poins of the node.
+        % Calculate the centre base and mid points of the node.
         %
         \pgfextract@process\centerpoint{%
             \pgf@x.5\wd\pgfnodeparttextbox%
@@ -1462,7 +1462,7 @@
         \pgfmathanglebetweenpoints{\referencepoint}{\pgfqpoint{\externalx}{\externaly}}%
         %
         % *Subtract* the rotation from the external angle. This is
-        % why the border point angles do not neeed to be rotated.
+        % why the border point angles do not need to be rotated.
         %
         \pgfmathsubtract@{\pgfmathresult}{\rotate}%
         \ifdim\pgfmathresult pt<0pt\relax%

--- a/tex/generic/pgf/math/pgfmathcalc.code.tex
+++ b/tex/generic/pgf/math/pgfmathcalc.code.tex
@@ -353,12 +353,12 @@
 %
 % A bit experimental at the moment:
 %
-% Locates the point where a line crosses an eliptical arc. If the line
+% Locates the point where a line crosses an elliptical arc. If the line
 % does not cross the arc, a meaningless point will result.
 %
 % #1 the point of the line on the "convex" side of the arc.
 % #2 the point of the line on the "concave" side of the arc.
-% #3 the center of the eliptical arc.
+% #3 the center of the elliptical arc.
 % #4 start angle of the arc.
 % #5 end angle of the arc.
 % #6 radii of the arc.

--- a/tex/generic/pgf/math/pgfmathfunctions.random.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.random.code.tex
@@ -17,7 +17,7 @@
 % \book@{pressetal1992,
 %    author    = {William H. Press and Brian P. Flannery and Saul A.
 %                 Teukolsky and William T. Vetterling},
-%    title     = {Numerical Recipies in C},
+%    title     = {Numerical Recipes in C},
 %    edition   = {Second},
 %    publisher = {Cambridge University Press}
 % }

--- a/tex/generic/pgf/modules/pgfmoduledatavisualization.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduledatavisualization.code.tex
@@ -2657,14 +2657,14 @@
   % \legend.add entry(seventh)
   % \legend.get arrangement(\arrangement)
   %
-  % Then \arrangment will expand to
+  % Then \arrangement will expand to
   %
   %   first  \pgfdvnextcell   fourth  \pgfdvnextcell  seventh  \pgfdvendrow
   %   second \pgfdvnextcell   fifth   \pgfdvnextcell  third    \pgfdvendrow
   %   third  \pgfdvendrow   sixth   \pgfdvnextcell           \pgfdvendrow
   %
   % By saying \let\pgfdvendrow=\\ and \let\pgfdvnextcell=&, you
-  % can use \arrangment inside a table.
+  % can use \arrangement inside a table.
 
 
   \attribute entries;%

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -237,7 +237,7 @@
 %   \pgfpositionnodelaterminy
 %   \pgfpositionnodelatermaxy
 %   These four macros store the bounding box as dimensions that are
-%   guarenteed to end with "pt".
+%   guaranteed to end with "pt".
 %
 % By setting #1 to \relax (which is the default), you can switch off
 % the whole mechanism

--- a/tex/generic/pgf/utilities/pgfkeyslibraryfiltered.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeyslibraryfiltered.code.tex
@@ -472,7 +472,7 @@
 
 \pgfkeys{%
     /errors/family unknown/.code=\pgfkeys@error{%
-        Sorry, I do not know family '#1' and can't work with any assoicated family handling. Perhaps you misspelled it?},
+        Sorry, I do not know family '#1' and can't work with any associated family handling. Perhaps you misspelled it?},
     /errors/no such key filter/.code 2 args=\pgfkeys@error{Sorry, there is no such key filter '#1'.},
     /errors/no such key filter handler/.code 2 args=\pgfkeys@error{Sorry, there is no such key filter handler '#1'.},
     % HANDLERS:

--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -728,7 +728,7 @@
 }%
 
 % Same as \pgfutilsolvetwotwoleq, but using floating point
-% arithmetics. The return value is still in fixed point.
+% arithmetic. The return value is still in fixed point.
 \def\pgfutilsolvetwotwoleqfloat#1#2{%
     \begingroup
         \pgfmathfloatcreate{1}{1.0}{-4}% FIXME : use a smaller threshold for FPU?


### PR DESCRIPTION
This PR fixes various typos I spotted in the documentation and in the source code.

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]