### PR TITLE
Fix typo

### DIFF
--- a/tex/generic/pgf/basiclayer/pgfcorepathprocessing.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcorepathprocessing.code.tex
@@ -70,10 +70,10 @@
 
 \def\pgfprocesssplitsubpath#1{%
   % First, we need to find the end:
-  \let\pgf@tempa\pgfutil@emtpy%
-  \let\pgf@tempb\pgfutil@emtpy%
-  \let\pgf@tempc\pgfutil@emtpy%
-  \let\pgf@tempd\pgfutil@emtpy%
+  \let\pgf@tempa\pgfutil@empty%
+  \let\pgf@tempb\pgfutil@empty%
+  \let\pgf@tempc\pgfutil@empty%
+  \let\pgf@tempd\pgfutil@empty%
   \let\pgfprocessresultsubpathprefix\pgfutil@empty%
   \let\pgfprocessresultsubpathsuffix\pgfutil@empty%
   \let\pgf@next\pgf@split@subpath%


### PR DESCRIPTION
This PR fixes four typos I spotted in the source code.

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]