### PR TITLE
Fix typo in pgfmanual-en-pgfkeys.tex

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
@@ -995,7 +995,7 @@ A number of handlers exist for defining the code of keys.
     special value |\pgfkeysnovalue|.
 
     It is permissible that \meta{code} calls the command |\pgfkeys|. It is also
-    permissible the \meta{code} calls the command |\pgfkeysalso|, which is
+    permissible that \meta{code} calls the command |\pgfkeysalso|, which is
     useful for styles, see below.
     %
 \begin{codeexample}[code only]


### PR DESCRIPTION
Fix typo in pgfkeys manual

**Motivation for this change**

I noticed a typo in the manual of pgfkeys.

**Checklist**

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
