### PR TITLE
Adapt short verb usages

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Typo fixes in the manual
+- Simplify short verb `|...|` or add required preamble for it
 
 ### Contributors
 

--- a/doc/generic/pgf/pgfmanual-en-base-shadings.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-shadings.tex
@@ -357,7 +357,7 @@ explicit color model (|rgb|, |cmyk|, or |gray|).
         defined, which store the individual components of \meta{color name}.
         These can also be used in the \meta{type 4 function} argument.
         %
-\begin{codeexample}[]
+\begin{codeexample}[preamble={\usepackage{shortvrb} \MakeShortVerb{\|}}]
 \pgfshadecolortorgb{orange}{\mycol}
 |\mycol|=\mycol |\mycolred|=\mycolred |\mycolgreen|=\mycolgreen |\mycolblue|=\mycolblue
 \end{codeexample}

--- a/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
@@ -565,12 +565,12 @@ instance, assume that you have a key that expects a \meta{value} of the form
 ``\meta{text}|+|\meta{more text}'' and wishes to store \meta{text} and
 \meta{more text} in two different macros. This can be achieved as follows:
 %
-\begin{codeexample}[]
+\begin{codeexample}[preamble={\usepackage{shortvrb} \MakeShortVerb{\|}}]
 \def\mystore#1+#2\pgfeov{\def\a{#1}\def\b{#2}}
 \pgfkeyslet{/my key/.@cmd}{\mystore}
 \pgfkeys{/my key=hello+world}
 
-|\a| is \a, |\b| is \b.
+|\a| is `\a', |\b| is `\b'.
 \end{codeexample}
 
 Naturally, defining the code to be stored in a key in the above manner is too
@@ -604,7 +604,7 @@ Section~\ref{section-code-handlers}.
     This command works like |\pgfkeysdef|, but it allows you to provide an
     arbitrary \meta{argument count} between $0$ and $9$ (inclusive).
     %
-\begin{codeexample}[]
+\begin{codeexample}[preamble={\usepackage{shortvrb} \MakeShortVerb{\|}}]
 \pgfkeysdefnargs{/my key}{2}{\def\a{#1}\def\b{#2}}
 \pgfkeys{/my key=
     {hello}
@@ -624,11 +624,11 @@ Section~\ref{section-code-handlers}.
     This command works like |\pgfkeysdefnargs|, but it allows you to provide an
     arbitrary \meta{argument pattern} rather than just a number of arguments.
     %
-\begin{codeexample}[]
+\begin{codeexample}[preamble={\usepackage{shortvrb} \MakeShortVerb{\|}}]
 \pgfkeysdefargs{/my key}{#1+#2}{\def\a{#1}\def\b{#2}}
 \pgfkeys{/my key=hello+world}
 
-|\a| is \a, |\b| is \b.
+|\a| is `\a', |\b| is `\b'.
 \end{codeexample}
     %
     Note that |\pgfkeysdefnargs| is \emph{better} when it comes to simple

--- a/doc/generic/pgf/pgfmanual-en-tikz-coordinates.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-coordinates.tex
@@ -380,11 +380,11 @@ following coordinate system:
         Specifies an anchor of the node. Here is an example:
         %
 \begin{codeexample}[preamble={\usetikzlibrary{arrows.meta}}]
-\begin{tikzpicture}
-  \node (shape)   at (0,2)  [draw] {|class Shape|};
-  \node (rect)    at (-2,0) [draw] {|class Rectangle|};
-  \node (circle)  at (2,0)  [draw] {|class Circle|};
-  \node (ellipse) at (6,0)  [draw] {|class Ellipse|};
+\begin{tikzpicture}[node font=\ttfamily]
+  \node (shape)   at (0,2)  [draw] {class Shape};
+  \node (rect)    at (-2,0) [draw] {class Rectangle};
+  \node (circle)  at (2,0)  [draw] {class Circle};
+  \node (ellipse) at (6,0)  [draw] {class Ellipse};
 
   \draw (node cs:name=circle,anchor=north) |- (0,1);
   \draw (node cs:name=ellipse,anchor=north) |- (0,1);


### PR DESCRIPTION
**Motivation for this change**

Simplify short verb `|...|` or add required preamble for it. See #1267.

`*.lvt` files generated in #1116 are used for filtering short verb usages.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
