### PR TITLE
Simplify the stripe-pattern matrix example

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-tikz-matrices.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-matrices.tex
@@ -486,24 +486,28 @@ create certain effects.
 \begin{codeexample}[preamble={\usetikzlibrary{matrix,fit}}]
 \begin{tikzpicture}[
   font=\sffamily,
-  striped col/.style={column #1/.append style={
-        every even row/.style={nodes={fill=olive!50}}}},
-  head color/.style args={#1/#2}{column #1/.append style={
-        row 1/.append style={nodes={fill=#2}}}}
+  head color/.style args={#1/#2}{
+    row 1 column #1/.append style={nodes={fill=#2}}},
+  % swap order of row and column styles
+  matrix/inner style order={
+    every cell,
+    row, even odd row,
+    column, even odd column,
+    cell
+  }
 ]
 
 \matrix [
    matrix of nodes, nodes in empty cells,
    nodes={text width=2cm, align=center,
           minimum height=1.5em, anchor=center},
-   striped col/.list={1,...,5}, % add striped col style to all cols
-   column 1/.style={ % Override stripes and modify the feature column
-     row 1 column 1/.style={nodes={fill=none, draw=none}},
-     nodes={fill=olive, inner ysep=0},
-   },
-   % modify headers first via common styles and then specific colors
-   row 1/.style={nodes={text depth=0.2ex, text width=2cm, text=white}},
-   head color/.list={2/orange,3/teal,4/cyan,5/magenta}
+   % add striped row style
+   every even row/.style={nodes={fill=olive!50}},
+   % modify the feature column and header row
+   column 1/.style=      {nodes={fill=olive, inner ysep=0}},
+   row 1/.style=         {nodes={text depth=0.2ex, text=white}},
+   row 1 column 1/.style={nodes={fill=none, draw=none}},
+   head color/.list={2/orange,3/teal,4/cyan,5/magenta} % specify header colors
   ] (m)
   {
             & Basic     & Standard   & Professional & Enterprise \\
@@ -515,7 +519,7 @@ create certain effects.
   };
 % Add emphasis on selection by the use of "fit" library
 \node[fit={(m-1-4.north west) (m-6-4.south east)},
-      ultra thick, inner sep=0, rounded corners=1mm,
+      ultra thick, inner sep=0pt, rounded corners=1mm,
       draw=cyan, label={[cyan,align=center]270:Popular\\Choice!}]{};
 \end{tikzpicture}
 \end{codeexample}


### PR DESCRIPTION
**Motivation for this change**

This PR tries to simplify the stripe-pattern matrix example previously add in #871 and improved in #873.

Not a serious change but just to make the changes comparable and reviewable.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
