### PR TITLE
allow sloped/transform shape with non-identity transformation

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -23,7 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Andreas Deininger
 - Matthias Hetzenberger
-- muzimuzhi
 - Qrrbrbirlbel
 - quark67
 - thinbold

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Typo in animations `end on` key #1273
+- `sloped` should consider the current transformation #1058
 
 ### Changed
 
@@ -22,8 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Andreas Deininger
 - Matthias Hetzenberger
+- muzimuzhi
 - Qrrbrbirlbel
 - quark67
+- thinbold
 - Yukai Chou (muzimuzhi)
 
 ## [3.1.10] - 2023-01-13 Henri Menke

--- a/tex/generic/pgf/basiclayer/pgfcoretransformations.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcoretransformations.code.tex
@@ -466,6 +466,10 @@
 % }
 %
 \def\pgftransformlineattime#1#2#3{%
+  \let\pgf@tempaa\pgf@pt@aa
+  \let\pgf@tempab\pgf@pt@ab
+  \let\pgf@tempba\pgf@pt@ba
+  \let\pgf@tempbb\pgf@pt@bb
   \pgf@process{#2}%
   \pgf@xb=\pgf@x% xb/yb = start point
   \pgf@yb=\pgf@y%
@@ -479,6 +483,14 @@
   \ifpgfslopedattime%
     \advance\pgf@xc by-\pgf@xb%
     \advance\pgf@yc by-\pgf@yb%
+    \ifpgfresetnontranslationattime
+      \begingroup
+        \pgfsettransformentries{\pgf@tempaa}{\pgf@tempab}{\pgf@tempba}{\pgf@tempbb}{0pt}{0pt}%
+        \pgf@pos@transform{\pgf@xc}{\pgf@yc}%
+        \xdef\pgf@marshal{\pgf@xc=\the\pgf@xc\pgf@yc=\the\pgf@yc}%
+      \endgroup
+      \pgf@marshal
+    \fi
     \ifpgfallowupsidedownattime%
     \else%
       \ifdim\pgf@xc<0pt%
@@ -515,6 +527,10 @@
 % }
 
 \def\pgftransformarcaxesattime#1#2#3#4#5#6{%
+  \let\pgf@tempaa\pgf@pt@aa
+  \let\pgf@tempab\pgf@pt@ab
+  \let\pgf@tempba\pgf@pt@ba
+  \let\pgf@tempbb\pgf@pt@bb
   \pgfpointarcaxesattime{#1}{#2}{#3}{#4}{#5}{#6}%
   \pgftransformshift{\pgfqpoint{\pgf@x}{\pgf@y}}%
   \ifpgfresetnontranslationattime%
@@ -523,6 +539,12 @@
   \ifpgfslopedattime%
     \pgf@x=\pgf@xa%
     \pgf@y=\pgf@ya%
+    \ifpgfresetnontranslationattime
+      \begingroup
+        \pgfsettransformentries{\pgf@tempaa}{\pgf@tempab}{\pgf@tempba}{\pgf@tempbb}{0pt}{0pt}%
+        \pgf@process{\pgf@pos@transform{\pgf@x}{\pgf@y}}%
+      \endgroup
+    \fi
     \pgf@process{\pgfpointnormalised{}}%
     \ifpgfallowupsidedownattime%
     \else%
@@ -564,6 +586,10 @@
 % }
 %
 \def\pgftransformcurveattime#1#2#3#4#5{%
+  \let\pgf@tempaa\pgf@pt@aa
+  \let\pgf@tempab\pgf@pt@ab
+  \let\pgf@tempba\pgf@pt@ba
+  \let\pgf@tempbb\pgf@pt@bb
   \pgfpointcurveattime{#1}{#2}{#3}{#4}{#5}%
   \pgftransformshift{\pgfqpoint{\pgf@x}{\pgf@y}}%
   \ifpgfresetnontranslationattime%
@@ -574,6 +600,12 @@
     \pgf@y=\pgf@ya%
     \advance\pgf@x by-\pgf@xb%
     \advance\pgf@y by-\pgf@yb%
+    \ifpgfresetnontranslationattime
+      \begingroup
+        \pgfsettransformentries{\pgf@tempaa}{\pgf@tempab}{\pgf@tempba}{\pgf@tempbb}{0pt}{0pt}%
+        \pgf@process{\pgf@pos@transform{\pgf@x}{\pgf@y}}%
+      \endgroup
+    \fi
     \ifpgfallowupsidedownattime%
     \else%
       \ifdim\pgf@x<0pt%

--- a/tex/generic/pgf/basiclayer/pgfcoretransformations.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcoretransformations.code.tex
@@ -444,6 +444,45 @@
 \newif\ifpgfallowupsidedownattime
 \newif\ifpgfresetnontranslationattime
 
+% Common code for \pgftransformlineatttime,
+% \pgftransformarcaxesattime and \pgftransformcurveattime
+%
+% #1 = \pgfpoint...attime
+% #2 = Setup for tangent in \pgf@x and \pgf@y for \ifslopedattime
+
+\def\pgftransform@commonattime#1#2{%
+  \let\pgf@tempaa\pgf@pt@aa
+  \let\pgf@tempab\pgf@pt@ab
+  \let\pgf@tempba\pgf@pt@ba
+  \let\pgf@tempbb\pgf@pt@bb
+  #1%
+  \pgftransformshift{}%
+  \ifpgfresetnontranslationattime
+    \pgftransformresetnontranslations
+  \fi
+  \ifpgfslopedattime
+    #2%
+    \ifpgfresetnontranslationattime
+      \begingroup
+        \pgfsettransformentries{\pgf@tempaa}{\pgf@tempab}{\pgf@tempba}{\pgf@tempbb}{0pt}{0pt}%
+        \pgf@process{\pgf@pos@transform{\pgf@x}{\pgf@y}}%
+      \endgroup
+    \fi
+    \pgfpointnormalised{}% x/y = normalised vector
+    \ifpgfallowupsidedownattime
+    \else
+      \ifdim\pgf@x<0pt
+        \pgf@x=-\pgf@x
+        \pgf@y=-\pgf@y
+      \fi
+    \fi
+    \pgf@ya=-\pgf@y
+    \pgftransformcm
+    {\pgf@sys@tonumber{\pgf@x}}{\pgf@sys@tonumber{\pgf@y}}%
+    {\pgf@sys@tonumber{\pgf@ya}}{\pgf@sys@tonumber{\pgf@x}}{\pgfpointorigin}%
+  \fi
+}
+
 
 % Transform to the coordinate system of a point on a line
 %
@@ -455,57 +494,23 @@
 % Example:
 %
 % {
-%   \pgftransformlineattime{.5}{\pgfxy(0,0)}{\pgfxy(3,2)}
+%   \pgftransformlineattime{.5}{\pgfpointxy{0}{0}}{\pgfpointxy{3}{2}}
 %   \pgftext{Hi!}
 % }
 %
 % {
-%   \pgftransformlineattime{.75}{\pgfxy(0,0)}{\pgfxy(3,2)}
+%   \pgftransformlineattime{.75}{\pgfpointxy{0}{0}}{\pgfpointxy{3}{2}}
 %   \pgftransformresetnontranslations
 %   \pgftext{Hi!}
 % }
 %
 \def\pgftransformlineattime#1#2#3{%
-  \let\pgf@tempaa\pgf@pt@aa
-  \let\pgf@tempab\pgf@pt@ab
-  \let\pgf@tempba\pgf@pt@ba
-  \let\pgf@tempbb\pgf@pt@bb
-  \pgf@process{#2}%
-  \pgf@xb=\pgf@x% xb/yb = start point
-  \pgf@yb=\pgf@y%
-  \pgf@process{#3}%
-  \pgf@xc=\pgf@x% xc/yc = end point
-  \pgf@yc=\pgf@y%
-  \pgftransformshift{\pgfpointlineattime{#1}{\pgfqpoint{\pgf@xb}{\pgf@yb}}{\pgfqpoint{\pgf@xc}{\pgf@yc}}}%
-  \ifpgfresetnontranslationattime%
-    \pgftransformresetnontranslations%
-  \fi%
-  \ifpgfslopedattime%
-    \advance\pgf@xc by-\pgf@xb%
-    \advance\pgf@yc by-\pgf@yb%
-    \ifpgfresetnontranslationattime
-      \begingroup
-        \pgfsettransformentries{\pgf@tempaa}{\pgf@tempab}{\pgf@tempba}{\pgf@tempbb}{0pt}{0pt}%
-        \pgf@pos@transform{\pgf@xc}{\pgf@yc}%
-        \xdef\pgf@marshal{\pgf@xc=\the\pgf@xc\pgf@yc=\the\pgf@yc}%
-      \endgroup
-      \pgf@marshal
-    \fi
-    \ifpgfallowupsidedownattime%
-    \else%
-      \ifdim\pgf@xc<0pt%
-        \pgf@xc=-\pgf@xc%
-        \pgf@yc=-\pgf@yc%
-      \fi%
-    \fi%
-    \pgf@x=\pgf@xc%
-    \pgf@y=\pgf@yc%
-    \pgfpointnormalised{}% x/y = normalised vector
-    \pgf@ya=-\pgf@y%
-    \pgftransformcm%
-    {\pgf@sys@tonumber{\pgf@x}}{\pgf@sys@tonumber{\pgf@y}}%
-    {\pgf@sys@tonumber{\pgf@ya}}{\pgf@sys@tonumber{\pgf@x}}{\pgfpointorigin}%
-  \fi%
+  \pgftransform@commonattime{%
+    \pgfpointlineattime{#1}{#2}{#3}%
+  }{% \pgfpointlineattime provides tangent in xa/ya
+    \pgf@x=\pgf@xa
+    \pgf@y=\pgf@ya
+  }%
 }
 
 
@@ -522,42 +527,17 @@
 % Example:
 %
 % {
-%   \pgftransformlineattime{.5}{\pgfpoint{1cm}{1cm}}{\pgfpoint{1cm}{0cm}}{\pgfpoint{0cm}{1cm}}{30}{40}
+%   \pgftransformarcaxesattime{.5}{\pgfpoint{1cm}{1cm}}{\pgfpoint{1cm}{0cm}}{\pgfpoint{0cm}{1cm}}{30}{40}
 %   \pgftext{Hi!}
 % }
 
 \def\pgftransformarcaxesattime#1#2#3#4#5#6{%
-  \let\pgf@tempaa\pgf@pt@aa
-  \let\pgf@tempab\pgf@pt@ab
-  \let\pgf@tempba\pgf@pt@ba
-  \let\pgf@tempbb\pgf@pt@bb
-  \pgfpointarcaxesattime{#1}{#2}{#3}{#4}{#5}{#6}%
-  \pgftransformshift{\pgfqpoint{\pgf@x}{\pgf@y}}%
-  \ifpgfresetnontranslationattime%
-    \pgftransformresetnontranslations%
-  \fi%
-  \ifpgfslopedattime%
-    \pgf@x=\pgf@xa%
-    \pgf@y=\pgf@ya%
-    \ifpgfresetnontranslationattime
-      \begingroup
-        \pgfsettransformentries{\pgf@tempaa}{\pgf@tempab}{\pgf@tempba}{\pgf@tempbb}{0pt}{0pt}%
-        \pgf@process{\pgf@pos@transform{\pgf@x}{\pgf@y}}%
-      \endgroup
-    \fi
-    \pgf@process{\pgfpointnormalised{}}%
-    \ifpgfallowupsidedownattime%
-    \else%
-      \ifdim\pgf@x<0pt%
-        \pgf@x=-\pgf@x%
-        \pgf@y=-\pgf@y%
-      \fi%
-    \fi%
-    \pgf@ya=-\pgf@y%
-    \pgftransformcm%
-    {\pgf@sys@tonumber{\pgf@x}}{\pgf@sys@tonumber{\pgf@y}}%
-    {\pgf@sys@tonumber{\pgf@ya}}{\pgf@sys@tonumber{\pgf@x}}{\pgfpointorigin}%
-  \fi%
+  \pgftransform@commonattime{%
+    \pgfpointarcaxesattime{#1}{#2}{#3}{#4}{#5}{#6}%
+  }{% \pgfpointarcaxestime provides tangent in xa/ya
+    \pgf@x=\pgf@xa
+    \pgf@y=\pgf@ya
+  }%
 }
 
 
@@ -575,50 +555,26 @@
 % Example:
 %
 % {
-%   \pgftransformcurveattime{.5}{\pgfxy(0,0)}{\pgfxy(3,2)}
+%   \pgftransformcurveattime{.5}{\pgfpointxy{0}{0}}{\pgfpointxy{1}{1}}{\pgfpointxy{2}{2}}{\pgfpointxy{3}{2}}
 %   \pgftext{Hi!}
 % }
 %
 % {
-%   \pgftransformcurveattime{.75}{\pgfxy(0,0)}{\pgfxy(3,2)}
+%   \pgftransformcurveattime{.75}{\pgfpointxy{0}{0}}{\pgfpointxy{1}{1}}{\pgfpointxy{2}{2}}{\pgfpointxy{3}{2}}
 %   \pgftransformresetnontranslations
 %   \pgftext{Hi!}
 % }
 %
 \def\pgftransformcurveattime#1#2#3#4#5{%
-  \let\pgf@tempaa\pgf@pt@aa
-  \let\pgf@tempab\pgf@pt@ab
-  \let\pgf@tempba\pgf@pt@ba
-  \let\pgf@tempbb\pgf@pt@bb
-  \pgfpointcurveattime{#1}{#2}{#3}{#4}{#5}%
-  \pgftransformshift{\pgfqpoint{\pgf@x}{\pgf@y}}%
-  \ifpgfresetnontranslationattime%
-    \pgftransformresetnontranslations%
-  \fi%
-  \ifpgfslopedattime%
-    \pgf@x=\pgf@xa%
-    \pgf@y=\pgf@ya%
-    \advance\pgf@x by-\pgf@xb%
-    \advance\pgf@y by-\pgf@yb%
-    \ifpgfresetnontranslationattime
-      \begingroup
-        \pgfsettransformentries{\pgf@tempaa}{\pgf@tempab}{\pgf@tempba}{\pgf@tempbb}{0pt}{0pt}%
-        \pgf@process{\pgf@pos@transform{\pgf@x}{\pgf@y}}%
-      \endgroup
-    \fi
-    \ifpgfallowupsidedownattime%
-    \else%
-      \ifdim\pgf@x<0pt%
-        \pgf@x=-\pgf@x%
-        \pgf@y=-\pgf@y%
-      \fi%
-    \fi%
-    \pgfpointnormalised{}% x/y = normalised vector
-    \pgf@ya=-\pgf@y%
-    \pgftransformcm%
-    {\pgf@sys@tonumber{\pgf@x}}{\pgf@sys@tonumber{\pgf@y}}%
-    {\pgf@sys@tonumber{\pgf@ya}}{\pgf@sys@tonumber{\pgf@x}}{\pgfpointorigin}%
-  \fi%
+  \pgftransform@commonattime{%
+    \pgfpointcurveattime{#1}{#2}{#3}{#4}{#5}%
+  }{% \pgfpoointcurveattime provides tangent xa/ya -- xb/yb
+    % need to calculate difference for tangent direction
+    \pgf@x=\pgf@xa
+    \pgf@y=\pgf@ya
+    \advance\pgf@x by-\pgf@xb
+    \advance\pgf@y by-\pgf@yb
+  }%
 }
 
 


### PR DESCRIPTION
This applies the fixes of @thinbold and @muzimuzhi also to curves and arc while not globalize xc/yc for the line function.

In my opinion, this is not a breaking change because the previous behavior was never the intended way.

**Motivation for this change**

Fixes #1058

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [X] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
