### PR TITLE
docs: fix default for isosceles triangle stretches

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-library-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-shapes.tex
@@ -461,7 +461,7 @@ anchors.
         Sets the angle of the apex of the isosceles triangle.
     \end{key}
 
-    \begin{key}{/pgf/isosceles triangle stretches=\meta{boolean} (default true)}
+    \begin{key}{/pgf/isosceles triangle stretches=\meta{boolean} (default false)}
         By default \meta{boolean} is |false|. This means, that when applying
         any minimum width or minimum height requirements, increasing the height
         will increase the width (and vice versa), in order to keep the apex


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Inconsistency in documentation.

For `isosceles triangle stretches`, the documentation currently states “default true” and “By default *⟨boolean⟩* is `false`.” A quick tests shows that `false` is correct.