### PR TITLE
docs: cleanup pgfmanual preamble

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-main-preamble.tex
+++ b/doc/generic/pgf/pgfmanual-en-main-preamble.tex
@@ -100,7 +100,7 @@
   perspective,
 }
 
-\usepackage{ifluatex}
+\usepackage{iftex}
 \newif\ifgdccodebasic
 \newif\ifgdccodeogdf
 
@@ -168,14 +168,7 @@
   % required by luatextra. Needs to be \relaxed since
   % pgfmanual-en-macros.tex defines an environment named filedescription
   \let\filedescription\relax
-  \usepackage[utf8]{luainputenc}
-  % dvisvgm does not support OpenType fonts so we have to bite the bullet and
-  % use T1 where quotes are weird.  In LuaTeX \outputmode=0 means DVI.
-  \ifnum\outputmode=0
-    \usepackage[T1]{fontenc}
-  \fi
 \else
-  \usepackage[utf8]{inputenc}
   \usepackage[T1]{fontenc}
 \fi
 


### PR DESCRIPTION
- Replace deprecated `ifluatex` package with `iftex`
- Drop setting input encoding to `utf8` `utf8` has been the new default since LaTeX2e release 2018-04-01.
- Drop setting `T1` font encoding for `dvisvgm` `dvisvgm` has supported OpenType fonts for years.

**Motivation for this change**

Preparation for adding a log analyzing step to manual compiling workflow, using [`texlogsieve`](https://ctan.org/pkg/texlogsieve) (#1210 proposed a manual way using `grep`).
```bash
texlogsieve --only-summary pgfmanual.log
```

Currently `texlogsieve` throws parsing errors among log lines written by `luainputinc`. I then found it's not required anymore in nowadays LuaLaTeX documents, along with some more cleanup opportunities in pgfmanual preamble.

<details><summary><code>texlogsieve</code> errors and corresponding log lines</summary>
<p>

```
/    texlogsieve: parsing error near input line 1350 (utf8FontMapHandler:handleOtherLines)
    texlogsieve: parsing error near input line 1356 (utf8FontMapHandler:handleOtherLines)
-    texlogsieve: parsing error near input line 1362 (utf8FontMapHandler:handleOtherLines)
\    texlogsieve: parsing error near input line 1368 (utf8FontMapHandler:handleOtherLines)
```

```
(/usr/local/texlive/2023/texmf-dist/tex/lualatex/luainputenc/lutf8.def
File: lutf8.def 2010/05/10 v0.97 UTF-8 support for luainputenc
Now handling font encoding OML ...
... no UTF-8 mapping file for font encoding OML
Now handling font encoding OMS ...
... processing UTF-8 mapping file for font encodingOMS

(/usr/local/texlive/2023/texmf-dist/tex/latex/base/omsenc.dfu
File: omsenc.dfu 2022/06/07 v1.3c UTF-8 support
)
Now handling font encoding OT1 ...
... processing UTF-8 mapping file for font encodingOT1

(/usr/local/texlive/2023/texmf-dist/tex/latex/base/ot1enc.dfu
File: ot1enc.dfu 2022/06/07 v1.3c UTF-8 support
)
Now handling font encoding T1 ...
... processing UTF-8 mapping file for font encodingT1

(/usr/local/texlive/2023/texmf-dist/tex/latex/base/t1enc.dfu
File: t1enc.dfu 2022/06/07 v1.3c UTF-8 support
)
Now handling font encoding TS1 ...
... processing UTF-8 mapping file for font encodingTS1
```

</p>
</details> 


**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
