### PR TITLE
Fix missing files in CTAN zip created by `l3build ctan`

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -9,11 +9,8 @@ tdsdirs = {tex = "tex"}
 
 -- For the manual
 docfiledir = "./doc/generic/pgf"
-docfiles =
-  {
-    "RELEASE_NOTES.md", "description.html", -- Part of the release script
-    "color.cfg", "pgfmanual.cfg", "images", "plots", "*.tex" -- Build the manual
-  }
+-- although some are useless in `l3build doc`, all are needed by `l3build ctan`
+docfiles = { "*" }
 tdsroot = "generic"
 typesetfiles = {"pgfmanual.tex"}
 typesetexe = "lualatex"

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Output bounding box adjustment in pgfsys-dvisvgm.def #1275
 - Fix shadings under LuaMetaTeX
 - Resolve missing `gnuplot` plots in manual #1238
+- Missing files in release zip, including licenses and more #1240
 
 ### Changed
 


### PR DESCRIPTION
**Motivation for this change**

This PR adds back `./source` directory and missing files including licenses and more under `./doc` to CTAN zip.

Therefor it makes the content and structure of CTAN zip almost the same as that in [`pgf_3.1.9.tds.zip`](https://github.com/pgf-tikz/pgf/releases/download/3.1.9/pgf_3.1.9.tds.zip), generated by [`generate_CTANzip()`](https://github.com/pgf-tikz/pgf/blob/3.1.9a/build.lua#L307-L353) defined in `build.lua`, with a flattened doc directory structure.

I will show the specific changes perhaps in the form of `git diff` on `tree <dirname>` outputs to show what's really changed.

Fixes #1240

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
