### PR TITLE
\makeatletter and \makeatother should match.

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-tikz-coordinates.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-coordinates.tex
@@ -663,6 +663,7 @@ coordinate systems. For this, the following commands are used:
 \define@key{cylindricalkeys}{angle}{\def\myangle{#1}}
 \define@key{cylindricalkeys}{radius}{\def\myradius{#1}}
 \define@key{cylindricalkeys}{z}{\def\myz{#1}}
+\makeatother
 \tikzdeclarecoordinatesystem{cylindrical}%
 {%
   \setkeys{cylindricalkeys}{#1}%


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**
It's a typo, `\makeatletter` and `\makeatother` should match.
<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
