### PR TITLE
doc(manual): fix typo in intro: "questions" => "question"

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/pgfmanual-en-introduction.tex
@@ -19,7 +19,7 @@ fortunately this documentation comes with a number of slowly-paced tutorials tha
 will teach you almost all you should know about \tikzname\ without your having
 to read the rest.
 
-I wish to start with the questions ``What is \tikzname?'' Basically, it just
+I wish to start with the question ``What is \tikzname?'' Basically, it just
 defines a number of \TeX\ commands that draw graphics. For example, the code
 |\tikz \draw (0pt,0pt) -- (20pt,6pt);| yields the line \tikz \draw (0pt,0pt) --
 (20pt,6pt); and the code |\tikz \fill[orange] (1ex,1ex) circle (1ex);| yields


### PR DESCRIPTION
Fix in context -- "question" should be singular:

> I wish to start with the question “What is TikZ?”


**Motivation for this change**

Fixes typo in the manual's introduction.
