### PR TITLE
docs: fix typo in pgfmanual: "which where" => "which were"

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-pgffor.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgffor.tex
@@ -100,7 +100,7 @@ This section describes the package |pgffor|, which is loaded automatically by
     ``missing values''. More precisely, the following happens:
 
     Normally, when a list item |...| is encountered, there should already have
-    been \emph{two} list items before it, which where numbers. Examples of
+    been \emph{two} list items before it, which were numbers. Examples of
     \emph{numbers} are |1|, |-10|, or |-0.24|. Let us call these numbers $x$
     and $y$ and let $d := y-x$ be their difference. Next, there should also be
     one number following the three dots, let us call this number~$z$.


### PR DESCRIPTION
Fix in context (in section "Repeating Things: The Foreach Statement"):
> Normally, when a list item '...' is encountered, there should already have
> been /two/ list items before it, which were numbers.

**Motivation for this change**

Fixes minor typo in the manual.