### PR TITLE
Fix foreach in TikZ to remember more stuff between iterations

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Foreach in path remembers nodes between iterations #356, #1047, #1303, #1313
 - Typo in animations `end on` key #1273
 - Output bounding box adjustment in pgfsys-dvisvgm.def #1275
 - Fix shadings under LuaMetaTeX

--- a/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
+++ b/tex/generic/pgf/frontendlayer/tikz/tikz.code.tex
@@ -2580,28 +2580,77 @@
 
 \def\tikz@fchar oreach{\tikz@foreach}%
 
+%
+% These are to allow \foreach to remember macros and dimensions between iterations
+%
+  
+\def\tikzforeach@smugglers@cove{}
+\let\tikztostart=\relax
+
+\def\tikzforeach@smuggle@macro#1{%
+  \pgfutil@ifx#1\relax{}{%
+    \expandafter
+    \pgfutil@g@addto@macro
+    \expandafter
+    \tikzforeach@smugglers@cove
+    \expandafter
+    {%
+      \expandafter\def\expandafter#1\expandafter{#1}%
+    }%
+  }%
+}
+
+\def\tikzforeach@smuggle@dimen#1{%
+  \pgfutil@ifx#1\relax{}{%
+    \expandafter
+    \pgfutil@g@addto@macro
+    \expandafter
+    \tikzforeach@smugglers@cove
+    \expandafter
+    {%
+      \expandafter#1\expandafter=\the#1\relax%
+    }%
+  }%
+}
+
+\def\tikzforeach@smugglers@loot{%
+  %
+  \tikzforeach@smuggle@macro\tikz@moveto@waiting%
+  \tikzforeach@smuggle@macro\tikztostart%
+  \tikzforeach@smuggle@macro\tikz@tangent%
+  %
+  \tikzforeach@smuggle@dimen\tikz@lastx%
+  \tikzforeach@smuggle@dimen\tikz@lasty%
+  \tikzforeach@smuggle@dimen\tikz@lastxsaved%
+  \tikzforeach@smuggle@dimen\tikz@lastysaved%
+  %
+}
+
+\tikzset{
+  remember macro/.code={
+    \tikzforeach@smuggle@macro#1
+  },
+  remember dimension/.code={
+    \tikzforeach@smuggle@dimen#1
+  }
+}
+
+
 \def\tikz@foreach{%
   \def\pgffor@beginhook{%
-    \tikz@lastx=\tikz@foreach@save@lastx%
-    \tikz@lasty=\tikz@foreach@save@lasty%
-    \tikz@lastxsaved=\tikz@foreach@save@lastxsaved%
-    \tikz@lastysaved=\tikz@foreach@save@lastysaved%
+    \tikzforeach@smugglers@cove%
+    \gdef\tikzforeach@smugglers@cove{}%
     \setbox\tikz@figbox=\box\tikz@tempbox%
     \setbox\tikz@figbox@bg=\box\tikz@tempbox@bg%
     \expandafter\tikz@scan@next@command\pgfutil@firstofone}%
   \def\pgffor@endhook{\pgfextra{%
-      \xdef\tikz@foreach@save@lastx{\the\tikz@lastx}%
-      \xdef\tikz@foreach@save@lasty{\the\tikz@lasty}%
-      \xdef\tikz@foreach@save@lastxsaved{\the\tikz@lastxsaved}%
-      \xdef\tikz@foreach@save@lastysaved{\the\tikz@lastysaved}%
+      \tikzforeach@smugglers@loot%
       \global\setbox\tikz@tempbox=\box\tikz@figbox%
       \global\setbox\tikz@tempbox@bg=\box\tikz@figbox@bg%
       \pgfutil@gobble}}%
   \def\pgffor@afterhook{%
-    \tikz@lastx=\tikz@foreach@save@lastx%
-    \tikz@lasty=\tikz@foreach@save@lasty%
-    \tikz@lastxsaved=\tikz@foreach@save@lastxsaved%
-    \tikz@lastysaved=\tikz@foreach@save@lastysaved%
+    \tikzforeach@smugglers@cove%
+    \gdef\tikzforeach@smugglers@cove{}%
     \let\pgffor@beginhook\relax%
     \let\pgffor@endhook\relax%
     \let\pgffor@afterhook\relax%
@@ -2610,10 +2659,7 @@
     \tikz@scan@next@command}%
   \global\setbox\tikz@tempbox=\box\tikz@figbox%
   \global\setbox\tikz@tempbox@bg=\box\tikz@figbox@bg%
-  \xdef\tikz@foreach@save@lastx{\the\tikz@lastx}%
-  \xdef\tikz@foreach@save@lasty{\the\tikz@lasty}%
-  \xdef\tikz@foreach@save@lastxsaved{\the\tikz@lastxsaved}%
-  \xdef\tikz@foreach@save@lastysaved{\the\tikz@lastysaved}%
+  \tikzforeach@smugglers@loot%
   \foreach}%
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

Fixes #356, #1047, #1303, #1313 by remembering more information between iterations of a foreach loop on a path, in particular the last node.  Also provides a more flexible interface to remember more macros & dimensions at both the code level and the user level (the latter via pgfkeys).

See https://github.com/pgf-tikz/pgf/pull/1304 for a previous version of this pull request where something went wrong with signing the commits.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [X] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [X] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
