### PR TITLE
Fix missing inclusion of libraries in graphdrawing examples

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Output bounding box adjustment in pgfsys-dvisvgm.def #1275
 - Fix shadings under LuaMetaTeX
 - Resolve missing `gnuplot` plots in manual #1238
-- Fix missing inclusion of libraries in the examples at https://tikz.dev/gd-trees and https://tikz.dev/gd-usage-tikz
+- Fix missing inclusion of libraries in `graphdrawing` examples
 - Fix mis-spelled Kellermann to Kellerman
 
 ### Changed

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Output bounding box adjustment in pgfsys-dvisvgm.def #1275
 - Fix shadings under LuaMetaTeX
 - Resolve missing `gnuplot` plots in manual #1238
+- Fix missing inclusion of three libraries in one of the examples at https://tikz.dev/gd-trees
 
 ### Changed
 
@@ -40,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Yukai Chou (@muzimuzhi)
 - Alexander Grahn
 - Max Chernoff
+- Hanson Char
 
 ## [3.1.10] - 2023-01-13 Henri Menke
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix shadings under LuaMetaTeX
 - Resolve missing `gnuplot` plots in manual #1238
 - Fix missing inclusion of libraries in the examples at https://tikz.dev/gd-trees and https://tikz.dev/gd-usage-tikz
+- Fix mis-spelled Kellermann to Kellerman
 
 ### Changed
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Output bounding box adjustment in pgfsys-dvisvgm.def #1275
 - Fix shadings under LuaMetaTeX
 - Resolve missing `gnuplot` plots in manual #1238
-- Fix missing inclusion of three libraries in one of the examples at https://tikz.dev/gd-trees
+- Fix missing inclusion of libraries in the examples at https://tikz.dev/gd-trees and https://tikz.dev/gd-usage-tikz
 
 ### Changed
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use luatexbase to register pgfsys@strcmp to not sidestep their allocation counting
 - Allow XOR and XNOR gates to have more than 2 inputs #376
 - Fix missing inclusion of libraries in `graphdrawing` examples
+- Fix missing inclusion of libraries in the examples at https://tikz.dev/gd-trees and https://tikz.dev/gd-usage-tikz
+- Fix mis-spelled Kellermann to Kellerman
 
 ### Added
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix handling of closepath command in svg.path library #1189
 - Use luatexbase to register pgfsys@strcmp to not sidestep their allocation counting
 - Allow XOR and XNOR gates to have more than 2 inputs #376
+- Fix missing inclusion of libraries in `graphdrawing` examples
 
 ### Added
 
@@ -27,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Dominik Peters
 - Erin Cold
+- Hanson Char
 
 ## [3.1.11a] - 2025-08-29 Henri Menke
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/control/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/control/doc.lua
@@ -98,58 +98,46 @@ sense that some nodes are ``nailed to the canvas'' while other
 nodes can ``move freely''.
 ]]
 
-example({options =
-[[
-  preamble=\usetikzlibrary{graphs,graphdrawing}
-    \usegdlibrary{force}
-]],
-code =
-[[
-\begin{tikzpicture}
-  \draw [help lines] (0,0) grid (3,2);
-  \graph [spring layout]
-  {
-    a[x=1] -- { b, c, d, e -- {f,g,h} };
-    { h, g } -- a;
-  };
-\end{tikzpicture}
-]]
+example({
+  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force} ]],
+  code = [[
+    \begin{tikzpicture}
+      \draw [help lines] (0,0) grid (3,2);
+      \graph [spring layout]
+      {
+        a[x=1] -- { b, c, d, e -- {f,g,h} };
+        { h, g } -- a;
+      };
+    \end{tikzpicture}
+  ]]
 })
 
-example({options =
-[[
-  preamble=\usetikzlibrary{graphs,graphdrawing}
-    \usegdlibrary{force}
-]],
-code =
-[[
-\begin{tikzpicture}
-  \draw [help lines] (0,0) grid (3,2);
-  \graph [spring layout]
-  {
-    a -- { b, c, d[x=0], e -- {f[x=2], g, h[x=1]} };
-    { h, g } -- a;
-  };
-\end{tikzpicture}
-]]
+example({
+  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force} ]],
+  code = [[
+    \begin{tikzpicture}
+      \draw [help lines] (0,0) grid (3,2);
+      \graph [spring layout]
+      {
+        a -- { b, c, d[x=0], e -- {f[x=2], g, h[x=1]} };
+        { h, g } -- a;
+      };
+    \end{tikzpicture}
+  ]]
 })
 
-example({options =
-[[
-  preamble=\usetikzlibrary{graphs,graphdrawing}
-    \usegdlibrary{force}
-]],
-code =
-[[
-\begin{tikzpicture}
-  \draw [help lines] (0,0) grid (3,2);
-  \graph [spring layout]
-  {
-    a -- { b, c, d[x=0], e -- {f[x=2,y=1], g, h[x=1]} };
-    { h, g } -- a;
-  };
-\end{tikzpicture}
-]]
+example({
+  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force} ]],
+  code = [[
+    \begin{tikzpicture}
+      \draw [help lines] (0,0) grid (3,2);
+      \graph [spring layout]
+      {
+        a -- { b, c, d[x=0], e -- {f[x=2,y=1], g, h[x=1]} };
+        { h, g } -- a;
+      };
+    \end{tikzpicture}
+  ]]
 })
 --------------------------------------------------------------------
 
@@ -180,34 +168,26 @@ Note how in the last example |c| is placed at |(1,1)| rather than
 |b| as would happen by default.
 ]]
 
-example({options =
-[[
-  preamble=\usetikzlibrary{graphs,graphdrawing}
-    \usegdlibrary{layered}
-]],
-code =
-[[
-\tikz \draw (0,0)
-  -- (1,0.5) graph [edges=red,  layered layout, anchor node=a] { a -> {b,c} }
-  -- (1.5,0) graph [edges=blue, layered layout,
-                    anchor node=y, anchor at={(2,0)}]          { x -> {y,z} };
-]]
+example({
+  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered} ]],
+  code = [[
+    \tikz \draw (0,0)
+      -- (1,0.5) graph [edges=red,  layered layout, anchor node=a] { a -> {b,c} }
+      -- (1.5,0) graph [edges=blue, layered layout,
+                        anchor node=y, anchor at={(2,0)}]          { x -> {y,z} };
+  ]]
 })
 
-example({options =
-[[
-  preamble=\usetikzlibrary{graphs,graphdrawing}
-    \usegdlibrary{layered}
-]],
-code =
-[[
-\begin{tikzpicture}
-  \draw [help lines] (0,0) grid (3,2);
+example({
+  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered} ]],
+  code = [[
+    \begin{tikzpicture}
+      \draw [help lines] (0,0) grid (3,2);
 
-  \graph [layered layout, anchor node=c, edges=rounded corners]
-    { a -- {b [x=1,y=1], c [x=1,y=1] } -- d -- a};
-\end{tikzpicture}
-]]
+      \graph [layered layout, anchor node=c, edges=rounded corners]
+        { a -- {b [x=1,y=1], c [x=1,y=1] } -- d -- a};
+    \end{tikzpicture}
+  ]]
 })
 --------------------------------------------------------------------
 
@@ -223,20 +203,16 @@ The coordinate at which the graph should be anchored when no
 explicit anchor is given for any node. The initial value is the origin.
 ]]
 
-example({options =
-[[
-  preamble=\usetikzlibrary{graphs,graphdrawing}
-    \usegdlibrary{layered}
-]],
-code =
-[[
-\begin{tikzpicture}
-  \draw [help lines] (0,0) grid (2,2);
+example({
+  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered} ]],
+  code = [[
+    \begin{tikzpicture}
+      \draw [help lines] (0,0) grid (2,2);
 
-  \graph [layered layout, edges=rounded corners, anchor at={(1,2)}]
-    { a -- {b, c [anchor here] } -- d -- a};
-\end{tikzpicture}
-]]
+      \graph [layered layout, edges=rounded corners, anchor at={(1,2)}]
+        { a -- {b, c [anchor here] } -- d -- a};
+    \end{tikzpicture}
+  ]]
 })
 --------------------------------------------------------------------
 
@@ -259,19 +235,15 @@ In the example, |c| is placed at the origin since this is the
 default |anchor at| position.
 ]]
 
-example({options =
-[[
-  preamble=\usetikzlibrary{graphs,graphdrawing}
-    \usegdlibrary{layered}
-]],
-code =
-[[
-\begin{tikzpicture}
-  \draw [help lines] (0,0) grid (2,2);
+example({
+  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered} ]],
+  code = [[
+    \begin{tikzpicture}
+      \draw [help lines] (0,0) grid (2,2);
 
-  \graph [layered layout, edges=rounded corners]
-    { a -- {b, c [anchor here] } -- d -- a};
-\end{tikzpicture}
-]]
+      \graph [layered layout, edges=rounded corners]
+        { a -- {b, c [anchor here] } -- d -- a};
+    \end{tikzpicture}
+  ]]
 })
 --------------------------------------------------------------------

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/control/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/control/doc.lua
@@ -98,8 +98,8 @@ sense that some nodes are ``nailed to the canvas'' while other
 nodes can ``move freely''.
 ]]
 
-example({
-  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force} ]],
+example {
+  options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force}} ]],
   code = [[
     \begin{tikzpicture}
       \draw [help lines] (0,0) grid (3,2);
@@ -110,10 +110,10 @@ example({
       };
     \end{tikzpicture}
   ]]
-})
+}
 
-example({
-  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force} ]],
+example {
+  options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force}} ]],
   code = [[
     \begin{tikzpicture}
       \draw [help lines] (0,0) grid (3,2);
@@ -124,10 +124,10 @@ example({
       };
     \end{tikzpicture}
   ]]
-})
+}
 
-example({
-  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force} ]],
+example {
+  options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force}} ]],
   code = [[
     \begin{tikzpicture}
       \draw [help lines] (0,0) grid (3,2);
@@ -138,7 +138,7 @@ example({
       };
     \end{tikzpicture}
   ]]
-})
+}
 --------------------------------------------------------------------
 
 
@@ -168,18 +168,18 @@ Note how in the last example |c| is placed at |(1,1)| rather than
 |b| as would happen by default.
 ]]
 
-example({
-  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered} ]],
+example {
+  options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered}} ]],
   code = [[
     \tikz \draw (0,0)
       -- (1,0.5) graph [edges=red,  layered layout, anchor node=a] { a -> {b,c} }
       -- (1.5,0) graph [edges=blue, layered layout,
                         anchor node=y, anchor at={(2,0)}]          { x -> {y,z} };
   ]]
-})
+}
 
-example({
-  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered} ]],
+example {
+  options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered}} ]],
   code = [[
     \begin{tikzpicture}
       \draw [help lines] (0,0) grid (3,2);
@@ -188,7 +188,7 @@ example({
         { a -- {b [x=1,y=1], c [x=1,y=1] } -- d -- a};
     \end{tikzpicture}
   ]]
-})
+}
 --------------------------------------------------------------------
 
 
@@ -203,8 +203,8 @@ The coordinate at which the graph should be anchored when no
 explicit anchor is given for any node. The initial value is the origin.
 ]]
 
-example({
-  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered} ]],
+example {
+  options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered}} ]],
   code = [[
     \begin{tikzpicture}
       \draw [help lines] (0,0) grid (2,2);
@@ -213,7 +213,7 @@ example({
         { a -- {b, c [anchor here] } -- d -- a};
     \end{tikzpicture}
   ]]
-})
+}
 --------------------------------------------------------------------
 
 
@@ -235,8 +235,8 @@ In the example, |c| is placed at the origin since this is the
 default |anchor at| position.
 ]]
 
-example({
-  options = [[ preamble=\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered} ]],
+example {
+  options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{layered}} ]],
   code = [[
     \begin{tikzpicture}
       \draw [help lines] (0,0) grid (2,2);
@@ -245,5 +245,5 @@ example({
         { a -- {b, c [anchor here] } -- d -- a};
     \end{tikzpicture}
   ]]
-})
+}
 --------------------------------------------------------------------

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/control/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/control/doc.lua
@@ -98,12 +98,12 @@ sense that some nodes are ``nailed to the canvas'' while other
 nodes can ``move freely''.
 ]]
 
---[[
-% TODOsp: codeexamples: the following 3 examples need these libraries
-%    \usetikzlibrary{graphs,graphdrawing}
-%    \usegdlibrary{force}
---]]
-example
+example({options =
+[[
+  preamble=\usetikzlibrary{graphs,graphdrawing}
+    \usegdlibrary{force}
+]],
+code =
 [[
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (3,2);
@@ -114,8 +114,14 @@ example
   };
 \end{tikzpicture}
 ]]
+})
 
-example
+example({options =
+[[
+  preamble=\usetikzlibrary{graphs,graphdrawing}
+    \usegdlibrary{force}
+]],
+code =
 [[
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (3,2);
@@ -126,8 +132,14 @@ example
   };
 \end{tikzpicture}
 ]]
+})
 
-example
+example({options =
+[[
+  preamble=\usetikzlibrary{graphs,graphdrawing}
+    \usegdlibrary{force}
+]],
+code =
 [[
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (3,2);
@@ -138,6 +150,7 @@ example
   };
 \end{tikzpicture}
 ]]
+})
 --------------------------------------------------------------------
 
 
@@ -167,20 +180,26 @@ Note how in the last example |c| is placed at |(1,1)| rather than
 |b| as would happen by default.
 ]]
 
---[[
-% TODOsp: codeexamples: the following 4 examples need these libraries
-%    \usetikzlibrary{graphs,graphdrawing}
-%    \usegdlibrary{layered}
---]]
-example
+example({options =
+[[
+  preamble=\usetikzlibrary{graphs,graphdrawing}
+    \usegdlibrary{layered}
+]],
+code =
 [[
 \tikz \draw (0,0)
   -- (1,0.5) graph [edges=red,  layered layout, anchor node=a] { a -> {b,c} }
   -- (1.5,0) graph [edges=blue, layered layout,
                     anchor node=y, anchor at={(2,0)}]          { x -> {y,z} };
 ]]
+})
 
-example
+example({options =
+[[
+  preamble=\usetikzlibrary{graphs,graphdrawing}
+    \usegdlibrary{layered}
+]],
+code =
 [[
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (3,2);
@@ -189,6 +208,7 @@ example
     { a -- {b [x=1,y=1], c [x=1,y=1] } -- d -- a};
 \end{tikzpicture}
 ]]
+})
 --------------------------------------------------------------------
 
 
@@ -203,7 +223,12 @@ The coordinate at which the graph should be anchored when no
 explicit anchor is given for any node. The initial value is the origin.
 ]]
 
-example
+example({options =
+[[
+  preamble=\usetikzlibrary{graphs,graphdrawing}
+    \usegdlibrary{layered}
+]],
+code =
 [[
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (2,2);
@@ -212,6 +237,7 @@ example
     { a -- {b, c [anchor here] } -- d -- a};
 \end{tikzpicture}
 ]]
+})
 --------------------------------------------------------------------
 
 
@@ -233,7 +259,12 @@ In the example, |c| is placed at the origin since this is the
 default |anchor at| position.
 ]]
 
-example
+example({options =
+[[
+  preamble=\usetikzlibrary{graphs,graphdrawing}
+    \usegdlibrary{layered}
+]],
+code =
 [[
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (2,2);
@@ -242,4 +273,5 @@ example
     { a -- {b, c [anchor here] } -- d -- a};
 \end{tikzpicture}
 ]]
+})
 --------------------------------------------------------------------

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc.lua
@@ -112,11 +112,10 @@ end
 -- Adds an example to the |examples| field of the last key selected
 -- through the |key| command.
 --
--- @param string An additional example string.
-
-function doc.example (string)
+-- @param input either a string of example or a table with two fields - "code" and "options".
+function doc.example (input)
   local examples = rawget(current_key, "examples") or {}
-  examples[#examples + 1] = string
+  examples[#examples + 1] = input
   current_key.examples = examples
 end
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/doc.lua
@@ -112,7 +112,9 @@ end
 -- Adds an example to the |examples| field of the last key selected
 -- through the |key| command.
 --
--- @param input either a string of example or a table with two fields - "code" and "options".
+-- @param input Either a string of example or a table with two fields:
+-- "code" and "options".
+
 function doc.example (input)
   local examples = rawget(current_key, "examples") or {}
   examples[#examples + 1] = input

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
@@ -293,29 +293,26 @@ example
   };
 ]]
 
-example({options =
-[[
-  preamble=\usetikzlibrary{shapes.misc, arrows.meta, decorations.pathmorphing}
-]],
-code =
-[[
-\tikz \graph [binary tree layout] {
-  Knuth -> {
-    Beeton -> Kellerman [second] -> Carnes,
-    Tobin -> Plass -> { Lamport, Spivak }
-  }
-};\qquad
-\tikz [>={Stealth[round,sep]}]
-  \graph [binary tree layout, grow'=right, level sep=1.5em,
-          nodes={right, fill=blue!50, text=white, chamfered rectangle},
-                 edges={decorate,decoration={snake, post length=5pt}}]
-  {
-    Knuth -> {
-      Beeton -> Kellerman [second] -> Carnes,
-      Tobin -> Plass -> { Lamport, Spivak }
-    }
-  };
-]]
+example({
+  options = [[ preamble=\usetikzlibrary{shapes.misc, arrows.meta, decorations.pathmorphing} ]],
+  code = [[
+    \tikz \graph [binary tree layout] {
+      Knuth -> {
+        Beeton -> Kellerman [second] -> Carnes,
+        Tobin -> Plass -> { Lamport, Spivak }
+      }
+    };\qquad
+    \tikz [>={Stealth[round,sep]}]
+      \graph [binary tree layout, grow'=right, level sep=1.5em,
+              nodes={right, fill=blue!50, text=white, chamfered rectangle},
+                    edges={decorate,decoration={snake, post length=5pt}}]
+      {
+        Knuth -> {
+          Beeton -> Kellerman [second] -> Carnes,
+          Tobin -> Plass -> { Lamport, Spivak }
+        }
+      };
+  ]]
 })
 --------------------------------------------------------------------
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
@@ -293,8 +293,13 @@ example
   };
 ]]
 
-example({
-  options = [[ preamble=\usetikzlibrary{shapes.misc, arrows.meta, decorations.pathmorphing} ]],
+example {
+  options = [[
+    preamble = {
+      \usetikzlibrary{shapes.misc,arrows.meta,graphs,graphdrawing,decorations.pathmorphing}
+      \usegdlibrary{trees}
+    }
+  ]],
   code = [[
     \tikz \graph [binary tree layout] {
       Knuth -> {
@@ -313,7 +318,7 @@ example({
         }
       };
   ]]
-})
+}
 --------------------------------------------------------------------
 
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
@@ -293,11 +293,9 @@ example
   };
 ]]
 
---[[
-% TODOsp: codeexamples: the next example needs the library `arrows.meta`
---]]
 example
 [[
+\usetikzlibrary{shapes.misc, arrows.meta, decorations.pathmorphing}
 \tikz \graph [binary tree layout] {
   Knuth -> {
     Beeton -> Kellermann [second] -> Carnes,

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
@@ -293,9 +293,12 @@ example
   };
 ]]
 
-example
+example({options =
 [[
-\usetikzlibrary{shapes.misc, arrows.meta, decorations.pathmorphing}
+  preamble=\usetikzlibrary{shapes.misc, arrows.meta, decorations.pathmorphing}
+]],
+code =
+[[
 \tikz \graph [binary tree layout] {
   Knuth -> {
     Beeton -> Kellermann [second] -> Carnes,
@@ -313,6 +316,7 @@ example
     }
   };
 ]]
+})
 --------------------------------------------------------------------
 
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
@@ -301,7 +301,7 @@ code =
 [[
 \tikz \graph [binary tree layout] {
   Knuth -> {
-    Beeton -> Kellermann [second] -> Carnes,
+    Beeton -> Kellerman [second] -> Carnes,
     Tobin -> Plass -> { Lamport, Spivak }
   }
 };\qquad
@@ -311,7 +311,7 @@ code =
                  edges={decorate,decoration={snake, post length=5pt}}]
   {
     Knuth -> {
-      Beeton -> Kellermann [second] -> Carnes,
+      Beeton -> Kellerman [second] -> Carnes,
       Tobin -> Plass -> { Lamport, Spivak }
     }
   };


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Some of the examples at ﻿﻿https://tikz.dev/gd-trees and https://tikz.dev/gd-usage-tikz don't currently compile with `lualatex`.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html

**Testing**

Changes tested successfully on Apple M2. 

```bash
$ lualatex --version
This is LuaHBTeX, Version 1.18.0 (TeX Live 2024)
Development id: 7611
```
Prior to this change, the example code would fail with the following log message:

```bash
...
! Package pgf Error: Unknown arrow tip kind 'Stealth'.

See the pgf package documentation for explanation.
Type  H <return>  for immediate help.
 ...

l.78 \tikz [>={Stealth[round,sep]}]
```

**Local building of `build/doc/pgfmanual.pdf`**

```bash
export tagname=$(git describe --abbrev=0 --tags)
export revision=$(git describe --tags)
export tagdate=$(git log -n 1 "$tagname" --pretty=format:%cs)
export revisiondate=$(git log -n 1 "$revision" --pretty=format:%cs)
l3build tag --date "$tagdate" "$tagname"
l3build doc -q
```

