### PR TITLE
Support applying options to multiple examples as suggested in #640

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.zip
 
 build/*
+tex/generic/pgf/pgf.revision.tex

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add `RGB` and `gray` color model support for ConTeXt #1130
+- Support an apply-all feature (suggested in issue #640) to
+  apply a single definition of options to multiple examples.
 
 ### Fixed
 
@@ -27,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Resolve overfull hboxes >=20pt in the manual
 - Adapt `\graphicspath` setting for flattened doc tree #1191
 - Promote warning "Plot data file \`...' not found" to error
+- Ignore file `tex/generic/pgf/pgf.revision.tex` in git
 
 ### Contributors
 
@@ -40,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Yukai Chou (@muzimuzhi)
 - Alexander Grahn
 - Max Chernoff
+- Hanson Char
 
 ## [3.1.10] - 2023-01-13 Henri Menke
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix missing inclusion of libraries in `graphdrawing` examples
 - Fix missing inclusion of libraries in the examples at https://tikz.dev/gd-trees and https://tikz.dev/gd-usage-tikz
 - Fix mis-spelled Kellermann to Kellerman
+- Support an apply-all feature (suggested in issue #640) to
+  apply a single definition of options to multiple examples.
 
 ### Added
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlElectric.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlElectric.lua
@@ -41,22 +41,18 @@ declare {
   ]],
   examples = {
     options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force}} ]],
-    {
-      code = [[
+    [[
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { 0 [electric charge=1] -- subgraph C_n [n=10] };
-      ]]
-    },{
-      code = [[
+    ]],
+    [[
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { 0 [electric charge=5] -- subgraph C_n [n=10] };
-      ]]
-    },{
-      code = [[
+    ]],
+    [[
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { [clique] 1 [electric charge=5], 2, 3, 4 };
-      ]]
-    }
+    ]]
   }
 }
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlElectric.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/force/ControlElectric.lua
@@ -29,7 +29,7 @@ declare {
   type = "number",
   initial = 1,
 
-  summary = [["
+  summary = [[
     Defines the electric charge of the node. The stronger the
     |electric charge| of a node the stronger the repulsion between the
     node and others in the graph. A negative |electric charge| means that
@@ -38,24 +38,24 @@ declare {
     |spring electrical layout| algorithm works.
     Two typical effects of increasing the |electric charge| are distortion
     of symmetries and an upscaling of the drawings.
-  "]],
+  ]],
   examples = {
+    options = [[ preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force}} ]],
     {
-      options = [["preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{force}}"]],
-      code = [["
+      code = [[
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { 0 [electric charge=1] -- subgraph C_n [n=10] };
-      "]]
+      ]]
     },{
-      code = [["
+      code = [[
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { 0 [electric charge=5] -- subgraph C_n [n=10] };
-      "]]
+      ]]
     },{
-      code = [["
+      code = [[
         \tikz \graph [spring electrical layout, horizontal=0 to 1]
           { [clique] 1 [electric charge=5], 2, 3, 4 };
-      "]]
+      ]]
     }
   }
 }

--- a/tex/generic/pgf/lua/pgf/manual/DocumentParser.lua
+++ b/tex/generic/pgf/lua/pgf/manual/DocumentParser.lua
@@ -162,9 +162,10 @@ local function process_examples(t)
     local code, options
     if type(t[i]) == "table" then
       code = assert(t[i].code)
-      options = t[i].options
+      options = t[i].options or t.options
     else
       code = t[i]
+      options = t.options
     end
     n[i] = {
       options = process_string(strip_quotes(options)),


### PR DESCRIPTION
**Motivation for this change**

The conversation at https://github.com/pgf-tikz/pgf/issues/640 on the possibility of supporting the specification of options that can be applied to multiple examples.

To demonstrate the usage of this feature, I've modified `ControlElectric.lua`, while simplifying the code by removing unnecessary double quotes at the same time.

**Checklist**

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
