### PR TITLE
Fix broken example of simpledemo.lua to work with "simple demo layout"

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Output bounding box adjustment in pgfsys-dvisvgm.def #1275
 - Fix shadings under LuaMetaTeX
 - Resolve missing `gnuplot` plots in manual #1238
+- Fix broken example of simpledemo.lua to work with "very simple demo layout"
 
 ### Changed
 
@@ -40,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Yukai Chou (@muzimuzhi)
 - Alexander Grahn
 - Max Chernoff
+- Hanson Char
 
 ## [3.1.10] - 2023-01-13 Henri Menke
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix mis-spelled Kellermann to Kellerman
 - Support an apply-all feature (suggested in issue #640) to
   apply a single definition of options to multiple examples.
-- Fix broken example of simpledemo.lua to work with "very simple demo layout"
+- Fix broken example of SimpleDemo.lua to work with "very simple demo layout"
 
 ### Added
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix mis-spelled Kellermann to Kellerman
 - Support an apply-all feature (suggested in issue #640) to
   apply a single definition of options to multiple examples.
+- Fix broken example of simpledemo.lua to work with "very simple demo layout"
 
 ### Added
 

--- a/doc/generic/pgf/pgfmanual-en-gd-algorithm-layer.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-algorithm-layer.tex
@@ -139,21 +139,6 @@ pgf.gd.interface.InterfaceToAlgorithms.declare {
   }
 }
 \end{codeexample}
-\directlua{
-pgf.gd.interface.InterfaceToAlgorithms.declare {
-  key = "very simple demo layout",
-  algorithm = {
-    run =
-      function (self)
-        local alpha = (2 * math.pi) / \luaescapestring{#}self.ugraph.vertices
-        for i,vertex in ipairs(self.ugraph.vertices) do
-          vertex.pos.x = math.cos(i * alpha) * 25
-          vertex.pos.y = math.sin(i * alpha) * 25
-        end
-      end
-  }
-}
-}
 
 This code \emph {declares} a new algorithm (|very simple demo layout|) and
 includes an implementation of the algorithm (through the |run| field of the
@@ -177,7 +162,7 @@ advertise this fact to the ``user''. In the case of \tikzname, this means that
 the option key |very simple demo layout| becomes available at this point and we
 can use it like this:
 %
-\begin{codeexample}[]
+\begin{codeexample}[preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{simpledemo}}]
 \tikz [very simple demo layout]
   \graph { f -> c -> e -> a -> {b -> {c, d, f}, e -> b}};
 \end{codeexample}
@@ -185,7 +170,7 @@ can use it like this:
 It turns out, that our little algorithm is already more powerful than one might
 expect. Consider the following example:
 %
-\begin{codeexample}[]
+\begin{codeexample}[preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{simpledemo}}]
 \tikz [very simple demo layout, componentwise]
   \graph {
     1 -> 2 ->[orient=right] 3 -> 1;
@@ -797,7 +782,7 @@ table. Instead, you should use a |Storage|.
 \label{section-gd-examples}
 
 \includeluadocumentationof{pgf.gd.examples.library}
-\includeluadocumentationof{pgf.gd.examples.SimpleDemo}
+\includeluadocumentationof{pgf.gd.examples.simpledemo}
 \includeluadocumentationof{pgf.gd.examples.SimpleEdgeDemo}
 \includeluadocumentationof{pgf.gd.examples.SimpleHuffman}
 

--- a/doc/generic/pgf/pgfmanual-en-gd-algorithm-layer.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-algorithm-layer.tex
@@ -150,7 +150,7 @@ this is done by assigning values to |vertex.pos.x| and |vertex.pos.y|).
 In order to actually \emph{use} the algorithm, the above code first needs to be
 executed somehow. For \tikzname, one can just call |\directlua| on it or put it
 in a file and then use |\directlua| plus |require| (a better alternative) or
-you put it in a file like |simpledemo.lua| and use |\usegdlibrary{simpledemo}|
+you put it in a file like |SimpleDemo.lua| and use |\usegdlibrary{SimpleDemo}|
 (undoubtedly the ``best'' way). For another display layer, like a graphical
 editor, the code could also be executed through the use of |require|.
 
@@ -162,7 +162,7 @@ advertise this fact to the ``user''. In the case of \tikzname, this means that
 the option key |very simple demo layout| becomes available at this point and we
 can use it like this:
 %
-\begin{codeexample}[preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{simpledemo}}]
+\begin{codeexample}[preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{SimpleDemo}}]
 \tikz [very simple demo layout]
   \graph { f -> c -> e -> a -> {b -> {c, d, f}, e -> b}};
 \end{codeexample}
@@ -170,7 +170,7 @@ can use it like this:
 It turns out, that our little algorithm is already more powerful than one might
 expect. Consider the following example:
 %
-\begin{codeexample}[preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{simpledemo}}]
+\begin{codeexample}[preamble={\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{SimpleDemo}}]
 \tikz [very simple demo layout, componentwise]
   \graph {
     1 -> 2 ->[orient=right] 3 -> 1;
@@ -782,7 +782,7 @@ table. Instead, you should use a |Storage|.
 \label{section-gd-examples}
 
 \includeluadocumentationof{pgf.gd.examples.library}
-\includeluadocumentationof{pgf.gd.examples.simpledemo}
+\includeluadocumentationof{pgf.gd.examples.Simpledemo}
 \includeluadocumentationof{pgf.gd.examples.SimpleEdgeDemo}
 \includeluadocumentationof{pgf.gd.examples.SimpleHuffman}
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/library.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/library.lua
@@ -24,7 +24,7 @@ local examples
 
 
 -- Load algorithms from:
-require "pgf.gd.examples.SimpleDemo"
+require "pgf.gd.examples.simpledemo"
 require "pgf.gd.examples.SimpleEdgeDemo"
 require "pgf.gd.examples.SimpleHuffman"
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/library.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/library.lua
@@ -24,7 +24,7 @@ local examples
 
 
 -- Load algorithms from:
-require "pgf.gd.examples.simpledemo"
+require "pgf.gd.examples.Simpledemo"
 require "pgf.gd.examples.SimpleEdgeDemo"
 require "pgf.gd.examples.SimpleHuffman"
 

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/simpledemo.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/simpledemo.lua
@@ -23,17 +23,14 @@ local declare = require "pgf.gd.interface.InterfaceToAlgorithms".declare
 ---
 
 declare {
-  key = "simple demo layout",
+  key = "very simple demo layout",
   algorithm = {
     run =
       function (self)
-        local g = self.digraph
-        local alpha = (2 * math.pi) / #g.vertices
-
-        for i,vertex in ipairs(g.vertices) do
-          local radius = vertex.options['radius'] or g.options['radius']
-          vertex.pos.x = radius * math.cos(i * alpha)
-          vertex.pos.y = radius * math.sin(i * alpha)
+        local alpha = (2 * math.pi) / #self.ugraph.vertices
+        for i,vertex in ipairs(self.ugraph.vertices) do
+          vertex.pos.x = math.cos(i * alpha) * 25
+          vertex.pos.y = math.sin(i * alpha) * 25
         end
       end
   },
@@ -49,11 +46,11 @@ declare {
     implement a graph drawing algorithm.
     %
 \begin{codeexample}[code only, tikz syntax=false]
--- File pgf.gd.examples.SimpleDemo
+-- File pgf.gd.examples.simpledemo
 local declare = require "pgf.gd.interface.InterfaceToAlgorithms".declare
 
 declare {
-  key = "simple demo layout",
+  key = "very simple demo layout",
   algorithm = {
     run =
       function (self)
@@ -61,9 +58,8 @@ declare {
         local alpha = (2 * math.pi) / #g.vertices
 
         for i,vertex in ipairs(g.vertices) do
-          local radius = vertex.options['radius'] or g.options['radius']
-          vertex.pos.x = radius * math.cos(i * alpha)
-          vertex.pos.y = radius * math.sin(i * alpha)
+          vertex.pos.x = math.cos(i * alpha)
+          vertex.pos.y = math.sin(i * alpha)
         end
       end
   },
@@ -76,7 +72,7 @@ declare {
 
     On the display layer (\tikzname, that is) the algorithm can now
     immediately be employed; you just need to say
-    |\usegdlibrary{examples.SimpleDemo}| at the beginning
+    |\usegdlibrary{simpledemo}| at the beginning
     somewhere.
   "]=]
 }

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/simpledemo.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/simpledemo.lua
@@ -46,7 +46,7 @@ declare {
     implement a graph drawing algorithm.
     %
 \begin{codeexample}[code only, tikz syntax=false]
--- File pgf.gd.examples.simpledemo
+-- File pgf.gd.examples.Simpledemo
 local declare = require "pgf.gd.interface.InterfaceToAlgorithms".declare
 
 declare {
@@ -72,7 +72,7 @@ declare {
 
     On the display layer (\tikzname, that is) the algorithm can now
     immediately be employed; you just need to say
-    |\usegdlibrary{simpledemo}| at the beginning
+    |\usegdlibrary{SimpleDemo}| at the beginning
     somewhere.
   "]=]
 }


### PR DESCRIPTION
**Motivation for this change**

I tried out the example at *36.2.1 The Hello World of Graph Drawing* but it didn't compile:

```latex
\documentclass{standalone}
\usepackage{fp,pgf,tikz,xcolor}
\usetikzlibrary{graphs,graphdrawing} \usegdlibrary{simpledemo}
\begin{document}
\tikz [very simple demo layout]
  \graph { f -> c -> e -> a -> {b -> {c, d, f}, e -> b}};
\end{document}
```

It seems to me the culprit is the implementation in [SimpleDemo.lua#L25-L39](https://github.com/pgf-tikz/pgf/blob/master/tex/generic/pgf/graphdrawing/lua/pgf/gd/examples/SimpleDemo.lua#L25-L39) differs from that in the documentation. 

**Checklist**

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
