### PR TITLE
Fix indentation in math example function

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-library-math.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-math.tex
@@ -57,8 +57,8 @@ following command:
     if \n == 0 then {
       return 0;
     } else {
-       return fibonacci2(\n, 0, 1);
-     };
+      return fibonacci2(\n, 0, 1);
+    };
   };
   function fibonacci2(\n, \p, \q) {
     if \n == 1 then {


### PR DESCRIPTION
**Motivation for this change**

Fixing the indentation of the math example to improve its readability.

**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
