### PR TITLE
fix: treat varargs for min and max in luamath

### DIFF
--- a/tex/generic/pgf/libraries/luamath/pgf/luamath/functions.lua
+++ b/tex/generic/pgf/libraries/luamath/pgf/luamath/functions.lua
@@ -148,12 +148,12 @@ function pgfluamathfunctions.less(x,y)
   end
 end
 
-function pgfluamathfunctions.min(x,y)
-  return mathmin(x,y)
+function pgfluamathfunctions.min(x,y,...)
+  return mathmin(x,y,...)
 end
 
-function pgfluamathfunctions.max(x,y)
-  return mathmax(x,y)
+function pgfluamathfunctions.max(x,y,...)
+  return mathmax(x,y,...)
 end
 
 function pgfluamathfunctions.notequal(x,y)


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

Fixes https://github.com/pgf-tikz/pgfplots/issues/492

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
