### PR TITLE
fix: use luatexbase to register pgfsys@strcmp

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Resolve parsing ambiguity in general shadow #1435
 - Fix clobbered register in `bending` library #896
 - Fix handling of closepath command in svg.path library #1189
+- Use luatexbase to register pgfsys@strcmp to not sidestep their allocation counting
 
 ### Added
 

--- a/tex/generic/pgf/systemlayer/pgfsys.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsys.code.tex
@@ -1725,7 +1725,8 @@
 \else\ifdefined\directlua
   \directlua{
   local lft = lua.get_functions_table()
-  lft[\string#lft+1] = function()
+  local fid = luatexbase and luatexbase.new_luafunction("pgfsys@strcmp") or \string#lft+1
+  lft[fid] = function()
       local lhs = token.scan_string()
       local rhs = token.scan_string()
       if lhs < rhs then
@@ -1736,7 +1737,7 @@
           tex.sprint(-2, "1")
       end
   end
-  token.set_lua("pgfsys@strcmp", \string#lft, "global")
+  token.set_lua("pgfsys@strcmp", fid, "global")
   }
 \else
   \def\pgfsys@strcmp#1#2{\pgf@sys@fail{string comparison}}%


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

Workaround for https://github.com/latex3/latex2e/issues/1100

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
