### PR TITLE
Update of the `dvisvgm4ht.def` driver

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix shadings under LuaMetaTeX
 - Resolve missing `gnuplot` plots in manual #1238
 - Treat varargs for `min` and `max` in `luamath` pgf-tikz/pgfplots#492 #1359
+- Fixed support for the `\tikz` command in the `dvisvg4ht` driver for TeX4ht
 
 ### Changed
 
@@ -29,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Adapt `\graphicspath` setting for flattened doc tree #1191
 - Promote warning "Plot data file \`...' not found" to error
 - Allow empty value for /pgf/arrow keys/fill to make it behave more like /tikz/fill #1352
+- Added support for alt text in the `dvisvg4ht` driver for TeX4ht
 
 ### Contributors
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix shadings under LuaMetaTeX
 - Resolve missing `gnuplot` plots in manual #1238
 - Treat varargs for `min` and `max` in `luamath` pgf-tikz/pgfplots#492 #1359
-- Fixed support for the `\tikz` command in the `dvisvg4ht` driver for TeX4ht
+- Fixed support for the `\tikz` command in the `dvisvgm4ht` driver for TeX4ht
 
 ### Changed
 
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Adapt `\graphicspath` setting for flattened doc tree #1191
 - Promote warning "Plot data file \`...' not found" to error
 - Allow empty value for /pgf/arrow keys/fill to make it behave more like /tikz/fill #1352
-- Added support for alt text in the `dvisvg4ht` driver for TeX4ht
+- Added support for alt text in the `dvisvgm4ht` driver for TeX4ht
 
 ### Contributors
 

--- a/tex/generic/pgf/systemlayer/pgfsys-dvisvgm4ht.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvisvgm4ht.def
@@ -1,4 +1,4 @@
-% Copyright 2021 by Michal Hoftich
+% Copyright 2021-2024 by Michal Hoftich
 % Copyright 2006 by Till Tantau
 %
 % This file may be distributed and/or modified
@@ -16,66 +16,55 @@
 % Load common pdf commands:
 %
 
-% we load the dvips driver by default. it doesn't support patterns and some other stuff,
-% but it handles better nested images and some formatting. if you use patterns or if you
-% have other issues with the default method, pass the "tikz-dvisvgm" option to make4ht. 
+% we switched to dvisvgm driver by default. it supports patterns and other features 
+% dvips driver is available through the tikz+ option. It doesn't support everything, 
+% but it worked better with nested pictures in the past.
 \ifdefined\ifOption
-\ifOption{tikz+}{\input pgfsys-dvisvgm.def}{\input pgfsys-dvips.def}
+\ifOption{tikz+}{\input pgfsys-dvips.def}{\input pgfsys-dvisvgm.def}
 \else
 % load the dvips driver by default
-\input pgfsys-dvips.def
+\input pgfsys-dvisvgm.def
 \fi
 
 
-\def\texfourht@tikz@begin{%
-  \bgroup%
-  \def\run@pict@cmd{}% insert the \Picture hooks only in the top nesting level
-  \def\end@pict@cmd{}%
-  \ifdefined\EndPicture\else% We are already inside command that uses \Picture
-  \ifdefined\inside@pict@cmd\else% handle nested uses
-  \ifdefined\tikzexternalize\else% Support externalize library
-  \def\run@pict@cmd{\Picture*}%
-  \def\end@pict@cmd{\EndPicture}%
-  \fi\fi\fi%
-  % command used to detect nesting
-  \def\inside@pict@cmd{}%
-  \csname a:tikzpicture\endcsname%
-}
+\catcode`\:=11%
 
-\def\texfourht@tikz@end{%
-  \csname b:tikzpicture\endcsname%
-  \egroup%
-}
-
+% we must call most of these redefinitions in \AtBeginDocument, because \HLet is available 
+% only at that moment
 \AtBeginDocument{%
-  \NewConfigure{tikzpicture}{2}%
-  \catcode`\:=11%
-  \Configure{tikzpicture}{%
-    \protect\csname nested:math\endcsname% support display math
-    \run@pict@cmd{}%
-  }{\end@pict@cmd}
-  % configure the output picture format to svg, as it will require dvisvgm
-  % post processing. 
-  \Configure{Picture}{.svg}%
-  % insert tex4ht hooks around TikZ picture box
-  \def\pgfsys@typesetpicturebox#1{%
-    \texfourht@tikz@begin%
-    \orig@pgfsys@typesetpicturebox{#1}%
-    \texfourht@tikz@end%
-  }
-  %
-  \ConfigureEnv{tikzpicture}{\texfourht@tikz@begin}{\texfourht@tikz@end}{}{}%
-  \ConfigureEnv{pgfpicture}{\texfourht@tikz@begin}{\texfourht@tikz@end}{}{}%
-  \catcode`\:=12%
+ % configure the output picture format to svg, as it will require dvisvgm
+ % post processing. 
+ \Configure{Picture}{.svg}%
+
+ % insert picture hooks to pgfsys commands 
+ % these redefinitions are usually called only with the \tikz command, 
+ % they are ignored in tikzpicture environment
+ \def\:tempa#1{%
+     \texfourht@tikz@begin%
+     \csname o:pgfsys@typesetpicturebox:\endcsname{#1}
+     \texfourht@tikz@end%
+ }
+ \HLet\pgfsys@typesetpicturebox\:tempa
+
+ % we must remove Picture-alt in \pgfsys@beginpicture, because it can result in alt text included in the image
+ \def\:tempa{\Configure{Picture-alt}{}\texfourht@tikz@begin\o:pgfsys@beginpicture:}
+ \HLet\pgfsys@beginpicture\:tempa
+ \let\o:pgfsys@endpicture:\pgfsys@endpicture
+ \def\:tempa{\o:pgfsys@endpicture:}
+ \HLet\pgfsys@endpicture\:tempa
+
+ %  start picture around TikZ and PGF environments
+ \ConfigureEnv{tikzpicture}{\begingroup\texfourht@tikz@begin}{\texfourht@tikz@end\endgroup}{}{}%
+ \ConfigureEnv{pgfpicture}{\begingroup\texfourht@tikz@begin}{\texfourht@tikz@end\endgroup}{}{}%
 }
 
+\def\texfourht@tikz@begin{
+  \protect\csname nested:math\endcsname% support display math
+  \Picture+[\csname a:Picture-alt\endcsname]{}%
+}
+\def\texfourht@tikz@end{\EndPicture}
 
-% Make the code inserted by tex4ht configurable
-% 
-
-
-\let\orig@pgfsys@typesetpicturebox\pgfsys@typesetpicturebox
-%\def\pgf@sys@postscript@header#1{{\special{! #1}}}
+\catcode`\:=12%
 
 
 \endinput


### PR DESCRIPTION


<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

Updated the `dvisvgm4ht.def` driver for TeX4ht. It is almost complete rewrite:

- use the `dvisvgm` driver instead of `dvips` as a backend by default
- simplified the code
- fixed support for the inline \tikz command
- added support for the alt text

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
