### PR TITLE
Add links to pdf spec for blend modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ packages.
 If you are feeling adventurous you can install the latest development
 version in TeX Live from our tlcontrib repository.
 ```console
-$ tlmgr repository add http://pgf-tikz.github.io/pgf/tlnet pgf-development
+$ tlmgr repository add https://pgf-tikz.github.io/pgf/tlnet pgf-development
 $ tlmgr pinning add pgf-development "*"
 $ tlmgr update --self --all
 $ tlmgr install pgf --reinstall

--- a/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
@@ -222,7 +222,8 @@ renderers, let alone printers, will have trouble rendering blending correctly.
 \begin{key}{/tikz/blend mode=\meta{mode}}
     Sets the current blend mode to \meta{mode}. Here \meta{mode} must be one of
     the modes listed below. More details on these modes can also be found in
-    Section~7.2.4 of the \textsc{pdf} Specification, version~1.7.
+    \href{https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf#G12.12449365}{Section~7.2.4}
+    of the \textsc{pdf} Specification, version~1.7.
 
     In the following example, the blend mode is only used and set inside a
     transparency group (see also Section~\ref{section-transparency-groups}).
@@ -315,7 +316,8 @@ renderers, let alone printers, will have trouble rendering blending correctly.
 
     \medskip
     \makeline{\emph{Example}}{\emph{Mode}}{\emph{Explanations quoted from
-        Table~7.2 of the \textsc{pdf} Specification, Version~1.7}}
+    \href{https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf#G12.12449569}{Table~7.2}
+        of the \textsc{pdf} Specification, Version~1.7}}
     \showmode{normal}{When painting a pixel with a some color (called the
         ``source color''), the background color (called the ``backdrop'') is
         completely ignored.}

--- a/tex/generic/pgf/math/pgfmathfunctions.random.code.tex
+++ b/tex/generic/pgf/math/pgfmathfunctions.random.code.tex
@@ -23,7 +23,7 @@
 % }
 %
 % See also, the documentation for the lcg package by Erich Janka:
-% (http://www.ctan.org/tex-archive/macros/latex/contrib/lcg/lcg.pdf)
+% (https://www.ctan.org/tex-archive/macros/latex/contrib/lcg/lcg.pdf)
 %
 \def\pgfmath@rnd@m{2147483647}% LaTeX Maximum.
 


### PR DESCRIPTION
This PR adds links to the pdf spec, more specifically to the chapter and a table describing blend modes.
It also converts two links from `http` to `https` protocol.

- [x] Documentation changes are licensed under [FDLv1.2][FDL]