### PR TITLE
Update pgfmanual-en-base-shadings.tex

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-base-shadings.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-shadings.tex
@@ -255,7 +255,7 @@ explicit color model (|rgb|, |cmyk|, or |gray|).
     \texttt{false}, \texttt{ge}, \texttt{gt}, \texttt{le}, \texttt{lt},
     \texttt{ne}, \texttt{not}, \texttt{or}, \texttt{true}, \texttt{xor},
     \texttt{if}, \texttt{ifelse}, \texttt{copy}, \texttt{dup}, \texttt{exch},
-    \texttt{index}, \texttt{pop}.
+    \texttt{index}, \texttt{pop}, \texttt{roll}.
 
     When the function is evaluated, the top two stack elements are the
     coordinates of the point for which the color should be computed. The
@@ -285,7 +285,7 @@ explicit color model (|rgb|, |cmyk|, or |gray|).
     whether a shading needs to be recalculated when a color has changed.
 
     The \meta{init code} is executed each time a shading is (re)calculated.
-    Typically, it will contain code to extract coordinates from colors.
+    Typically, it will contain code to extract components from colors.
     %
 \begin{codeexample}[]
 \pgfdeclarefunctionalshading{twospots}


### PR DESCRIPTION
Line 258: missing `roll` operator (see line 301 where it is used). Line 288: probably *components* of colors, not coordinates of colors, for exemple components of the color yellow is 1 1 0 in rgb. Lines 271,272, not modified but `cvr` don't fix the broke in Apple Preview, see https://tex.stackexchange.com/q/739653/132405. Need to be updated if any solution is find.

<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
