### PR TITLE
docs: format "default XXX, initially XXX" correctly

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -35,7 +35,7 @@ specialformats["latex"] = specialformats["latex"] or
 checkengines = {"pdftex", "latexdvips", "latexdvisvgm", "luatex", "xetex"}
 
 -- Use multiple sets of tests
-checkconfigs = { "build", "config-gd" }
+checkconfigs = { "build", "config-gd", "config-manual" }
 
 -- For release
 ctanzip = "pgf.ctan.flatdir"
@@ -79,4 +79,3 @@ function tag_hook(tagname, tagdate)
   file:close()
   return 0
 end
-

--- a/config-manual.lua
+++ b/config-manual.lua
@@ -1,0 +1,8 @@
+-- Tests for pgfmanual macros
+
+stdengine    = "luatex"
+checkengines = {"luatex"}
+testfiledir  = "testfiles-manual"
+
+-- this copies all doc sources "pgfmanual-en-xxx.tex", which are unneeded
+testsuppdir  = "./doc/generic/pgf"

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- Fix formatting of `default XXX, initially XXX` in key docs #1278
+
 ## [3.1.11] - 2025-08-14 Henri Menke
 
 ### BREAKING CHANGES

--- a/testfiles-manual/key-env.lvt
+++ b/testfiles-manual/key-env.lvt
@@ -1,0 +1,37 @@
+% based on pgfmanual-test.tex
+\input{regression-test}
+\documentclass[a4paper,doc2]{ltxdoc}
+
+\input{pgfmanual.cfg} % default engine is LuaTeX
+\input{pgfmanual-en-main-preamble.tex}
+
+\showoutput
+
+\begin{document}
+
+\START
+
+\begin{key}{/path/x=value}
+\end{key}
+
+\begin{key}{/path/x=value (default XXX)}
+\end{key}
+
+\begin{key}{/path/x=value (initially XXX)}
+\end{key}
+
+% see #1278
+\begin{key}{/path/x=value (default XXX, initially XXX)}
+\end{key}
+
+% values containing "=", see #1325
+\begin{key}{/path/x=value (default {K=V})}
+\end{key}
+
+\begin{key}{/path/x=value (initially {K=V})}
+\end{key}
+
+\begin{key}{/path/x=value (default {K=V}, initially {K=V})}
+\end{key}
+
+\end{document}

--- a/testfiles-manual/key-env.tlg
+++ b/testfiles-manual/key-env.tlg
@@ -1,0 +1,633 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Completed box being shipped out [1]
+\vbox(731.64497+0.0)x461.2192, direction TLT
+.\hbox(0.0+0.0)x0.0, direction TLT
+.\hbox(0.0+0.0)x0.0, direction TLT
+..\kern-72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil, direction TLT
+...\kern-72.26999
+...\hbox(0.0+0.0)x0.0, direction TLT
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999, direction TLT
+.....\kern-72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 2.14185fil, direction TLT
+..\kern0.0
+..\kern-1.1381
+..\kern-1.00374
+..\hbox(0.0+0.0)x0.0, glue set 9.25504fil, direction TLT
+...\kern0.0
+...\kern-8.2513
+...\kern-1.00374
+...\pdfdest name{page.1} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(731.64497+0.0)x461.2192, direction TLT
+..\glue -1.1381
+..\vbox(732.78308+0.0)x469.47049, shifted -8.2513, direction TLT
+...\vbox(0.0+0.0)x469.47049, direction TLT
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x469.47049, direction TLT
+.....\pdfcolorstack 0 push {0 g 0 G}
+.....\hbox(0.0+0.0)x469.47049, direction TLT
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(702.78308+0.0)x469.47049, glue set 547.12463fil, direction TLT
+....\write-{}
+....\pdfcolorstack 0 push {0 g 0 G}
+....\write4{\indexentry{Options for graphics|hyperxindexformat{\see{Graphic options and styles}}}{\thepage }}
+....\write4{\indexentry{Styles for graphics|hyperxindexformat{\see{Graphic options and styles}}}{\thepage }}
+....\write4{\indexentry{Options for packages|hyperxindexformat{\see{Package options}}}{\thepage }}
+....\write4{\indexentry{Handlers for keys|hyperxindexformat{\see{Key handlers}}}{\thepage }}
+....\write4{\indexentry{File|hyperxindexformat{\see{Packages and files}}}{\thepage }}
+....\write4{\indexentry{Layout|hyperxindexformat{\see{Page layout}}}{\thepage }}
+....\write4{\indexentry{Node|hyperxindexformat{\see{Predefined node}}}{\thepage }}
+....\write4{\indexentry{Data formats|hyperxindexformat{\see{Formats}}}{\thepage }}
+....\pdfdest name{Doc-Start} xyz
+....\pdfdest name{pgfmanualentry.1} xyz
+....\glue(\topskip) 1.60004
+....\hbox(8.39996+3.60004)x449.47049, glue set 349.68048fill, shifted 20.0, direction TLT
+.....\localpar
+......\localinterlinepenalty=0
+......\localbrokenpenalty=0
+......\localleftbox=null
+......\localrightbox=null
+.....\hbox(0.0+0.0)x-20.0, direction TLT
+......\glue -20.0
+......\glue -20.0
+......\glue -5.0
+......\hbox(0.0+0.0)x20.0, glue set 20.0fil, direction TLT
+.......\pdfcolorstack 0 push {0 g 0 G}
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+......\glue 5.0
+.....\penalty 0
+.....\rule(8.39996+3.60004)x0.0
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\hbox(0.0+0.0)x0.0, shifted -10.0, direction TLT
+.......\pdfdest name{pgf./path/x} xyz
+.......\penalty 10000
+.....\write4{\indexentry{x@\protect \texttt {x} key|hyperpage}{\thepage }}
+.....\write4{\indexentry{path@\protect \texttt {/path/}!x@\protect \texttt {x}|hyperpage}{\thepage }}
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\hbox(0.0+0.0)x0.0, shifted -10.0, direction TLT
+.......\pdfdest name{pgf.x} xyz
+.......\penalty 10000
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 push {0.75 0 0 rg 0.75 0 0 RG}
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 p
+.....\TU/lmtt/m/n/10 a
+.....\TU/lmtt/m/n/10 t
+.....\TU/lmtt/m/n/10 h
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 x
+.....\pdfcolorstack 0 pop
+.....\TU/lmtt/m/n/10 =
+.....\TU/lmr/m/n/10 v
+.....\kern-0.56 (font)
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 e
+.....\glue 0.0 plus 1.0fill
+.....\TU/lmr/m/n/10 (
+.....\TU/lmr/m/n/10 n
+.....\TU/lmr/m/n/10 o
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmr/m/n/10 d
+.....\TU/lmr/m/n/10 e
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 f
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 t
+.....\TU/lmr/m/n/10 )
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0 plus 1.0fil
+....\penalty -51
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue -13.60004 plus -3.0 minus -5.0
+....\penalty -51
+....\glue 3.60004
+....\glue 10.0 plus 3.0 minus 5.0
+....\pdfdest name{pgfmanualentry.2} xyz
+....\penalty 10000
+....\glue -10.0 plus -3.0 minus -5.0
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 0.0
+....\hbox(8.39996+3.60004)x449.47049, glue set 341.16049fill, shifted 20.0, direction TLT
+.....\localpar
+......\localinterlinepenalty=0
+......\localbrokenpenalty=0
+......\localleftbox=null
+......\localrightbox=null
+.....\hbox(0.0+0.0)x-20.0, direction TLT
+......\glue -20.0
+......\glue -20.0
+......\glue -5.0
+......\hbox(0.0+0.0)x20.0, glue set 20.0fil, direction TLT
+.......\pdfcolorstack 0 push {0 g 0 G}
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+......\glue 5.0
+.....\penalty 0
+.....\rule(8.39996+3.60004)x0.0
+.....\write4{\indexentry{x@\protect \texttt {x} key|hyperpage}{\thepage }}
+.....\write4{\indexentry{path@\protect \texttt {/path/}!x@\protect \texttt {x}|hyperpage}{\thepage }}
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 push {0.75 0 0 rg 0.75 0 0 RG}
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 p
+.....\TU/lmtt/m/n/10 a
+.....\TU/lmtt/m/n/10 t
+.....\TU/lmtt/m/n/10 h
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 x
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
+.....\TU/lmtt/m/n/10 =
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
+.....\TU/lmr/m/n/10 v
+.....\kern-0.56 (font)
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 e
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fill
+.....\TU/lmr/m/n/10 (
+.....\TU/lmr/m/n/10 d
+.....\TU/lmr/m/n/10 e
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 f
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 t
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmr/m/n/10 )
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0 plus 1.0fil
+....\penalty -51
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue -13.60004 plus -3.0 minus -5.0
+....\penalty -51
+....\glue 3.60004
+....\glue 10.0 plus 3.0 minus 5.0
+....\pdfdest name{pgfmanualentry.3} xyz
+....\penalty 10000
+....\glue -10.0 plus -3.0 minus -5.0
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 0.0
+....\hbox(8.39996+3.60004)x449.47049, glue set 287.53052fill, shifted 20.0, direction TLT
+.....\localpar
+......\localinterlinepenalty=0
+......\localbrokenpenalty=0
+......\localleftbox=null
+......\localrightbox=null
+.....\hbox(0.0+0.0)x-20.0, direction TLT
+......\glue -20.0
+......\glue -20.0
+......\glue -5.0
+......\hbox(0.0+0.0)x20.0, glue set 20.0fil, direction TLT
+.......\pdfcolorstack 0 push {0 g 0 G}
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+......\glue 5.0
+.....\penalty 0
+.....\rule(8.39996+3.60004)x0.0
+.....\write4{\indexentry{x@\protect \texttt {x} key|hyperpage}{\thepage }}
+.....\write4{\indexentry{path@\protect \texttt {/path/}!x@\protect \texttt {x}|hyperpage}{\thepage }}
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 push {0.75 0 0 rg 0.75 0 0 RG}
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 p
+.....\TU/lmtt/m/n/10 a
+.....\TU/lmtt/m/n/10 t
+.....\TU/lmtt/m/n/10 h
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 x
+.....\pdfcolorstack 0 pop
+.....\TU/lmtt/m/n/10 =
+.....\TU/lmr/m/n/10 v
+.....\kern-0.56 (font)
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 e
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\glue 0.0 plus 1.0fill
+.....\TU/lmr/m/n/10 (
+.....\TU/lmr/m/n/10 n
+.....\TU/lmr/m/n/10 o
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmr/m/n/10 d
+.....\TU/lmr/m/n/10 e
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 f
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 t
+.....\TU/lmr/m/n/10 ,
+.....\glue(\spaceskip) 3.33 plus 2.08124 minus 0.888
+.....\TU/lmr/m/n/10 i
+.....\TU/lmr/m/n/10 n
+.....\TU/lmr/m/n/10 i
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 t
+.....\TU/lmr/m/n/10 i
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 y
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmr/m/n/10 )
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0 plus 1.0fil
+....\penalty -51
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue -13.60004 plus -3.0 minus -5.0
+....\penalty -51
+....\glue 3.60004
+....\glue 10.0 plus 3.0 minus 5.0
+....\pdfdest name{pgfmanualentry.4} xyz
+....\penalty 10000
+....\glue -10.0 plus -3.0 minus -5.0
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 0.0
+....\hbox(8.39996+3.60004)x449.47049, glue set 282.34052fill, shifted 20.0, direction TLT
+.....\localpar
+......\localinterlinepenalty=0
+......\localbrokenpenalty=0
+......\localleftbox=null
+......\localrightbox=null
+.....\hbox(0.0+0.0)x-20.0, direction TLT
+......\glue -20.0
+......\glue -20.0
+......\glue -5.0
+......\hbox(0.0+0.0)x20.0, glue set 20.0fil, direction TLT
+.......\pdfcolorstack 0 push {0 g 0 G}
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+......\glue 5.0
+.....\penalty 0
+.....\rule(8.39996+3.60004)x0.0
+.....\write4{\indexentry{x@\protect \texttt {x} key|hyperpage}{\thepage }}
+.....\write4{\indexentry{path@\protect \texttt {/path/}!x@\protect \texttt {x}|hyperpage}{\thepage }}
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 push {0.75 0 0 rg 0.75 0 0 RG}
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 p
+.....\TU/lmtt/m/n/10 a
+.....\TU/lmtt/m/n/10 t
+.....\TU/lmtt/m/n/10 h
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 x
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
+.....\TU/lmtt/m/n/10 =
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
+.....\TU/lmr/m/n/10 v
+.....\kern-0.56 (font)
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 e
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fill
+.....\TU/lmr/m/n/10 (
+.....\TU/lmr/m/n/10 d
+.....\TU/lmr/m/n/10 e
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 f
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 t
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmr/m/n/10 ,
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmr/m/n/10 i
+.....\TU/lmr/m/n/10 n
+.....\TU/lmr/m/n/10 i
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 t
+.....\TU/lmr/m/n/10 i
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 y
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmtt/m/n/10 X
+.....\TU/lmr/m/n/10 )
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0 plus 1.0fil
+....\penalty -51
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue -13.60004 plus -3.0 minus -5.0
+....\penalty -51
+....\glue 3.60004
+....\glue 10.0 plus 3.0 minus 5.0
+....\pdfdest name{pgfmanualentry.5} xyz
+....\penalty 10000
+....\glue -10.0 plus -3.0 minus -5.0
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 0.0
+....\hbox(8.39996+3.60004)x449.47049, glue set 341.16049fill, shifted 20.0, direction TLT
+.....\localpar
+......\localinterlinepenalty=0
+......\localbrokenpenalty=0
+......\localleftbox=null
+......\localrightbox=null
+.....\hbox(0.0+0.0)x-20.0, direction TLT
+......\glue -20.0
+......\glue -20.0
+......\glue -5.0
+......\hbox(0.0+0.0)x20.0, glue set 20.0fil, direction TLT
+.......\pdfcolorstack 0 push {0 g 0 G}
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+......\glue 5.0
+.....\penalty 0
+.....\rule(8.39996+3.60004)x0.0
+.....\write4{\indexentry{x@\protect \texttt {x} key|hyperpage}{\thepage }}
+.....\write4{\indexentry{path@\protect \texttt {/path/}!x@\protect \texttt {x}|hyperpage}{\thepage }}
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 push {0.75 0 0 rg 0.75 0 0 RG}
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 p
+.....\TU/lmtt/m/n/10 a
+.....\TU/lmtt/m/n/10 t
+.....\TU/lmtt/m/n/10 h
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 x
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
+.....\TU/lmtt/m/n/10 =
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
+.....\TU/lmr/m/n/10 v
+.....\kern-0.56 (font)
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 e
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fill
+.....\TU/lmr/m/n/10 (
+.....\TU/lmr/m/n/10 d
+.....\TU/lmr/m/n/10 e
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 f
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 t
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmtt/m/n/10 K
+.....\TU/lmtt/m/n/10 =
+.....\TU/lmtt/m/n/10 V
+.....\TU/lmr/m/n/10 )
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0 plus 1.0fil
+....\penalty -51
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue -13.60004 plus -3.0 minus -5.0
+....\penalty -51
+....\glue 3.60004
+....\glue 10.0 plus 3.0 minus 5.0
+....\pdfdest name{pgfmanualentry.6} xyz
+....\penalty 10000
+....\glue -10.0 plus -3.0 minus -5.0
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 0.0
+....\hbox(8.39996+3.60004)x449.47049, glue set 287.53052fill, shifted 20.0, direction TLT
+.....\localpar
+......\localinterlinepenalty=0
+......\localbrokenpenalty=0
+......\localleftbox=null
+......\localrightbox=null
+.....\hbox(0.0+0.0)x-20.0, direction TLT
+......\glue -20.0
+......\glue -20.0
+......\glue -5.0
+......\hbox(0.0+0.0)x20.0, glue set 20.0fil, direction TLT
+.......\pdfcolorstack 0 push {0 g 0 G}
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+......\glue 5.0
+.....\penalty 0
+.....\rule(8.39996+3.60004)x0.0
+.....\write4{\indexentry{x@\protect \texttt {x} key|hyperpage}{\thepage }}
+.....\write4{\indexentry{path@\protect \texttt {/path/}!x@\protect \texttt {x}|hyperpage}{\thepage }}
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 push {0.75 0 0 rg 0.75 0 0 RG}
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 p
+.....\TU/lmtt/m/n/10 a
+.....\TU/lmtt/m/n/10 t
+.....\TU/lmtt/m/n/10 h
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 x
+.....\pdfcolorstack 0 pop
+.....\TU/lmtt/m/n/10 =
+.....\TU/lmr/m/n/10 v
+.....\kern-0.56 (font)
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 e
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\glue 0.0 plus 1.0fill
+.....\TU/lmr/m/n/10 (
+.....\TU/lmr/m/n/10 n
+.....\TU/lmr/m/n/10 o
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmr/m/n/10 d
+.....\TU/lmr/m/n/10 e
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 f
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 t
+.....\TU/lmr/m/n/10 ,
+.....\glue(\spaceskip) 3.33 plus 2.08124 minus 0.888
+.....\TU/lmr/m/n/10 i
+.....\TU/lmr/m/n/10 n
+.....\TU/lmr/m/n/10 i
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 t
+.....\TU/lmr/m/n/10 i
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 y
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmtt/m/n/10 K
+.....\TU/lmtt/m/n/10 =
+.....\TU/lmtt/m/n/10 V
+.....\TU/lmr/m/n/10 )
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0 plus 1.0fil
+....\penalty -51
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue -13.60004 plus -3.0 minus -5.0
+....\penalty -51
+....\glue 3.60004
+....\glue 10.0 plus 3.0 minus 5.0
+....\pdfdest name{pgfmanualentry.7} xyz
+....\penalty 10000
+....\glue -10.0 plus -3.0 minus -5.0
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 0.0
+....\hbox(8.39996+3.60004)x449.47049, glue set 282.34052fill, shifted 20.0, direction TLT
+.....\localpar
+......\localinterlinepenalty=0
+......\localbrokenpenalty=0
+......\localleftbox=null
+......\localrightbox=null
+.....\hbox(0.0+0.0)x-20.0, direction TLT
+......\glue -20.0
+......\glue -20.0
+......\glue -5.0
+......\hbox(0.0+0.0)x20.0, glue set 20.0fil, direction TLT
+.......\pdfcolorstack 0 push {0 g 0 G}
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+......\glue 5.0
+.....\penalty 0
+.....\rule(8.39996+3.60004)x0.0
+.....\write4{\indexentry{x@\protect \texttt {x} key|hyperpage}{\thepage }}
+.....\write4{\indexentry{path@\protect \texttt {/path/}!x@\protect \texttt {x}|hyperpage}{\thepage }}
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 push {0.75 0 0 rg 0.75 0 0 RG}
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 p
+.....\TU/lmtt/m/n/10 a
+.....\TU/lmtt/m/n/10 t
+.....\TU/lmtt/m/n/10 h
+.....\TU/lmtt/m/n/10 /
+.....\TU/lmtt/m/n/10 x
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
+.....\TU/lmtt/m/n/10 =
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
+.....\TU/lmr/m/n/10 v
+.....\kern-0.56 (font)
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 e
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fill
+.....\TU/lmr/m/n/10 (
+.....\TU/lmr/m/n/10 d
+.....\TU/lmr/m/n/10 e
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 f
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 u
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 t
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmtt/m/n/10 K
+.....\TU/lmtt/m/n/10 =
+.....\TU/lmtt/m/n/10 V
+.....\TU/lmr/m/n/10 ,
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmr/m/n/10 i
+.....\TU/lmr/m/n/10 n
+.....\TU/lmr/m/n/10 i
+.....\discretionary (penalty 50)
+......< \TU/lmr/m/n/10 -
+.....\TU/lmr/m/n/10 t
+.....\TU/lmr/m/n/10 i
+.....\TU/lmr/m/n/10 a
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 l
+.....\TU/lmr/m/n/10 y
+.....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.....\TU/lmtt/m/n/10 K
+.....\TU/lmtt/m/n/10 =
+.....\TU/lmtt/m/n/10 V
+.....\TU/lmr/m/n/10 )
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0 plus 1.0fil
+....\penalty -51
+....\glue 10.0 plus 3.0 minus 5.0
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+....\glue 0.0 plus 0.0001fil
+...\glue(\baselineskip) 23.34
+...\hbox(6.66+0.0)x469.47049, direction TLT
+....\pdfcolorstack 0 push {0 g 0 G}
+....\hbox(6.66+0.0)x469.47049, glue set 232.23524fil, direction TLT
+.....\glue 0.0 plus 1.0fil
+.....\TU/lmr/m/n/10 1
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern0.0
+.\kern0.0
+(key-env.aux)
+Package rerunfilecheck Warning: File `key-env.out' has changed.
+(rerunfilecheck)                Rerun to get outlines right
+(rerunfilecheck)                or use package `bookmark'.
+Package rerunfilecheck Info: Checksums for `key-env.out':
+(rerunfilecheck)             Before: <no file>
+(rerunfilecheck)             After:  D41D8CD98F00B204E9800998ECF8427E;0.

--- a/tex/latex/pgf/doc/pgfmanual-en-macros.tex
+++ b/tex/latex/pgf/doc/pgfmanual-en-macros.tex
@@ -647,6 +647,7 @@
 % \begin{key}{/path/x=value}
 % \begin{key}{/path/x=value (initially XXX)}
 % \begin{key}{/path/x=value (default XXX)}
+% \begin{key}{/path/x=value (default XXX, initially XXX)}
 \newenvironment{key}[1]{
   \begin{pgfmanualentry}
     \def\extrakeytext{}
@@ -725,7 +726,12 @@
 \def\extractkeyequal#1=#2\@nil{%
   \pgfutil@in@{(default}{#2}%
   \ifpgfutil@in@%
-    \extractdefault{#1}#2\@nil%
+    \pgfutil@in@{, initial}{#2}%
+    \ifpgfutil@in@
+      \extractdefaultinitial{#1}#2\@nil
+    \else
+      \extractdefault{#1}#2\@nil
+    \fi
   \else%
     \pgfutil@in@{(initial}{#2}%
     \ifpgfutil@in@%
@@ -763,6 +769,18 @@
     \pgfmanualdecomposecount=0\relax%
     \decompose#1/\nil%
     {\ttfamily\declare{#1}=}#2\hfill (\extrakeytext no default, initially {\ttfamily#3})}%
+}
+
+\def\extractdefaultinitial#1#2(default #3, initially #4)\@nil{%
+  \pgfmanualentryheadline{%
+    \def\mykey{#1}%
+    \def\mypath{}%
+    \gdef\myname{}%
+    \firsttimetrue%
+    \pgfmanualdecomposecount=0\relax
+    \decompose#1/\nil
+    {\ttfamily\declare{#1}\opt{=}}\opt{#2}\hfill
+    (\extrakeytext default {\ttfamily#3}, initially {\ttfamily#4})}%
 }
 
 \def\extractequalinitial#1 (initially #2)\@nil{%


### PR DESCRIPTION
**Motivation for this change**

Fixes #1278.

Compiled PDF of new test `key-env.lvt`:

<img width="1004" height="320" alt="image" src="https://github.com/user-attachments/assets/5cb929d6-8fea-4359-bd8e-3ac460259da1" />


**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
