### PR TITLE
Fix closepath command in `svg.path` library

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix formatting of `default XXX, initially XXX` in key docs #1278
+- Fix handling of closepath command in svg.path library #1189
 
 ## [3.1.11] - 2025-08-14 Henri Menke
 

--- a/tex/generic/pgf/libraries/pgflibrarysvg.path.code.tex
+++ b/tex/generic/pgf/libraries/pgflibrarysvg.path.code.tex
@@ -55,6 +55,8 @@
 }%
 
 
+\newdimen\pgf@lib@svg@subpath@initial@x
+\newdimen\pgf@lib@svg@subpath@initial@y
 
 \newdimen\pgf@lib@svg@last@x
 \newdimen\pgf@lib@svg@last@y
@@ -96,6 +98,8 @@
   \pgf@lib@svg@clear@bezier@quad%
   \pgf@lib@svg@last@x=\pgf@lib@svg@get@num{0}pt%
   \pgf@lib@svg@last@y=\pgf@lib@svg@get@num{1}pt%
+  \pgf@lib@svg@subpath@initial@x=\pgf@lib@svg@last@x
+  \pgf@lib@svg@subpath@initial@y=\pgf@lib@svg@last@y
   \pgfpathmoveto{\pgfqpoint{\pgf@lib@svg@last@x}{\pgf@lib@svg@last@y}}%
   \pgf@lib@svg@read@nums{2}{\pgf@lib@svg@lineto}%
 }%
@@ -113,6 +117,8 @@
   \pgf@lib@svg@clear@bezier@quad%
   \advance\pgf@lib@svg@last@x by\pgf@lib@svg@get@num{0}pt%
   \advance\pgf@lib@svg@last@y by\pgf@lib@svg@get@num{1}pt%
+  \pgf@lib@svg@subpath@initial@x=\pgf@lib@svg@last@x
+  \pgf@lib@svg@subpath@initial@y=\pgf@lib@svg@last@y
   \pgfpathmoveto{\pgfqpoint{\pgf@lib@svg@last@x}{\pgf@lib@svg@last@y}}%
   \pgf@lib@svg@read@nums{2}{\pgf@lib@svg@lineto@rel}%
 }%
@@ -173,6 +179,8 @@
 \def\pgf@lib@svg@closepath{%
   \pgf@lib@svg@finish@prev
   \pgfpathclose
+  \pgf@lib@svg@last@x=\pgf@lib@svg@subpath@initial@x
+  \pgf@lib@svg@last@y=\pgf@lib@svg@subpath@initial@y
   \let\pgf@lib@svg@finish@prev=\relax
   \pgf@lib@svg@clear@bezier@quad%
   \pgfparserswitch{initial}%


### PR DESCRIPTION
**Motivation for this change**

Fixes #1189

The `svg.path` library for parsing SVG paths currently misinterprets the `closepath` (`Z`/`z`) command in the SVG path syntax. According to the [SVG specification](https://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand), when a path is closed using the closepath command
> then the next subpath must start at the same [initial point](https://www.w3.org/TR/SVG/paths.html#TermInitialPoint) as the current subpath.

In other words, the current point must go to the initial point of the subpath that was just closed. But the current interpretation as part of the `svg.path` library leaves the current point at the last position before we closed the path. This PR saves the initial point when a new subpath is started (using `m` or `M`) and sets the current point to this initial point when `Z` or `z` is invoked.

Example:
```tex
\documentclass[tikz,border=20pt]{standalone}
\usetikzlibrary{svg.path}
\begin{document}
	\begin{tikzpicture}[scale=20]
		% Intended: start at (100,0), go horizontal +10, go vertical +10, close (to get a triangle)
		% then move +20 horizontally (to 120,0) and draw another triangle.
		\fill[blue!40] svg {m 100,0 h10 v10 z m 20,0 h10 v10 z};
	\end{tikzpicture}
\end{document}
```
In version 3.1.11 of pgf, this produces the following output:
<img width="432" height="225" alt="image" src="https://github.com/user-attachments/assets/f940dad8-6994-429b-bcb9-497c93aa2150" />

After this PR, it produces the following:
<img width="331" height="115" alt="image" src="https://github.com/user-attachments/assets/83f43082-4c40-4ba0-8a99-72386615e83f" />
which corresponds to what it should look like (see [this visualizer](https://yqnn.github.io/svg-path-editor/#P=m_100,0_h10_v10_z_m_20,0_h10_v10_z)).

The problem with the current version is that the move "`m 20,0`" goes from the last mentioned point of the previous path (the top right corner of the first triangle), rather than from the initial point of the previous path (the bottom left corner of the first triangle).

The change also fixes the example given in issue #1189. Before / after PR:
<img width="80" height="165" alt="image" src="https://github.com/user-attachments/assets/94fc5571-3b3e-4c8c-8ee2-8817b1da537f" /> <img width="68" height="108" alt="image" src="https://github.com/user-attachments/assets/b5cb0186-367c-4684-a5ed-256a15591e1b" />


**Checklist**

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
