### PR TITLE
Circle suggestion

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix formatting of `default XXX, initially XXX` in key docs #1278
+- Moved `base west`, `base east`, `mid west`, and `mid east` anchors
+    onto the edge of the shape for `circle` and `ellipse` shapes
 
 ## [3.1.11] - 2025-08-14 Henri Menke
 

--- a/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
+++ b/tex/generic/pgf/libraries/shapes/pgflibraryshapes.geometric.code.tex
@@ -91,18 +91,26 @@
   \anchor{mid west}
   {%
     \pgf@process{\radius}
-    \pgf@xa=\pgf@x%
+    \pgf@xa=\pgf@x
+    \pgf@ya=\pgf@y
     \pgf@process{\centerpoint}
-    \advance\pgf@x by-\pgf@xa%
-    \pgfmathsetlength\pgf@y{.5ex}
+    \pgf@xc=\pgf@x
+    \pgf@yc=\pgf@y
+    \pgfmathsetlength\pgf@y{0.5ex}%
+    \pgfmathsetlength\pgf@x{\pgf@xc
+        - \pgf@xa*cos(asin((\pgf@y-\pgf@yc)/\pgf@ya))}
   }%
   \anchor{base west}
   {%
     \pgf@process{\radius}
-    \pgf@xa=\pgf@x%
+    \pgf@xa=\pgf@x
+    \pgf@ya=\pgf@y
     \pgf@process{\centerpoint}
-    \advance\pgf@x by-\pgf@xa%
-    \pgf@y=0pt
+    \pgf@xc=\pgf@x
+    \pgf@yc=\pgf@y
+    \pgf@y=0pt%
+    \pgfmathsetlength\pgf@x{\pgf@xc
+        - \pgf@xa*cos(asin((\pgf@y-\pgf@yc)/\pgf@ya))}
   }%
   \anchor{north west}
   {
@@ -132,18 +140,26 @@
   \anchor{mid east}
   {%
     \pgf@process{\radius}
-    \pgf@xa=\pgf@x%
+    \pgf@xa=\pgf@x
+    \pgf@ya=\pgf@y
     \pgf@process{\centerpoint}
-    \advance\pgf@x by\pgf@xa%
-    \pgfmathsetlength\pgf@y{.5ex}
+    \pgf@xc=\pgf@x
+    \pgf@yc=\pgf@y
+    \pgfmathsetlength\pgf@y{0.5ex}%
+    \pgfmathsetlength\pgf@x{\pgf@xc
+        + \pgf@xa*cos(asin((\pgf@y-\pgf@yc)/\pgf@ya))}
   }%
   \anchor{base east}
   {%
     \pgf@process{\radius}
-    \pgf@xa=\pgf@x%
+    \pgf@xa=\pgf@x
+    \pgf@ya=\pgf@y
     \pgf@process{\centerpoint}
-    \advance\pgf@x by\pgf@xa%
-    \pgf@y=0pt
+    \pgf@xc=\pgf@x
+    \pgf@yc=\pgf@y
+    \pgf@y=0pt%
+    \pgfmathsetlength\pgf@x{\pgf@xc
+        + \pgf@xa*cos(asin(-(\pgf@y-\pgf@yc)/\pgf@ya))}
   }%
   \anchor{north east}
   {

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -1285,14 +1285,14 @@
     \centerpoint
     \pgf@xc=\pgf@x
     \pgf@yc=\pgf@y
-    \pgfmathsetlength\pgf@y{0pt}%
+    \pgf@y=0pt%
     \pgfmathsetlength\pgf@x{\pgf@xc - \radius*cos(asin(-\pgf@yc/\radius))}%
   }%
   \anchor{base east}{%
     \centerpoint
     \pgf@xc=\pgf@x
     \pgf@yc=\pgf@y
-    \pgfmathsetlength\pgf@y{0pt}%
+    \pgf@y=0pt%
     \pgfmathsetlength\pgf@x{\pgf@xc + \radius*cos(asin(-\pgf@yc/\radius))}%
   }%
   \anchor{north west}{

--- a/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleshapes.code.tex
@@ -1267,10 +1267,34 @@
   \anchor{south}{\centerpoint\advance\pgf@y by-\radius}%
   \anchor{west}{\centerpoint\advance\pgf@x by-\radius}%
   \anchor{east}{\centerpoint\advance\pgf@x by\radius}%
-  \anchor{mid west}{\centerpoint\advance\pgf@x by-\radius\pgfmathsetlength\pgf@y{.5ex}}%
-  \anchor{mid east}{\centerpoint\advance\pgf@x by\radius\pgfmathsetlength\pgf@y{.5ex}}%
-  \anchor{base west}{\centerpoint\advance\pgf@x by-\radius\pgf@y=0pt}%
-  \anchor{base east}{\centerpoint\advance\pgf@x by\radius\pgf@y=0pt}%
+  \anchor{mid west}{\centerpoint
+    \pgf@xc=\pgf@x
+    \pgf@yc=\pgf@y
+    \pgfmathsetlength\pgf@y{0.5ex}%
+    \pgfmathsetlength\pgf@x{\pgf@xc
+        - \radius*cos(asin((\pgf@y-\pgf@yc)/\radius))}%
+  }%
+  \anchor{mid east}{\centerpoint
+    \pgf@xc=\pgf@x
+    \pgf@yc=\pgf@y
+    \pgfmathsetlength\pgf@y{0.5ex}%
+    \pgfmathsetlength\pgf@x{\pgf@xc
+        + \radius*cos(asin((\pgf@y-\pgf@yc)/\radius))}%
+  }%
+  \anchor{base west}{%
+    \centerpoint
+    \pgf@xc=\pgf@x
+    \pgf@yc=\pgf@y
+    \pgfmathsetlength\pgf@y{0pt}%
+    \pgfmathsetlength\pgf@x{\pgf@xc - \radius*cos(asin(-\pgf@yc/\radius))}%
+  }%
+  \anchor{base east}{%
+    \centerpoint
+    \pgf@xc=\pgf@x
+    \pgf@yc=\pgf@y
+    \pgfmathsetlength\pgf@y{0pt}%
+    \pgfmathsetlength\pgf@x{\pgf@xc + \radius*cos(asin(-\pgf@yc/\radius))}%
+  }%
   \anchor{north west}{
     \centerpoint
     \pgf@xa=\radius


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

This is a suggestion for the `circle` and `ellipse` shapes. In most other shapes I see in the manual (e.g., `trapezium`, `semicircle`, `isosceles triangle`, `kite`), the `base east`, `mid east`, `base west`, and `base east` anchors all end up on the shape boundary. In `circle` and `ellipse`, however, they are directly beneath `east` and `west`, outside the shape border. This patch would place them on the edge of the background path for circles and ellipses as well.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
