### PR TITLE
docs: drop unavailable read-only Matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ official mailing list at https://tug.org/mailman/listinfo/pgf-tikz to submit
 bug reports, request new features, etc.
 
 We also have a chat on the Matrix network at
-[#pgf-tikz:matrix.org](https://matrix.to/#/#pgf-tikz:matrix.org) ([read-only
-version](https://view.matrix.org/room/!NuxCISwYQJuyWwNsEI:matrix.org/)).
+[#pgf-tikz:matrix.org](https://matrix.to/#/#pgf-tikz:matrix.org).
 
 ## Installation
 


### PR DESCRIPTION
**Motivation for this change**

The Matrix Public View has been discontinued.

Originally found in https://github.com/pgf-tikz/pgfplots/pull/510#discussion_r2306638771.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [ ] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [ ] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
