### PR TITLE
Add support for dvisvgm4ht driver in pgfcoreshade

### DIFF
--- a/tex/generic/pgf/basiclayer/pgfcoreshade.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcoreshade.code.tex
@@ -371,6 +371,11 @@
   \ifx\pgfsysdriver\pgf@sys@driver@texforht
     \def\pgf@shading@model{rgb}%
   \fi
+  \edef\pgf@sys@driver@dvisvgmforht{pgfsys-dvisvgm4ht.def}%
+  \ifx\pgfsysdriver\pgf@sys@driver@dvisvgmforht
+    \def\pgf@shading@model{rgb}%
+  \fi
+
 }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

I think we need to set the  shading mode to `rgb` explicitly with the `dvisvgm4ht` driver (which is used by default with TeX4ht), otherwise there can be errors if user selects the `cmyk` option for `xcolor`:

```latex
\documentclass{article}
\usepackage[cmyk]{xcolor}
\usepackage{tikz}
\usetikzlibrary{fadings}
\begin{document}
  hello
\end{document}
```

Compile using:

```bash
$ make4ht -a debug sample.tex
```

The error:

```
! Undefined control sequence.
<argument> ...@end@pos }{\pgf@sys@shading@end@rgb
                                                  }{\pgf@sys@shading@end@rgb }
l.17 ...t!100); color(100bp)=(pgftransparent!100)}
```

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
