### PR TITLE
Add support for directions in LuaTeX and LuaMetaTeX.

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Resolve parsing ambiguity in general shadow #1435
 
+- Support directions in LuaTeX and LuaMetaTeX
+
 ### Added
 
 - Documentation of `\pgfkeysifassignable` #1423

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix mis-spelled Kellermann to Kellerman
 - Support an apply-all feature (suggested in issue #640) to
   apply a single definition of options to multiple examples.
+- Support directions in LuaTeX and LuaMetaTeX
 
 ### Added
 
@@ -50,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dominik Peters
 - Erin Cold
 - Hanson Char
+- Udi Fogiel
 
 ## [3.1.11a] - 2025-08-29 Henri Menke
 

--- a/testfiles-examples/pgfmanual-en-base-animations.tlg
+++ b/testfiles-examples/pgfmanual-en-base-animations.tlg
@@ -49,6 +49,7 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -59,6 +60,7 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -133,10 +135,12 @@ TEST 2: pgfmanual-en-base-animations-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.28+0.14)x17.35, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/sc/10 p
 ...........\TU/lmr/m/sc/10 g
 ...........\TU/lmr/m/sc/10 f
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -203,10 +207,12 @@ TEST 2: pgfmanual-en-base-animations-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.28+0.14)x17.35, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/sc/10 p
 ...........\TU/lmr/m/sc/10 g
 ...........\TU/lmr/m/sc/10 f
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -273,10 +279,12 @@ TEST 2: pgfmanual-en-base-animations-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.28+0.14)x17.35, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/sc/10 p
 ...........\TU/lmr/m/sc/10 g
 ...........\TU/lmr/m/sc/10 f
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -343,10 +351,12 @@ TEST 2: pgfmanual-en-base-animations-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.28+0.14)x17.35, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/sc/10 p
 ...........\TU/lmr/m/sc/10 g
 ...........\TU/lmr/m/sc/10 f
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -418,6 +428,7 @@ TEST 3: pgfmanual-en-base-animations-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -428,6 +439,7 @@ TEST 3: pgfmanual-en-base-animations-3
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -497,11 +509,13 @@ TEST 4: pgfmanual-en-base-animations-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -571,6 +585,7 @@ TEST 5: pgfmanual-en-base-animations-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -581,6 +596,7 @@ TEST 5: pgfmanual-en-base-animations-5
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -696,6 +712,7 @@ TEST 6: pgfmanual-en-base-animations-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -706,6 +723,7 @@ TEST 6: pgfmanual-en-base-animations-6
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -822,6 +840,7 @@ TEST 7: pgfmanual-en-base-animations-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -832,6 +851,7 @@ TEST 7: pgfmanual-en-base-animations-7
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -948,6 +968,7 @@ TEST 8: pgfmanual-en-base-animations-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -958,6 +979,7 @@ TEST 8: pgfmanual-en-base-animations-8
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1027,6 +1049,7 @@ TEST 9: pgfmanual-en-base-animations-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -1037,6 +1060,7 @@ TEST 9: pgfmanual-en-base-animations-9
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1131,11 +1155,13 @@ TEST 10: pgfmanual-en-base-animations-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 N
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1218,7 +1244,9 @@ TEST 11: pgfmanual-en-base-animations-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1290,7 +1318,9 @@ TEST 11: pgfmanual-en-base-animations-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1362,7 +1392,9 @@ TEST 11: pgfmanual-en-base-animations-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1434,7 +1466,9 @@ TEST 11: pgfmanual-en-base-animations-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1506,7 +1540,9 @@ TEST 11: pgfmanual-en-base-animations-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1590,7 +1626,9 @@ TEST 12: pgfmanual-en-base-animations-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1662,7 +1700,9 @@ TEST 12: pgfmanual-en-base-animations-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1734,7 +1774,9 @@ TEST 12: pgfmanual-en-base-animations-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1806,7 +1848,9 @@ TEST 12: pgfmanual-en-base-animations-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1877,7 +1921,9 @@ TEST 12: pgfmanual-en-base-animations-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1948,6 +1994,7 @@ TEST 13: pgfmanual-en-base-animations-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -1958,6 +2005,7 @@ TEST 13: pgfmanual-en-base-animations-13
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2026,6 +2074,7 @@ TEST 14: pgfmanual-en-base-animations-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2036,6 +2085,7 @@ TEST 14: pgfmanual-en-base-animations-14
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2104,6 +2154,7 @@ TEST 15: pgfmanual-en-base-animations-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2114,6 +2165,7 @@ TEST 15: pgfmanual-en-base-animations-15
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2211,6 +2263,7 @@ TEST 16: pgfmanual-en-base-animations-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2221,6 +2274,7 @@ TEST 16: pgfmanual-en-base-animations-16
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2256,6 +2310,7 @@ TEST 16: pgfmanual-en-base-animations-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x38.87001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 N
 ...........\TU/lmr/m/n/10 o
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
@@ -2268,6 +2323,7 @@ TEST 16: pgfmanual-en-base-animations-16
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2336,6 +2392,7 @@ TEST 17: pgfmanual-en-base-animations-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2346,6 +2403,7 @@ TEST 17: pgfmanual-en-base-animations-17
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2381,6 +2439,7 @@ TEST 17: pgfmanual-en-base-animations-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x25.41, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 E
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 f
@@ -2390,6 +2449,7 @@ TEST 17: pgfmanual-en-base-animations-17
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2458,6 +2518,7 @@ TEST 18: pgfmanual-en-base-animations-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2468,6 +2529,7 @@ TEST 18: pgfmanual-en-base-animations-18
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2503,11 +2565,13 @@ TEST 18: pgfmanual-en-base-animations-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(14.10321+0.16592)x38.0579, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 T
 ...........\kern-1.61772 (font)
 ...........\TU/lmr/m/n/20.74 e
 ...........\TU/lmr/m/n/20.74 x
 ...........\TU/lmr/m/n/20.74 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2576,6 +2640,7 @@ TEST 19: pgfmanual-en-base-animations-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2586,6 +2651,7 @@ TEST 19: pgfmanual-en-base-animations-19
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2654,6 +2720,7 @@ TEST 20: pgfmanual-en-base-animations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2664,6 +2731,7 @@ TEST 20: pgfmanual-en-base-animations-20
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2732,6 +2800,7 @@ TEST 21: pgfmanual-en-base-animations-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2742,6 +2811,7 @@ TEST 21: pgfmanual-en-base-animations-21
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2810,6 +2880,7 @@ TEST 22: pgfmanual-en-base-animations-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2820,6 +2891,7 @@ TEST 22: pgfmanual-en-base-animations-22
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2888,6 +2960,7 @@ TEST 23: pgfmanual-en-base-animations-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2898,6 +2971,7 @@ TEST 23: pgfmanual-en-base-animations-23
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2933,6 +3007,7 @@ TEST 23: pgfmanual-en-base-animations-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x25.41, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 E
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 f
@@ -2942,6 +3017,7 @@ TEST 23: pgfmanual-en-base-animations-23
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3009,6 +3085,7 @@ TEST 24: pgfmanual-en-base-animations-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3019,6 +3096,7 @@ TEST 24: pgfmanual-en-base-animations-24
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3087,6 +3165,7 @@ TEST 25: pgfmanual-en-base-animations-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3097,6 +3176,7 @@ TEST 25: pgfmanual-en-base-animations-25
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3165,6 +3245,7 @@ TEST 26: pgfmanual-en-base-animations-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3175,6 +3256,7 @@ TEST 26: pgfmanual-en-base-animations-26
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3243,6 +3325,7 @@ TEST 27: pgfmanual-en-base-animations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3253,6 +3336,7 @@ TEST 27: pgfmanual-en-base-animations-27
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3322,6 +3406,7 @@ TEST 28: pgfmanual-en-base-animations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3332,6 +3417,7 @@ TEST 28: pgfmanual-en-base-animations-28
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3412,6 +3498,7 @@ TEST 29: pgfmanual-en-base-animations-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3422,6 +3509,7 @@ TEST 29: pgfmanual-en-base-animations-29
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3499,6 +3587,7 @@ TEST 30: pgfmanual-en-base-animations-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3509,6 +3598,7 @@ TEST 30: pgfmanual-en-base-animations-30
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3718,6 +3808,7 @@ TEST 31: pgfmanual-en-base-animations-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3728,6 +3819,7 @@ TEST 31: pgfmanual-en-base-animations-31
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3795,6 +3887,7 @@ TEST 32: pgfmanual-en-base-animations-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3805,6 +3898,7 @@ TEST 32: pgfmanual-en-base-animations-32
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3872,6 +3966,7 @@ TEST 33: pgfmanual-en-base-animations-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3882,6 +3977,7 @@ TEST 33: pgfmanual-en-base-animations-33
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3950,6 +4046,7 @@ TEST 34: pgfmanual-en-base-animations-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3960,6 +4057,7 @@ TEST 34: pgfmanual-en-base-animations-34
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4028,6 +4126,7 @@ TEST 35: pgfmanual-en-base-animations-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4038,6 +4137,7 @@ TEST 35: pgfmanual-en-base-animations-35
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4106,6 +4206,7 @@ TEST 36: pgfmanual-en-base-animations-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4116,6 +4217,7 @@ TEST 36: pgfmanual-en-base-animations-36
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4186,6 +4288,7 @@ TEST 37: pgfmanual-en-base-animations-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4196,6 +4299,7 @@ TEST 37: pgfmanual-en-base-animations-37
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4266,6 +4370,7 @@ TEST 38: pgfmanual-en-base-animations-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4276,6 +4381,7 @@ TEST 38: pgfmanual-en-base-animations-38
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4346,6 +4452,7 @@ TEST 39: pgfmanual-en-base-animations-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4356,6 +4463,7 @@ TEST 39: pgfmanual-en-base-animations-39
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4424,11 +4532,13 @@ TEST 39: pgfmanual-en-base-animations-39
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(3.47+0.055)x9.515, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/5 r
 ...........\TU/lmr/m/n/5 e
 ...........\TU/lmr/m/n/5 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4501,6 +4611,7 @@ TEST 40: pgfmanual-en-base-animations-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x46.39, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Z
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
@@ -4511,6 +4622,7 @@ TEST 40: pgfmanual-en-base-animations-40
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4548,6 +4660,7 @@ TEST 40: pgfmanual-en-base-animations-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x41.97, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Z
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
@@ -4557,6 +4670,7 @@ TEST 40: pgfmanual-en-base-animations-40
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4625,12 +4739,14 @@ TEST 40: pgfmanual-en-base-animations-40
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.94+0.11)x18.34, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 b
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4680,11 +4796,13 @@ TEST 40: pgfmanual-en-base-animations-40
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(3.47+0.055)x9.515, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/5 r
 ...........\TU/lmr/m/n/5 e
 ...........\TU/lmr/m/n/5 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4756,6 +4874,7 @@ TEST 41: pgfmanual-en-base-animations-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x60.12, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 T
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 u
@@ -4773,6 +4892,7 @@ TEST 41: pgfmanual-en-base-animations-41
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4840,11 +4960,13 @@ TEST 42: pgfmanual-en-base-animations-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4912,11 +5034,13 @@ TEST 43: pgfmanual-en-base-animations-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4984,6 +5108,7 @@ TEST 44: pgfmanual-en-base-animations-44
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4994,6 +5119,7 @@ TEST 44: pgfmanual-en-base-animations-44
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5061,6 +5187,7 @@ TEST 45: pgfmanual-en-base-animations-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -5071,6 +5198,7 @@ TEST 45: pgfmanual-en-base-animations-45
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5138,6 +5266,7 @@ TEST 46: pgfmanual-en-base-animations-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -5148,6 +5277,7 @@ TEST 46: pgfmanual-en-base-animations-46
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5215,6 +5345,7 @@ TEST 47: pgfmanual-en-base-animations-47
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -5225,6 +5356,7 @@ TEST 47: pgfmanual-en-base-animations-47
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5292,6 +5424,7 @@ TEST 48: pgfmanual-en-base-animations-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -5302,6 +5435,7 @@ TEST 48: pgfmanual-en-base-animations-48
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-base-decorations.tlg
+++ b/testfiles-examples/pgfmanual-en-base-decorations.tlg
@@ -97,9 +97,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.05+0.22)x5.56, direction TLT
 ........\hbox(7.05+0.22)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 S
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -113,9 +115,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -129,9 +133,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x8.33, direction TLT
 ........\hbox(4.42+0.0)x8.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 m
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -145,9 +151,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -161,9 +169,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -177,9 +187,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -193,9 +205,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -209,9 +223,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+0.0)x5.28, direction TLT
 ........\hbox(4.31+0.0)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 x
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -225,9 +241,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -241,9 +259,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -257,9 +277,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -273,9 +295,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -289,9 +313,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -305,9 +331,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -321,9 +349,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -337,9 +367,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -353,9 +385,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -369,9 +403,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -385,9 +421,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -401,9 +439,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -417,9 +457,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -433,9 +475,11 @@ TEST 2: pgfmanual-en-base-decorations-2
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x5.56, direction TLT
 ........\hbox(6.94+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 h
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -756,6 +800,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -786,6 +832,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -816,6 +864,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -846,6 +896,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -876,6 +928,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -906,6 +960,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -936,6 +992,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -966,6 +1024,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -996,6 +1056,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1026,6 +1088,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1056,6 +1120,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1086,6 +1152,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1116,6 +1184,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1146,6 +1216,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1176,6 +1248,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1206,6 +1280,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1236,6 +1312,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1266,6 +1344,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1296,6 +1376,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1326,6 +1408,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1356,6 +1440,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1386,6 +1472,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1416,6 +1504,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1446,6 +1536,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1476,6 +1568,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1506,6 +1600,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1536,6 +1632,8 @@ TEST 4: pgfmanual-en-base-decorations-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x0.0, direction TLT
+........\begindir TLT
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil

--- a/testfiles-examples/pgfmanual-en-base-images.tlg
+++ b/testfiles-examples/pgfmanual-en-base-images.tlg
@@ -25,7 +25,9 @@ TEST 1: pgfmanual-en-base-images-2
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(28.45274+0.0)x28.45274, direction TLT
+........\begindir TLT
 ........\image(28.45274+0.0)x28.45274
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -38,7 +40,9 @@ TEST 1: pgfmanual-en-base-images-2
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(32.19652+0.0)x28.45274, direction TLT
+........\begindir TLT
 ........\image(32.19652+0.0)x28.45274
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -51,7 +55,9 @@ TEST 1: pgfmanual-en-base-images-2
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(28.45274+0.0)x25.14429, direction TLT
+........\begindir TLT
 ........\image(28.45274+0.0)x25.14429
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -99,7 +105,9 @@ TEST 2: pgfmanual-en-base-images-3
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(28.45274+0.0)x28.45274, direction TLT
+........\begindir TLT
 ........\image(28.45274+0.0)x28.45274
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -112,7 +120,9 @@ TEST 2: pgfmanual-en-base-images-3
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(32.19652+0.0)x28.45274, direction TLT
+........\begindir TLT
 ........\image(32.19652+0.0)x28.45274
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -125,7 +135,9 @@ TEST 2: pgfmanual-en-base-images-3
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(28.45274+0.0)x25.14429, direction TLT
+........\begindir TLT
 ........\image(28.45274+0.0)x25.14429
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -172,7 +184,9 @@ TEST 3: pgfmanual-en-base-images-4
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(28.45274+0.0)x28.45274, direction TLT
+........\begindir TLT
 ........\image(28.45274+0.0)x28.45274
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -185,7 +199,9 @@ TEST 3: pgfmanual-en-base-images-4
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(32.19652+0.0)x28.45274, direction TLT
+........\begindir TLT
 ........\image(32.19652+0.0)x28.45274
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -198,7 +214,9 @@ TEST 3: pgfmanual-en-base-images-4
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(28.45274+0.0)x25.14429, direction TLT
+........\begindir TLT
 ........\image(28.45274+0.0)x25.14429
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil

--- a/testfiles-examples/pgfmanual-en-base-layers.tlg
+++ b/testfiles-examples/pgfmanual-en-base-layers.tlg
@@ -122,6 +122,7 @@ TEST 1: pgfmanual-en-base-layers-2
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+2.06)x47.01999, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
@@ -136,6 +137,7 @@ TEST 1: pgfmanual-en-base-layers-2
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-base-matrices.tlg
+++ b/testfiles-examples/pgfmanual-en-base-matrices.tlg
@@ -71,9 +71,11 @@ TEST 1: pgfmanual-en-base-matrices-1
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(3.33+0.0)x3.405, direction TLT
+...................\begindir TLT
 ...................\pdfcolorstack 0 push {0 g 0 G}
 ...................\TU/lmr/m/n/5 1
 ...................\pdfcolorstack 0 pop
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -126,9 +128,11 @@ TEST 1: pgfmanual-en-base-matrices-1
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(3.33+0.0)x3.405, direction TLT
+...................\begindir TLT
 ...................\pdfcolorstack 0 push {0 g 0 G}
 ...................\TU/lmr/m/n/5 2
 ...................\pdfcolorstack 0 pop
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -181,9 +185,11 @@ TEST 1: pgfmanual-en-base-matrices-1
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(3.33+0.11)x3.405, direction TLT
+...................\begindir TLT
 ...................\pdfcolorstack 0 push {0 g 0 G}
 ...................\TU/lmr/m/n/5 3
 ...................\pdfcolorstack 0 pop
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -236,9 +242,11 @@ TEST 1: pgfmanual-en-base-matrices-1
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(3.385+0.0)x3.405, direction TLT
+...................\begindir TLT
 ...................\pdfcolorstack 0 push {0 g 0 G}
 ...................\TU/lmr/m/n/5 4
 ...................\pdfcolorstack 0 pop
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -295,9 +303,11 @@ TEST 1: pgfmanual-en-base-matrices-1
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(3.33+0.11)x3.405, direction TLT
+...................\begindir TLT
 ...................\pdfcolorstack 0 push {0 g 0 G}
 ...................\TU/lmr/m/n/5 5
 ...................\pdfcolorstack 0 pop
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -350,9 +360,11 @@ TEST 1: pgfmanual-en-base-matrices-1
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(3.33+0.11)x3.405, direction TLT
+...................\begindir TLT
 ...................\pdfcolorstack 0 push {0 g 0 G}
 ...................\TU/lmr/m/n/5 6
 ...................\pdfcolorstack 0 pop
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -405,9 +417,11 @@ TEST 1: pgfmanual-en-base-matrices-1
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(3.38+0.11)x3.405, direction TLT
+...................\begindir TLT
 ...................\pdfcolorstack 0 push {0 g 0 G}
 ...................\TU/lmr/m/n/5 7
 ...................\pdfcolorstack 0 pop
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -460,9 +474,11 @@ TEST 1: pgfmanual-en-base-matrices-1
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(3.33+0.11)x3.405, direction TLT
+...................\begindir TLT
 ...................\pdfcolorstack 0 push {0 g 0 G}
 ...................\TU/lmr/m/n/5 8
 ...................\pdfcolorstack 0 pop
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -547,7 +563,9 @@ TEST 2: pgfmanual-en-base-matrices-2
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(4.48+0.11)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 a
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -584,7 +602,9 @@ TEST 2: pgfmanual-en-base-matrices-2
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.94+0.11)x5.56, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 b
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -625,7 +645,9 @@ TEST 2: pgfmanual-en-base-matrices-2
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(4.48+0.11)x4.44, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 c
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -662,7 +684,9 @@ TEST 2: pgfmanual-en-base-matrices-2
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.94+0.11)x5.56, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 d
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -750,7 +774,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 8
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -789,7 +815,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 1
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -828,7 +856,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 6
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -871,7 +901,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 3
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -910,7 +942,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 5
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -949,7 +983,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.76+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 7
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -992,7 +1028,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.77+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 4
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1031,7 +1069,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 9
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1070,7 +1110,9 @@ TEST 3: pgfmanual-en-base-matrices-3
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 2
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1158,7 +1200,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 8
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1197,7 +1241,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 1
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1236,7 +1282,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 6
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1279,7 +1327,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 3
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1318,7 +1368,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 5
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1357,7 +1409,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.76+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 7
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1400,7 +1454,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.77+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 4
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1439,7 +1495,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 9
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1478,7 +1536,9 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 2
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1537,12 +1597,14 @@ TEST 4: pgfmanual-en-base-matrices-4
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x26.66, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1622,7 +1684,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 8
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1661,7 +1725,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 1
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1700,7 +1766,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 6
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1743,7 +1811,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 3
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1782,7 +1852,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 5
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1821,7 +1893,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.76+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 7
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1864,7 +1938,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.77+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 4
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1903,7 +1979,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.22)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 9
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1942,7 +2020,9 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.66+0.0)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 2
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1999,12 +2079,14 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x26.66, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2050,12 +2132,14 @@ TEST 5: pgfmanual-en-base-matrices-5
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x26.66, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2135,7 +2219,9 @@ TEST 6: pgfmanual-en-base-matrices-6
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(4.48+0.11)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 a
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2172,12 +2258,14 @@ TEST 6: pgfmanual-en-base-matrices-6
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.15+2.05)x27.22, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 e
 ...................\TU/lmr/m/n/10 m
 ...................\TU/lmr/m/n/10 p
 ...................\TU/lmr/m/n/10 t
 ...................\kern-0.28 (font)
 ...................\TU/lmr/m/n/10 y
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2214,7 +2302,9 @@ TEST 6: pgfmanual-en-base-matrices-6
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.94+0.11)x5.56, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 b
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2255,12 +2345,14 @@ TEST 6: pgfmanual-en-base-matrices-6
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.15+2.05)x27.22, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 e
 ...................\TU/lmr/m/n/10 m
 ...................\TU/lmr/m/n/10 p
 ...................\TU/lmr/m/n/10 t
 ...................\kern-0.28 (font)
 ...................\TU/lmr/m/n/10 y
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2297,7 +2389,9 @@ TEST 6: pgfmanual-en-base-matrices-6
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(4.48+0.11)x4.44, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 c
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2334,7 +2428,9 @@ TEST 6: pgfmanual-en-base-matrices-6
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.94+0.11)x5.56, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 d
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2371,12 +2467,14 @@ TEST 6: pgfmanual-en-base-matrices-6
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.15+2.05)x27.22, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 e
 ...................\TU/lmr/m/n/10 m
 ...................\TU/lmr/m/n/10 p
 ...................\TU/lmr/m/n/10 t
 ...................\kern-0.28 (font)
 ...................\TU/lmr/m/n/10 y
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2464,7 +2562,9 @@ TEST 7: pgfmanual-en-base-matrices-7
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(4.48+0.11)x5.0, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 a
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2503,7 +2603,9 @@ TEST 7: pgfmanual-en-base-matrices-7
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.94+0.11)x5.56, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 b
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2542,7 +2644,9 @@ TEST 7: pgfmanual-en-base-matrices-7
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(4.48+0.11)x4.44, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 c
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2585,7 +2689,9 @@ TEST 7: pgfmanual-en-base-matrices-7
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.94+0.11)x5.56, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 d
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -2633,7 +2739,9 @@ TEST 7: pgfmanual-en-base-matrices-7
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(4.48+0.11)x4.44, direction TLT
+...................\begindir TLT
 ...................\TU/lmr/m/n/10 e
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-base-nodes.tlg
+++ b/testfiles-examples/pgfmanual-en-base-nodes.tlg
@@ -76,6 +76,7 @@ TEST 1: pgfmanual-en-base-nodes-1
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.22)x52.54, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
@@ -88,6 +89,7 @@ TEST 1: pgfmanual-en-base-nodes-1
 ........\TU/lmr/m/n/10 r
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -118,6 +120,7 @@ TEST 1: pgfmanual-en-base-nodes-1
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.22)x52.54, direction TLT
+........\begindir TLT
 ........\pdfcolorstack 0 push {0 g 0 G}
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
@@ -132,6 +135,7 @@ TEST 1: pgfmanual-en-base-nodes-1
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
 ........\pdfcolorstack 0 pop
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -230,6 +234,7 @@ TEST 2: pgfmanual-en-base-nodes-2
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.22)x52.54, direction TLT
+........\begindir TLT
 ........\pdfcolorstack 0 push {0 g 0 G}
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
@@ -244,6 +249,7 @@ TEST 2: pgfmanual-en-base-nodes-2
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
 ........\pdfcolorstack 0 pop
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -407,6 +413,7 @@ TEST 4: pgfmanual-en-base-nodes-6
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.22)x52.54, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
@@ -419,6 +426,7 @@ TEST 4: pgfmanual-en-base-nodes-6
 ........\TU/lmr/m/n/10 r
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -505,6 +513,7 @@ TEST 5: pgfmanual-en-base-nodes-7
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.22)x52.54, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
@@ -517,6 +526,7 @@ TEST 5: pgfmanual-en-base-nodes-7
 ........\TU/lmr/m/n/10 r
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -603,6 +613,7 @@ TEST 6: pgfmanual-en-base-nodes-8
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.22)x52.54, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
@@ -615,6 +626,7 @@ TEST 6: pgfmanual-en-base-nodes-8
 ........\TU/lmr/m/n/10 r
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -781,6 +793,7 @@ TEST 7: pgfmanual-en-base-nodes-9
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(6.94+0.11)x50.03, direction TLT
+..............\begindir TLT
 ..............\TU/lmr/m/n/10 H
 ..............\TU/lmr/m/n/10 e
 ..............\TU/lmr/m/n/10 l
@@ -793,6 +806,7 @@ TEST 7: pgfmanual-en-base-nodes-9
 ..............\TU/lmr/m/n/10 r
 ..............\TU/lmr/m/n/10 l
 ..............\TU/lmr/m/n/10 d
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0
@@ -860,6 +874,7 @@ TEST 8: pgfmanual-en-base-nodes-10
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.22)x55.31999, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
@@ -873,6 +888,7 @@ TEST 8: pgfmanual-en-base-nodes-10
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -967,6 +983,7 @@ TEST 9: pgfmanual-en-base-nodes-11
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.22)x55.31999, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
@@ -980,6 +997,7 @@ TEST 9: pgfmanual-en-base-nodes-11
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1045,6 +1063,7 @@ TEST 10: pgfmanual-en-base-nodes-12
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.22)x55.31999, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
@@ -1058,6 +1077,7 @@ TEST 10: pgfmanual-en-base-nodes-12
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1290,8 +1310,10 @@ TEST 12: pgfmanual-en-base-nodes-30
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1318,6 +1340,7 @@ TEST 12: pgfmanual-en-base-nodes-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x34.33, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 R
 ...........\TU/lmr/m/n/10 e
 ...........\discretionary (penalty 50)
@@ -1326,6 +1349,7 @@ TEST 12: pgfmanual-en-base-nodes-30
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 k
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1378,6 +1402,7 @@ TEST 12: pgfmanual-en-base-nodes-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x39.81001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 U
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
@@ -1386,6 +1411,7 @@ TEST 12: pgfmanual-en-base-nodes-30
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-base-paths.tlg
+++ b/testfiles-examples/pgfmanual-en-base-paths.tlg
@@ -84,6 +84,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.94)x50.67, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 a
@@ -96,6 +97,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ...........\TU/lmr/m/n/10 t
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -121,6 +123,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x72.35, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 r
@@ -141,6 +144,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ...........\TU/lmr/m/n/10 n
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -166,6 +170,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x74.85, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 d
@@ -185,6 +190,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ...........\TU/lmr/m/n/10 n
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -210,6 +216,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x45.59, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 d
@@ -220,6 +227,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ...........\TU/lmr/m/n/10 t
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -243,6 +251,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x63.97, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 p
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
@@ -258,6 +267,7 @@ TEST 1: pgfmanual-en-base-paths-1
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 )
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-base-points.tlg
+++ b/testfiles-examples/pgfmanual-en-base-points.tlg
@@ -751,9 +751,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -789,10 +791,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x5.2616, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 y
 ...........\kern0.35878 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -826,10 +830,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.0903, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 z
 ...........\kern0.4398 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3007,7 +3013,9 @@ TEST 14: pgfmanual-en-base-points-14
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x5.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3020,10 +3028,12 @@ TEST 14: pgfmanual-en-base-points-14
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x17.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 2
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3036,9 +3046,11 @@ TEST 14: pgfmanual-en-base-points-14
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x12.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3051,10 +3063,12 @@ TEST 14: pgfmanual-en-base-points-14
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.76+0.22)x17.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 7
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3067,7 +3081,9 @@ TEST 14: pgfmanual-en-base-points-14
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.0)x5.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 1
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3080,10 +3096,12 @@ TEST 14: pgfmanual-en-base-points-14
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x17.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 1
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 2
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3167,9 +3185,11 @@ TEST 15: pgfmanual-en-base-points-15
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+1.94)x14.45, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 p
 ........\TU/lmr/m/n/10 t
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3182,10 +3202,12 @@ TEST 15: pgfmanual-en-base-points-15
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+1.94)x19.45, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 2
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 p
 ........\TU/lmr/m/n/10 t
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3198,10 +3220,12 @@ TEST 15: pgfmanual-en-base-points-15
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.77+1.94)x19.45, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 4
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 p
 ........\TU/lmr/m/n/10 t
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3214,10 +3238,12 @@ TEST 15: pgfmanual-en-base-points-15
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.76+1.94)x19.45, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 7
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 p
 ........\TU/lmr/m/n/10 t
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3301,7 +3327,9 @@ TEST 16: pgfmanual-en-base-points-16
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x5.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3314,10 +3342,12 @@ TEST 16: pgfmanual-en-base-points-16
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x17.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 2
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3330,9 +3360,11 @@ TEST 16: pgfmanual-en-base-points-16
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x12.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3345,10 +3377,12 @@ TEST 16: pgfmanual-en-base-points-16
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.76+0.22)x17.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 7
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3361,7 +3395,9 @@ TEST 16: pgfmanual-en-base-points-16
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.0)x5.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 1
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3445,7 +3481,9 @@ TEST 17: pgfmanual-en-base-points-17
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x5.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3458,10 +3496,12 @@ TEST 17: pgfmanual-en-base-points-17
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x17.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 2
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3474,9 +3514,11 @@ TEST 17: pgfmanual-en-base-points-17
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.22)x12.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3489,10 +3531,12 @@ TEST 17: pgfmanual-en-base-points-17
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.76+0.22)x17.78, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\TU/lmr/m/n/10 .
 ........\TU/lmr/m/n/10 7
 ........\TU/lmr/m/n/10 5
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3505,7 +3549,9 @@ TEST 17: pgfmanual-en-base-points-17
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.66+0.0)x5.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 1
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil

--- a/testfiles-examples/pgfmanual-en-base-scopes.tlg
+++ b/testfiles-examples/pgfmanual-en-base-scopes.tlg
@@ -308,6 +308,7 @@ TEST 5: pgfmanual-en-base-scopes-5
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x26.98, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 w
 ........\kern-0.28 (font)
 ........\TU/lmr/m/n/10 o
@@ -315,6 +316,7 @@ TEST 5: pgfmanual-en-base-scopes-5
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 d
 ........\TU/lmr/m/n/10 .
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -454,6 +456,7 @@ TEST 8: pgfmanual-en-base-scopes-8
 ....\hbox(0.0+0.0)x0.0, direction TLT
 .....\hbox(28.85274+1.94)x64.87999, direction TLT
 ......\glue(\spaceskip) 0.0
+......\begindir TLT
 ......\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ......\TU/lmr/m/n/10 S
 ......\TU/lmr/m/n/10 u
@@ -488,6 +491,7 @@ TEST 8: pgfmanual-en-base-scopes-8
 ......\TU/lmr/m/n/10 e
 ......\TU/lmr/m/n/10 .
 ......\glue(\spaceskip) 4.44 plus 4.99498 minus 0.37
+......\enddir TLT
 ......\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
@@ -554,6 +558,7 @@ TEST 9: pgfmanual-en-base-scopes-9
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -562,6 +567,7 @@ TEST 9: pgfmanual-en-base-scopes-9
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -627,6 +633,7 @@ TEST 10: pgfmanual-en-base-scopes-10
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -635,6 +642,7 @@ TEST 10: pgfmanual-en-base-scopes-10
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -700,6 +708,7 @@ TEST 11: pgfmanual-en-base-scopes-11
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -708,6 +717,7 @@ TEST 11: pgfmanual-en-base-scopes-11
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -773,6 +783,7 @@ TEST 12: pgfmanual-en-base-scopes-12
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -781,6 +792,7 @@ TEST 12: pgfmanual-en-base-scopes-12
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -846,6 +858,7 @@ TEST 13: pgfmanual-en-base-scopes-13
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -854,6 +867,7 @@ TEST 13: pgfmanual-en-base-scopes-13
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -919,6 +933,7 @@ TEST 14: pgfmanual-en-base-scopes-14
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -927,6 +942,7 @@ TEST 14: pgfmanual-en-base-scopes-14
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -992,6 +1008,7 @@ TEST 15: pgfmanual-en-base-scopes-15
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -1000,6 +1017,7 @@ TEST 15: pgfmanual-en-base-scopes-15
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1065,6 +1083,7 @@ TEST 16: pgfmanual-en-base-scopes-16
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -1073,6 +1092,7 @@ TEST 16: pgfmanual-en-base-scopes-16
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1138,6 +1158,7 @@ TEST 17: pgfmanual-en-base-scopes-17
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -1146,6 +1167,7 @@ TEST 17: pgfmanual-en-base-scopes-17
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1211,6 +1233,7 @@ TEST 18: pgfmanual-en-base-scopes-18
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -1219,6 +1242,7 @@ TEST 18: pgfmanual-en-base-scopes-18
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1284,6 +1308,7 @@ TEST 19: pgfmanual-en-base-scopes-19
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+2.05)x25.0, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 o
 ........\kern-0.28 (font)
@@ -1292,6 +1317,7 @@ TEST 19: pgfmanual-en-base-scopes-19
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil

--- a/testfiles-examples/pgfmanual-en-base-shadings.tlg
+++ b/testfiles-examples/pgfmanual-en-base-shadings.tlg
@@ -225,8 +225,10 @@ TEST 9: pgfmanual-en-base-shadings-12
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(20.0+0.0)x20.0, direction TLT
+........\begindir TLT
 ........\hbox(20.0+0.0)x20.0, direction TLT
 .........\box(20.0+0.0)x20.0
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -239,8 +241,10 @@ TEST 9: pgfmanual-en-base-shadings-12
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(20.0+0.0)x20.0, direction TLT
+........\begindir TLT
 ........\hbox(20.0+0.0)x20.0, direction TLT
 .........\box(20.0+0.0)x20.0
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -288,8 +292,10 @@ TEST 10: pgfmanual-en-base-shadings-13
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -310,8 +316,10 @@ TEST 10: pgfmanual-en-base-shadings-13
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -332,8 +340,10 @@ TEST 10: pgfmanual-en-base-shadings-13
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -360,8 +370,10 @@ TEST 10: pgfmanual-en-base-shadings-13
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -421,8 +433,10 @@ TEST 11: pgfmanual-en-base-shadings-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(100.375+0.0)x100.375, direction TLT
+...........\begindir TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
 ............\box(100.375+0.0)x100.375
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -467,6 +481,7 @@ TEST 11: pgfmanual-en-base-shadings-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x91.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ﬁ
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 s
@@ -496,6 +511,7 @@ TEST 11: pgfmanual-en-base-shadings-14
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -527,8 +543,10 @@ TEST 11: pgfmanual-en-base-shadings-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(100.375+0.0)x100.375, direction TLT
+...........\begindir TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
 ............\box(100.375+0.0)x100.375
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -573,6 +591,7 @@ TEST 11: pgfmanual-en-base-shadings-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x73.38998, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
@@ -596,6 +615,7 @@ TEST 11: pgfmanual-en-base-shadings-14
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -630,8 +650,10 @@ TEST 11: pgfmanual-en-base-shadings-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(100.375+0.0)x100.375, direction TLT
+...........\begindir TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
 ............\box(100.375+0.0)x100.375
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -676,6 +698,7 @@ TEST 11: pgfmanual-en-base-shadings-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x78.66998, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 u
@@ -700,6 +723,7 @@ TEST 11: pgfmanual-en-base-shadings-14
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -756,8 +780,10 @@ TEST 12: pgfmanual-en-base-shadings-15
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -782,8 +808,10 @@ TEST 12: pgfmanual-en-base-shadings-15
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -808,8 +836,10 @@ TEST 12: pgfmanual-en-base-shadings-15
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -853,8 +883,10 @@ TEST 13: pgfmanual-en-base-shadings-16
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -875,8 +907,10 @@ TEST 13: pgfmanual-en-base-shadings-16
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -897,8 +931,10 @@ TEST 13: pgfmanual-en-base-shadings-16
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -952,8 +988,10 @@ TEST 14: pgfmanual-en-base-shadings-17
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -981,6 +1019,7 @@ TEST 14: pgfmanual-en-base-shadings-17
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(5.14+0.14)x26.44002, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/sc/10 p
 ...........\TU/lmr/m/sc/10 r
@@ -989,6 +1028,7 @@ TEST 14: pgfmanual-en-base-shadings-17
 ...........\TU/lmr/m/sc/10 e
 ...........\kern0.0 (italic)
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1018,8 +1058,10 @@ TEST 14: pgfmanual-en-base-shadings-17
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }

--- a/testfiles-examples/pgfmanual-en-base-transformations.tlg
+++ b/testfiles-examples/pgfmanual-en-base-transformations.tlg
@@ -811,9 +811,11 @@ TEST 10: pgfmanual-en-base-transformations-10
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+1.94)x12.23, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 t
 ........\TU/lmr/m/n/10 i
 ........\TU/lmr/m/n/10 p
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -895,9 +897,11 @@ TEST 11: pgfmanual-en-base-transformations-11
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.0)x13.06, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 i
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -979,9 +983,11 @@ TEST 12: pgfmanual-en-base-transformations-12
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.0)x13.06, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 i
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1064,9 +1070,11 @@ TEST 13: pgfmanual-en-base-transformations-13
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.0)x13.06, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 i
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1149,9 +1157,11 @@ TEST 14: pgfmanual-en-base-transformations-14
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.0)x13.06, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 i
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1232,9 +1242,11 @@ TEST 15: pgfmanual-en-base-transformations-15
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.0)x13.06, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 i
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1315,9 +1327,11 @@ TEST 16: pgfmanual-en-base-transformations-16
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.0)x13.06, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 i
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1400,9 +1414,11 @@ TEST 17: pgfmanual-en-base-transformations-17
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.0)x13.06, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 H
 ........\TU/lmr/m/n/10 i
 ........\TU/lmr/m/n/10 !
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1567,6 +1583,7 @@ TEST 19: pgfmanual-en-base-transformations-19
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x31.7, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 r
 ........\TU/lmr/m/n/10 o
 ........\discretionary (penalty 50)
@@ -1576,6 +1593,7 @@ TEST 19: pgfmanual-en-base-transformations-19
 ........\TU/lmr/m/n/10 t
 ........\TU/lmr/m/n/10 e
 ........\TU/lmr/m/n/10 d
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1589,6 +1607,7 @@ TEST 19: pgfmanual-en-base-transformations-19
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.05+2.05)x51.18, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 s
 ........\TU/lmr/m/n/10 h
 ........\TU/lmr/m/n/10 i
@@ -1601,6 +1620,7 @@ TEST 19: pgfmanual-en-base-transformations-19
 ........\TU/lmr/m/n/10 n
 ........\TU/lmr/m/n/10 l
 ........\TU/lmr/m/n/10 y
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2280,8 +2300,10 @@ TEST 27: pgfmanual-en-base-transformations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2387,8 +2409,10 @@ TEST 28: pgfmanual-en-base-transformations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4037,12 +4061,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.88586+0.22)x9.59723, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\mathon
 ........\hbox(0.0+0.0)x0.0, direction TLT
 ........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 .........\OMS/cmsy/m/n/7 ^^N
 ........\mathoff
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4061,12 +4087,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.88586+0.22)x9.59723, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 0
 ........\mathon
 ........\hbox(0.0+0.0)x0.0, direction TLT
 ........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 .........\OMS/cmsy/m/n/7 ^^N
 ........\mathoff
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4085,6 +4113,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.88586+0.22)x14.59723, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 3
 ........\TU/lmr/m/n/10 0
 ........\mathon
@@ -4092,6 +4121,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 .........\OMS/cmsy/m/n/7 ^^N
 ........\mathoff
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4110,6 +4140,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.88586+0.22)x14.59723, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 3
 ........\TU/lmr/m/n/10 0
 ........\mathon
@@ -4117,6 +4148,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 .........\OMS/cmsy/m/n/7 ^^N
 ........\mathoff
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4135,6 +4167,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.88586+0.22)x14.59723, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 6
 ........\TU/lmr/m/n/10 0
 ........\mathon
@@ -4142,6 +4175,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 .........\OMS/cmsy/m/n/7 ^^N
 ........\mathoff
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4160,6 +4194,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.88586+0.22)x14.59723, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 6
 ........\TU/lmr/m/n/10 0
 ........\mathon
@@ -4167,6 +4202,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 .........\OMS/cmsy/m/n/7 ^^N
 ........\mathoff
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4185,6 +4221,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.88586+0.22)x14.59723, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 9
 ........\TU/lmr/m/n/10 0
 ........\mathon
@@ -4192,6 +4229,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 .........\OMS/cmsy/m/n/7 ^^N
 ........\mathoff
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4210,6 +4248,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.88586+0.22)x14.59723, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 9
 ........\TU/lmr/m/n/10 0
 ........\mathon
@@ -4217,6 +4256,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 .........\OMS/cmsy/m/n/7 ^^N
 ........\mathoff
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4934,10 +4974,12 @@ TEST 33: pgfmanual-en-base-transformations-36
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.05+0.11)x13.34, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 f
 ........\TU/lmr/m/n/10 o
 ........\kern0.28 (font)
 ........\TU/lmr/m/n/10 o
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5653,10 +5695,12 @@ TEST 34: pgfmanual-en-base-transformations-37
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.05+0.11)x13.34, direction TLT
+........\begindir TLT
 ........\TU/lmr/m/n/10 f
 ........\TU/lmr/m/n/10 o
 ........\kern0.28 (font)
 ........\TU/lmr/m/n/10 o
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil

--- a/testfiles-examples/pgfmanual-en-base-transparency.tlg
+++ b/testfiles-examples/pgfmanual-en-base-transparency.tlg
@@ -790,6 +790,7 @@ TEST 12: pgfmanual-en-base-transparency-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(55.35144+0.0)x55.35144, direction TLT
+...........\begindir TLT
 ...........\hbox(55.35144+0.0)x55.35144, direction TLT
 ............\glue -1.55405
 ............\hbox(0.0+0.0)x0.0, shifted -27.67572, direction TLT
@@ -811,6 +812,7 @@ TEST 12: pgfmanual-en-base-transparency-12
 .............\pdfliteral origin{n }
 .............\pdfliteral origin{Q }
 .............\glue 0.0 plus 1.0fil minus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-dv-examples.tlg
+++ b/testfiles-examples/pgfmanual-en-dv-examples.tlg
@@ -3696,10 +3696,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3912,9 +3914,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4048,9 +4052,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4263,9 +4269,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4399,12 +4407,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.0+2.0)x13.66824, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\OML/cmm/m/it/8 =
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4538,10 +4548,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.44444+0.0)x5.16812, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4685,10 +4697,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4820,9 +4834,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4954,9 +4970,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5092,9 +5110,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.87498+0.0)x5.24304, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/9 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5209,10 +5229,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.87498+1.75)x4.87842, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/9 y
 ...........\kern0.3229 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7146,6 +7168,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.68999+0.0)x41.6994, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\glue(\medmuskip) 1.88892 plus 0.94446 minus 1.88892
@@ -7162,6 +7185,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\OML/cmm/m/it/8 m
 ...........\OML/cmm/m/it/8 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7279,6 +7303,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.68999+0.0)x41.6994, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\glue(\medmuskip) 1.88892 plus 0.94446 minus 1.88892
@@ -7295,6 +7320,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\OML/cmm/m/it/8 m
 ...........\OML/cmm/m/it/8 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7412,6 +7438,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x23.72717, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
@@ -7422,6 +7449,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\OML/cmm/m/it/8 m
 ...........\OML/cmm/m/it/8 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7539,6 +7567,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x17.11597, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
@@ -7547,6 +7576,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\OML/cmm/m/it/8 m
 ...........\OML/cmm/m/it/8 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7664,6 +7694,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x21.36603, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -7673,6 +7704,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\OML/cmm/m/it/8 m
 ...........\OML/cmm/m/it/8 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7790,6 +7822,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x25.61609, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -7800,6 +7833,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\OML/cmm/m/it/8 m
 ...........\OML/cmm/m/it/8 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7917,6 +7951,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x32.2273, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\hbox(0.88889+1.55556)x2.36115, direction TLT
@@ -7930,6 +7965,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\OML/cmm/m/it/8 m
 ...........\OML/cmm/m/it/8 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8047,6 +8083,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x36.47736, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -8061,6 +8098,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\OML/cmm/m/it/8 m
 ...........\OML/cmm/m/it/8 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8193,10 +8231,12 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8314,10 +8354,12 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8435,9 +8477,11 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8555,9 +8599,11 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8675,9 +8721,11 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8790,10 +8838,12 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.913+0.099)x17.99101, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 t
 ...........\TU/lmr/m/n/9 i
 ...........\TU/lmr/m/n/9 m
 ...........\TU/lmr/m/n/9 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8843,6 +8893,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.246+0.099)x32.94905, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 d
 ...........\TU/lmr/m/n/9 i
 ...........\TU/lmr/m/n/9 s
@@ -8853,6 +8904,7 @@ TEST 2: pgfmanual-en-dv-examples-2
 ...........\TU/lmr/m/n/9 n
 ...........\TU/lmr/m/n/9 c
 ...........\TU/lmr/m/n/9 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10989,9 +11041,11 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11111,9 +11165,11 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11233,9 +11289,11 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11355,10 +11413,12 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11478,10 +11538,12 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11601,10 +11663,12 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12220,9 +12284,11 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12340,9 +12406,11 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12460,9 +12528,11 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12580,9 +12650,11 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 9
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12700,10 +12772,12 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12821,10 +12895,12 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12942,10 +13018,12 @@ TEST 3: pgfmanual-en-dv-examples-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-dv-formats.tlg
+++ b/testfiles-examples/pgfmanual-en-dv-formats.tlg
@@ -1208,9 +1208,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1328,9 +1330,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1448,9 +1452,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1578,9 +1584,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1696,9 +1704,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1814,9 +1824,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2938,9 +2950,11 @@ TEST 2: pgfmanual-en-dv-formats-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3058,9 +3072,11 @@ TEST 2: pgfmanual-en-dv-formats-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3178,9 +3194,11 @@ TEST 2: pgfmanual-en-dv-formats-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3308,9 +3326,11 @@ TEST 2: pgfmanual-en-dv-formats-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3426,9 +3446,11 @@ TEST 2: pgfmanual-en-dv-formats-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4502,9 +4524,11 @@ TEST 3: pgfmanual-en-dv-formats-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4622,9 +4646,11 @@ TEST 3: pgfmanual-en-dv-formats-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4742,9 +4768,11 @@ TEST 3: pgfmanual-en-dv-formats-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4872,9 +4900,11 @@ TEST 3: pgfmanual-en-dv-formats-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4990,9 +5020,11 @@ TEST 3: pgfmanual-en-dv-formats-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7319,9 +7351,11 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7441,9 +7475,11 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7563,9 +7599,11 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7685,9 +7723,11 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7807,9 +7847,11 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7929,9 +7971,11 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8051,9 +8095,11 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8186,11 +8232,13 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8308,9 +8356,11 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8428,11 +8478,13 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8550,10 +8602,12 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8671,12 +8725,14 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x15.11133, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8794,10 +8850,12 @@ TEST 4: pgfmanual-en-dv-formats-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9914,9 +9972,11 @@ TEST 5: pgfmanual-en-dv-formats-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10034,9 +10094,11 @@ TEST 5: pgfmanual-en-dv-formats-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10154,9 +10216,11 @@ TEST 5: pgfmanual-en-dv-formats-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10284,9 +10348,11 @@ TEST 5: pgfmanual-en-dv-formats-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10402,9 +10468,11 @@ TEST 5: pgfmanual-en-dv-formats-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12184,10 +12252,12 @@ TEST 6: pgfmanual-en-dv-formats-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12384,9 +12454,11 @@ TEST 6: pgfmanual-en-dv-formats-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12514,9 +12586,11 @@ TEST 6: pgfmanual-en-dv-formats-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12632,9 +12706,11 @@ TEST 6: pgfmanual-en-dv-formats-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12750,9 +12826,11 @@ TEST 6: pgfmanual-en-dv-formats-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14582,10 +14660,12 @@ TEST 7: pgfmanual-en-dv-formats-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14782,9 +14862,11 @@ TEST 7: pgfmanual-en-dv-formats-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14902,9 +14984,11 @@ TEST 7: pgfmanual-en-dv-formats-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15022,9 +15106,11 @@ TEST 7: pgfmanual-en-dv-formats-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15152,10 +15238,12 @@ TEST 7: pgfmanual-en-dv-formats-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15271,10 +15359,12 @@ TEST 7: pgfmanual-en-dv-formats-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15390,9 +15480,11 @@ TEST 7: pgfmanual-en-dv-formats-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24156,6 +24248,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x8.58337, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
@@ -24164,6 +24257,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24283,6 +24377,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -24292,6 +24387,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24411,6 +24507,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 0
@@ -24420,6 +24517,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24539,6 +24637,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 0
@@ -24548,6 +24647,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24667,6 +24767,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\OT1/cmr/m/n/8 0
@@ -24676,6 +24777,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24795,6 +24897,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
@@ -24804,6 +24907,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24936,6 +25040,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x21.72253, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
@@ -24943,6 +25048,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25060,6 +25166,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x21.72253, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
@@ -25067,6 +25174,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25184,6 +25292,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x21.72253, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
@@ -25191,6 +25300,7 @@ TEST 8: pgfmanual-en-dv-formats-10
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25308,12 +25418,14 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x15.11133, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25431,12 +25543,14 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x15.11133, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25554,12 +25668,14 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x15.11133, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25677,12 +25793,14 @@ TEST 8: pgfmanual-en-dv-formats-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x15.11133, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-dv-introduction.tlg
+++ b/testfiles-examples/pgfmanual-en-dv-introduction.tlg
@@ -1802,10 +1802,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1923,10 +1925,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2123,9 +2127,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2243,9 +2249,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2373,9 +2381,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2491,9 +2501,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2609,9 +2621,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2727,9 +2741,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2845,9 +2861,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2963,9 +2981,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5240,10 +5260,12 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5359,10 +5381,12 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5478,9 +5502,11 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5596,9 +5622,11 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5714,9 +5742,11 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6230,9 +6260,11 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6346,9 +6378,11 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6462,9 +6496,11 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6578,9 +6614,11 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6694,9 +6732,11 @@ TEST 2: pgfmanual-en-dv-introduction-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-dv-main.tlg
+++ b/testfiles-examples/pgfmanual-en-dv-main.tlg
@@ -1143,10 +1143,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1343,9 +1345,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1473,9 +1477,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1591,9 +1597,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1709,9 +1717,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2825,10 +2835,12 @@ TEST 2: pgfmanual-en-dv-main-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3025,9 +3037,11 @@ TEST 2: pgfmanual-en-dv-main-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3155,9 +3169,11 @@ TEST 2: pgfmanual-en-dv-main-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3273,9 +3289,11 @@ TEST 2: pgfmanual-en-dv-main-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3391,9 +3409,11 @@ TEST 2: pgfmanual-en-dv-main-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4936,10 +4956,12 @@ TEST 3: pgfmanual-en-dv-main-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5055,9 +5077,11 @@ TEST 3: pgfmanual-en-dv-main-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5173,9 +5197,11 @@ TEST 3: pgfmanual-en-dv-main-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5541,9 +5567,11 @@ TEST 3: pgfmanual-en-dv-main-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5657,11 +5685,13 @@ TEST 3: pgfmanual-en-dv-main-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5775,9 +5805,11 @@ TEST 3: pgfmanual-en-dv-main-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5891,11 +5923,13 @@ TEST 3: pgfmanual-en-dv-main-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6009,9 +6043,11 @@ TEST 3: pgfmanual-en-dv-main-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8413,10 +8449,12 @@ TEST 4: pgfmanual-en-dv-main-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8536,9 +8574,11 @@ TEST 4: pgfmanual-en-dv-main-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8658,9 +8698,11 @@ TEST 4: pgfmanual-en-dv-main-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8793,9 +8835,11 @@ TEST 4: pgfmanual-en-dv-main-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8913,11 +8957,13 @@ TEST 4: pgfmanual-en-dv-main-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9035,9 +9081,11 @@ TEST 4: pgfmanual-en-dv-main-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9155,11 +9203,13 @@ TEST 4: pgfmanual-en-dv-main-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9277,9 +9327,11 @@ TEST 4: pgfmanual-en-dv-main-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10856,10 +10908,12 @@ TEST 5: pgfmanual-en-dv-main-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10979,9 +11033,11 @@ TEST 5: pgfmanual-en-dv-main-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11101,9 +11157,11 @@ TEST 5: pgfmanual-en-dv-main-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11236,9 +11294,11 @@ TEST 5: pgfmanual-en-dv-main-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11356,11 +11416,13 @@ TEST 5: pgfmanual-en-dv-main-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11478,9 +11540,11 @@ TEST 5: pgfmanual-en-dv-main-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11598,11 +11662,13 @@ TEST 5: pgfmanual-en-dv-main-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11720,9 +11786,11 @@ TEST 5: pgfmanual-en-dv-main-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13301,10 +13369,12 @@ TEST 6: pgfmanual-en-dv-main-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13424,9 +13494,11 @@ TEST 6: pgfmanual-en-dv-main-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13546,9 +13618,11 @@ TEST 6: pgfmanual-en-dv-main-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13681,9 +13755,11 @@ TEST 6: pgfmanual-en-dv-main-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13801,11 +13877,13 @@ TEST 6: pgfmanual-en-dv-main-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13923,9 +14001,11 @@ TEST 6: pgfmanual-en-dv-main-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14043,11 +14123,13 @@ TEST 6: pgfmanual-en-dv-main-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14165,9 +14247,11 @@ TEST 6: pgfmanual-en-dv-main-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19141,10 +19225,12 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19264,9 +19350,11 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19386,9 +19474,11 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19508,9 +19598,11 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19630,9 +19722,11 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19752,9 +19846,11 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19887,10 +19983,12 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20008,12 +20106,14 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20131,9 +20231,11 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20251,11 +20353,13 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20373,9 +20477,11 @@ TEST 7: pgfmanual-en-dv-main-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20529,6 +20635,7 @@ TEST 7: pgfmanual-en-dv-main-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x18.14157, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -20542,6 +20649,7 @@ TEST 7: pgfmanual-en-dv-main-7
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20665,6 +20773,7 @@ TEST 7: pgfmanual-en-dv-main-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x19.16934, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -20678,6 +20787,7 @@ TEST 7: pgfmanual-en-dv-main-7
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20801,6 +20911,7 @@ TEST 7: pgfmanual-en-dv-main-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x20.14572, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -20814,6 +20925,7 @@ TEST 7: pgfmanual-en-dv-main-7
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -22008,9 +22120,11 @@ TEST 8: pgfmanual-en-dv-main-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22128,9 +22242,11 @@ TEST 8: pgfmanual-en-dv-main-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22258,9 +22374,11 @@ TEST 8: pgfmanual-en-dv-main-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22376,9 +22494,11 @@ TEST 8: pgfmanual-en-dv-main-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22494,9 +22614,11 @@ TEST 8: pgfmanual-en-dv-main-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23555,9 +23677,11 @@ TEST 9: pgfmanual-en-dv-main-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23675,9 +23799,11 @@ TEST 9: pgfmanual-en-dv-main-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23805,9 +23931,11 @@ TEST 9: pgfmanual-en-dv-main-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23923,9 +24051,11 @@ TEST 9: pgfmanual-en-dv-main-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24041,9 +24171,11 @@ TEST 9: pgfmanual-en-dv-main-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25107,9 +25239,11 @@ TEST 10: pgfmanual-en-dv-main-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25227,9 +25361,11 @@ TEST 10: pgfmanual-en-dv-main-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25357,9 +25493,11 @@ TEST 10: pgfmanual-en-dv-main-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25475,9 +25613,11 @@ TEST 10: pgfmanual-en-dv-main-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25593,9 +25733,11 @@ TEST 10: pgfmanual-en-dv-main-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26854,9 +26996,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26974,9 +27118,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27094,9 +27240,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27214,9 +27362,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27334,9 +27484,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27464,9 +27616,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27582,9 +27736,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27700,9 +27856,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29293,9 +29451,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29415,9 +29575,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29537,9 +29699,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29659,9 +29823,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29781,9 +29947,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29903,9 +30071,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30038,9 +30208,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30158,11 +30330,13 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30280,9 +30454,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30400,11 +30576,13 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30522,9 +30700,11 @@ TEST 11: pgfmanual-en-dv-main-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32162,6 +32342,7 @@ TEST 12: pgfmanual-en-dv-main-17
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(5.552+1.552)x54.52802, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/8 e
 ...........\TU/lmr/m/n/8 x
@@ -32182,6 +32363,7 @@ TEST 12: pgfmanual-en-dv-main-17
 ...........\kern-0.24 (font)
 ...........\TU/lmr/m/n/8 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32466,9 +32648,11 @@ TEST 12: pgfmanual-en-dv-main-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32586,9 +32770,11 @@ TEST 12: pgfmanual-en-dv-main-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32716,9 +32902,11 @@ TEST 12: pgfmanual-en-dv-main-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32834,9 +33022,11 @@ TEST 12: pgfmanual-en-dv-main-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34691,9 +34881,11 @@ TEST 13: pgfmanual-en-dv-main-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34811,9 +35003,11 @@ TEST 13: pgfmanual-en-dv-main-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34941,9 +35135,11 @@ TEST 13: pgfmanual-en-dv-main-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35059,9 +35255,11 @@ TEST 13: pgfmanual-en-dv-main-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-dv-polar.tlg
+++ b/testfiles-examples/pgfmanual-en-dv-polar.tlg
@@ -4238,9 +4238,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4351,6 +4353,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x14.90134, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x9.73322, direction TLT
 ............\hbox(7.13731+3.13733)x9.73322, direction TLT
@@ -4372,6 +4375,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4482,6 +4486,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x11.23473, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x6.0666, direction TLT
 ............\hbox(7.13731+3.13733)x6.0666, direction TLT
@@ -4500,6 +4505,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4610,6 +4616,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x11.23473, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x6.0666, direction TLT
 ............\hbox(7.13731+3.13733)x6.0666, direction TLT
@@ -4628,6 +4635,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4738,6 +4746,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x11.23473, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x6.0666, direction TLT
 ............\hbox(7.13731+3.13733)x6.0666, direction TLT
@@ -4756,6 +4765,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4866,6 +4876,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x14.90134, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x9.73322, direction TLT
 ............\hbox(7.13731+3.13733)x9.73322, direction TLT
@@ -4887,6 +4898,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4999,6 +5011,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x11.23473, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x6.0666, direction TLT
 ............\hbox(7.13731+3.13733)x6.0666, direction TLT
@@ -5017,6 +5030,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5129,6 +5143,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x14.90134, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x9.73322, direction TLT
 ............\hbox(7.13731+3.13733)x9.73322, direction TLT
@@ -5150,6 +5165,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5262,6 +5278,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x11.23473, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x6.0666, direction TLT
 ............\hbox(7.13731+3.13733)x6.0666, direction TLT
@@ -5280,6 +5297,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5392,6 +5410,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x11.23473, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x6.0666, direction TLT
 ............\hbox(7.13731+3.13733)x6.0666, direction TLT
@@ -5410,6 +5429,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5522,6 +5542,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x11.23473, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x6.0666, direction TLT
 ............\hbox(7.13731+3.13733)x6.0666, direction TLT
@@ -5540,6 +5561,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5652,6 +5674,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.13731+3.13733)x14.90134, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.13731+3.13733)x9.73322, direction TLT
 ............\hbox(7.13731+3.13733)x9.73322, direction TLT
@@ -5672,6 +5695,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5782,10 +5806,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.44444+0.0)x5.16812, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/8 ^^Y
 ...........\kern0.28703 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5904,9 +5930,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6013,11 +6041,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6124,9 +6154,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6233,11 +6265,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6344,9 +6378,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6533,11 +6569,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6645,9 +6683,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6755,11 +6795,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6867,9 +6909,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7000,6 +7044,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x34.764, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -7018,6 +7063,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7125,6 +7171,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x35.79178, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -7143,6 +7190,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12254,9 +12302,11 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12376,10 +12426,12 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12499,10 +12551,12 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12622,10 +12676,12 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12759,11 +12815,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12883,11 +12941,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13007,11 +13067,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13131,11 +13193,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13255,11 +13319,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18963,11 +19029,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19079,9 +19147,11 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19193,10 +19263,12 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19308,9 +19380,11 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19422,9 +19496,11 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19536,9 +19612,11 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19650,9 +19728,11 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19764,10 +19844,12 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19879,10 +19961,12 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19998,11 +20082,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20105,11 +20191,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20212,11 +20300,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20319,11 +20409,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20426,11 +20518,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20611,11 +20705,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20719,11 +20815,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20827,11 +20925,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20935,11 +21035,13 @@ TEST 2: pgfmanual-en-dv-polar-2
 ..........\pdfliteral origin{0.8 0 0 RG }
 ..........\pdfliteral origin{0.8 0 0 rg }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.8 0 0 rg 0.8 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23779,6 +23881,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x8.58337, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
@@ -23787,6 +23890,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23897,6 +24001,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
@@ -23906,6 +24011,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24016,6 +24122,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 0
@@ -24025,6 +24132,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24135,6 +24243,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\OT1/cmr/m/n/8 5
@@ -24144,6 +24253,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24254,6 +24364,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\OT1/cmr/m/n/8 0
@@ -24263,6 +24374,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24373,6 +24485,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
@@ -24382,6 +24495,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24494,6 +24608,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 9
 ...........\OT1/cmr/m/n/8 0
@@ -24503,6 +24618,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24615,6 +24731,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -24625,6 +24742,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24737,6 +24855,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 2
@@ -24747,6 +24866,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24859,6 +24979,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 3
@@ -24869,6 +24990,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24981,6 +25103,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
@@ -24991,6 +25114,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25103,6 +25227,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 6
@@ -25113,6 +25238,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25223,6 +25349,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 8
@@ -25233,6 +25360,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25343,6 +25471,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 9
@@ -25353,6 +25482,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25463,6 +25593,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 1
@@ -25473,6 +25604,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25583,6 +25715,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 2
@@ -25593,6 +25726,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25703,6 +25837,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 4
@@ -25713,6 +25848,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25823,6 +25959,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
@@ -25833,6 +25970,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25945,6 +26083,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 7
@@ -25955,6 +26094,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26067,6 +26207,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 8
@@ -26077,6 +26218,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26189,6 +26331,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 0
@@ -26199,6 +26342,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26311,6 +26455,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 1
@@ -26321,6 +26466,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26433,6 +26579,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 3
@@ -26443,6 +26590,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26555,6 +26703,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 4
@@ -26565,6 +26714,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26755,9 +26905,11 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26865,6 +27017,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x19.36139, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\hbox(0.88889+1.55556)x2.36115, direction TLT
@@ -26873,6 +27026,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26980,6 +27134,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x23.61145, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -26989,6 +27144,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27176,6 +27332,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x19.36139, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\hbox(0.88889+1.55556)x2.36115, direction TLT
@@ -27184,6 +27341,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27292,6 +27450,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x23.61145, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -27301,6 +27460,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27486,6 +27646,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x19.36139, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\hbox(0.88889+1.55556)x2.36115, direction TLT
@@ -27494,6 +27655,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27600,6 +27762,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x23.61145, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -27609,6 +27772,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27796,6 +27960,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x19.36139, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\hbox(0.88889+1.55556)x2.36115, direction TLT
@@ -27804,6 +27969,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27912,6 +28078,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x23.61145, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -27921,6 +28088,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28106,6 +28274,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x19.36139, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\hbox(0.88889+1.55556)x2.36115, direction TLT
@@ -28114,6 +28283,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28220,6 +28390,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+1.55556)x23.61145, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -28229,6 +28400,7 @@ TEST 3: pgfmanual-en-dv-polar-4
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30654,6 +30826,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x8.58337, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
@@ -30662,6 +30835,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30772,6 +30946,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
@@ -30781,6 +30956,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30891,6 +31067,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 0
@@ -30900,6 +31077,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31010,6 +31188,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\OT1/cmr/m/n/8 5
@@ -31019,6 +31198,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31129,6 +31309,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\OT1/cmr/m/n/8 0
@@ -31138,6 +31319,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31248,6 +31430,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
@@ -31257,6 +31440,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31369,6 +31553,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 9
 ...........\OT1/cmr/m/n/8 0
@@ -31378,6 +31563,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31490,6 +31676,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -31500,6 +31687,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31612,6 +31800,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 2
@@ -31622,6 +31811,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31734,6 +31924,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 3
@@ -31744,6 +31935,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31856,6 +32048,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
@@ -31866,6 +32059,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31978,6 +32172,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 6
@@ -31988,6 +32183,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32098,6 +32294,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 8
@@ -32108,6 +32305,7 @@ TEST 4: pgfmanual-en-dv-polar-5
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32227,9 +32425,11 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32337,10 +32537,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32448,10 +32650,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32559,10 +32763,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32670,11 +32876,13 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32862,10 +33070,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32974,10 +33184,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33086,10 +33298,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33198,11 +33412,13 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33388,10 +33604,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33498,10 +33716,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33608,10 +33828,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33718,11 +33940,13 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33910,10 +34134,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34022,10 +34248,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34134,10 +34362,12 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34246,11 +34476,13 @@ TEST 4: pgfmanual-en-dv-polar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36669,6 +36901,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x8.58337, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
@@ -36677,6 +36910,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36787,6 +37021,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
@@ -36796,6 +37031,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36906,6 +37142,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 0
@@ -36915,6 +37152,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37025,6 +37263,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\OT1/cmr/m/n/8 5
@@ -37034,6 +37273,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37144,6 +37384,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\OT1/cmr/m/n/8 0
@@ -37153,6 +37394,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37263,6 +37505,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
@@ -37272,6 +37515,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37384,6 +37628,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 9
 ...........\OT1/cmr/m/n/8 0
@@ -37393,6 +37638,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37505,6 +37751,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -37515,6 +37762,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37627,6 +37875,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 2
@@ -37637,6 +37886,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37749,6 +37999,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 3
@@ -37759,6 +38010,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37871,6 +38123,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
@@ -37881,6 +38134,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37993,6 +38247,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 6
@@ -38003,6 +38258,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38113,6 +38369,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 8
@@ -38123,6 +38380,7 @@ TEST 5: pgfmanual-en-dv-polar-6
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38242,9 +38500,11 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38352,10 +38612,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38463,10 +38725,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38574,10 +38838,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38685,11 +38951,13 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38877,10 +39145,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38989,10 +39259,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39101,10 +39373,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39213,11 +39487,13 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39403,10 +39679,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39513,10 +39791,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39623,10 +39903,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39733,11 +40015,13 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39925,10 +40209,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40037,10 +40323,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40149,10 +40437,12 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40261,11 +40551,13 @@ TEST 5: pgfmanual-en-dv-polar-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42630,6 +42922,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x8.58337, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
@@ -42638,6 +42931,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42748,6 +43042,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
@@ -42757,6 +43052,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42867,6 +43163,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 0
@@ -42876,6 +43173,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42986,6 +43284,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\OT1/cmr/m/n/8 5
@@ -42995,6 +43294,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43105,6 +43405,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\OT1/cmr/m/n/8 0
@@ -43114,6 +43415,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43224,6 +43526,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
@@ -43233,6 +43536,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43345,6 +43649,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 9
 ...........\OT1/cmr/m/n/8 0
@@ -43354,6 +43659,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43466,6 +43772,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
@@ -43476,6 +43783,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43588,6 +43896,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 2
@@ -43598,6 +43907,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43710,6 +44020,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 3
@@ -43720,6 +44031,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43832,6 +44144,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 5
@@ -43842,6 +44155,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43954,6 +44268,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 6
@@ -43964,6 +44279,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44074,6 +44390,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x17.0835, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 8
@@ -44084,6 +44401,7 @@ TEST 6: pgfmanual-en-dv-polar-7
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44202,9 +44520,11 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44311,10 +44631,12 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44421,10 +44743,12 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44531,10 +44855,12 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44641,11 +44967,13 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44832,10 +45160,12 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44943,10 +45273,12 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45054,10 +45386,12 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x8.50012, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45165,11 +45499,13 @@ TEST 6: pgfmanual-en-dv-polar-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x12.75018, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OT1/cmr/m/n/8 0
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46550,6 +46886,7 @@ TEST 7: pgfmanual-en-dv-polar-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x8.58337, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
@@ -46558,6 +46895,7 @@ TEST 7: pgfmanual-en-dv-polar-8
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46668,6 +47006,7 @@ TEST 7: pgfmanual-en-dv-polar-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\OT1/cmr/m/n/8 0
@@ -46677,6 +47016,7 @@ TEST 7: pgfmanual-en-dv-polar-8
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46787,6 +47127,7 @@ TEST 7: pgfmanual-en-dv-polar-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\OT1/cmr/m/n/8 0
@@ -46796,6 +47137,7 @@ TEST 7: pgfmanual-en-dv-polar-8
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46908,6 +47250,7 @@ TEST 7: pgfmanual-en-dv-polar-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.68442+0.0)x12.83344, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 9
 ...........\OT1/cmr/m/n/8 0
@@ -46917,6 +47260,7 @@ TEST 7: pgfmanual-en-dv-polar-8
 ...........\hbox(2.86108+0.0)x4.33331, shifted -2.82333, direction TLT
 ............\OMS/cmsy/m/n/6 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47035,9 +47379,11 @@ TEST 7: pgfmanual-en-dv-polar-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47144,9 +47490,11 @@ TEST 7: pgfmanual-en-dv-polar-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47263,9 +47611,11 @@ TEST 7: pgfmanual-en-dv-polar-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47370,9 +47720,11 @@ TEST 7: pgfmanual-en-dv-polar-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-dv-visualizers.tlg
+++ b/testfiles-examples/pgfmanual-en-dv-visualizers.tlg
@@ -1191,9 +1191,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1311,9 +1313,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1441,9 +1445,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1559,9 +1565,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1677,9 +1685,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2845,9 +2855,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2965,9 +2977,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3095,9 +3109,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3213,9 +3229,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3331,9 +3349,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4495,9 +4515,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4615,9 +4637,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4745,9 +4769,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4863,9 +4889,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4981,9 +5009,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7148,9 +7178,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7270,9 +7302,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7392,9 +7426,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7514,9 +7550,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7636,9 +7674,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7771,10 +7811,12 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7892,9 +7934,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8012,9 +8056,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8132,9 +8178,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8252,9 +8300,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8372,9 +8422,11 @@ TEST 2: pgfmanual-en-dv-visualizers-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10285,9 +10337,11 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10407,9 +10461,11 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10529,9 +10585,11 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10651,9 +10709,11 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10773,9 +10833,11 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10908,10 +10970,12 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11029,12 +11093,14 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11152,9 +11218,11 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11272,11 +11340,13 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11394,9 +11464,11 @@ TEST 3: pgfmanual-en-dv-visualizers-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15864,9 +15936,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15986,9 +16060,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16108,9 +16184,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16230,9 +16308,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16352,9 +16432,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16487,9 +16569,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16607,9 +16691,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16727,9 +16813,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16847,9 +16935,11 @@ TEST 4: pgfmanual-en-dv-visualizers-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20225,9 +20315,11 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20347,9 +20439,11 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20469,9 +20563,11 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20591,9 +20687,11 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20713,9 +20811,11 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20848,10 +20948,12 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20969,12 +21071,14 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21092,9 +21196,11 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21212,11 +21318,13 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21334,9 +21442,11 @@ TEST 5: pgfmanual-en-dv-visualizers-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24836,9 +24946,11 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24958,9 +25070,11 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25080,9 +25194,11 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25202,9 +25318,11 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25324,9 +25442,11 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25459,10 +25579,12 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25580,12 +25702,14 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25703,9 +25827,11 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25823,11 +25949,13 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25945,9 +26073,11 @@ TEST 6: pgfmanual-en-dv-visualizers-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31998,9 +32128,11 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32120,9 +32252,11 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32242,9 +32376,11 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32364,9 +32500,11 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32486,9 +32624,11 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32621,10 +32761,12 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32742,12 +32884,14 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32865,9 +33009,11 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32985,11 +33131,13 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33107,9 +33255,11 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33221,9 +33371,11 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.87498+0.0)x5.24304, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/9 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33308,6 +33460,7 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x18.14157, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -33321,6 +33474,7 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -33425,6 +33579,7 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x22.76654, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -33439,6 +33594,7 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -33547,6 +33703,7 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x19.16934, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -33560,6 +33717,7 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -33664,6 +33822,7 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.75+2.25)x23.79431, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -33678,6 +33837,7 @@ TEST 7: pgfmanual-en-dv-visualizers-9
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -36020,9 +36180,11 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36142,9 +36304,11 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36264,9 +36428,11 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36386,9 +36552,11 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36508,9 +36676,11 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36643,10 +36813,12 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36764,6 +36936,7 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x21.72253, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
@@ -36771,6 +36944,7 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36888,12 +37062,14 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37011,6 +37187,7 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x21.72253, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
@@ -37018,6 +37195,7 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37135,9 +37313,11 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37255,12 +37435,14 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x15.11133, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 2
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37378,11 +37560,13 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37500,12 +37684,14 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x15.11133, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 7
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37623,9 +37809,11 @@ TEST 8: pgfmanual-en-dv-visualizers-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39382,9 +39570,11 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39504,11 +39694,13 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39628,9 +39820,11 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39750,11 +39944,13 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39874,9 +40070,11 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39996,11 +40194,13 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40120,9 +40320,11 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40255,9 +40457,11 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40375,11 +40579,13 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40497,11 +40703,13 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40619,11 +40827,13 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40741,11 +40951,13 @@ TEST 9: pgfmanual-en-dv-visualizers-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44116,9 +44328,11 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44238,11 +44452,13 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44362,9 +44578,11 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44484,11 +44702,13 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44608,9 +44828,11 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44730,11 +44952,13 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44854,9 +45078,11 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44989,12 +45215,14 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 7
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45112,10 +45340,12 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45233,12 +45463,14 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45356,9 +45588,11 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45476,11 +45710,13 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45598,9 +45834,11 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45718,11 +45956,13 @@ TEST 10: pgfmanual-en-dv-visualizers-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 7
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47223,12 +47463,14 @@ TEST 11: pgfmanual-en-dv-visualizers-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47348,9 +47590,11 @@ TEST 11: pgfmanual-en-dv-visualizers-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47470,11 +47714,13 @@ TEST 11: pgfmanual-en-dv-visualizers-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47594,9 +47840,11 @@ TEST 11: pgfmanual-en-dv-visualizers-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47729,12 +47977,14 @@ TEST 11: pgfmanual-en-dv-visualizers-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47852,9 +48102,11 @@ TEST 11: pgfmanual-en-dv-visualizers-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47972,11 +48224,13 @@ TEST 11: pgfmanual-en-dv-visualizers-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49478,12 +49732,14 @@ TEST 12: pgfmanual-en-dv-visualizers-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49603,9 +49859,11 @@ TEST 12: pgfmanual-en-dv-visualizers-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49725,11 +49983,13 @@ TEST 12: pgfmanual-en-dv-visualizers-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49849,9 +50109,11 @@ TEST 12: pgfmanual-en-dv-visualizers-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49984,12 +50246,14 @@ TEST 12: pgfmanual-en-dv-visualizers-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50107,9 +50371,11 @@ TEST 12: pgfmanual-en-dv-visualizers-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50227,11 +50493,13 @@ TEST 12: pgfmanual-en-dv-visualizers-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51735,12 +52003,14 @@ TEST 13: pgfmanual-en-dv-visualizers-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51860,9 +52130,11 @@ TEST 13: pgfmanual-en-dv-visualizers-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51982,11 +52254,13 @@ TEST 13: pgfmanual-en-dv-visualizers-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52106,9 +52380,11 @@ TEST 13: pgfmanual-en-dv-visualizers-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52241,12 +52517,14 @@ TEST 13: pgfmanual-en-dv-visualizers-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52364,9 +52642,11 @@ TEST 13: pgfmanual-en-dv-visualizers-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52484,11 +52764,13 @@ TEST 13: pgfmanual-en-dv-visualizers-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53994,12 +54276,14 @@ TEST 14: pgfmanual-en-dv-visualizers-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54119,9 +54403,11 @@ TEST 14: pgfmanual-en-dv-visualizers-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54241,11 +54527,13 @@ TEST 14: pgfmanual-en-dv-visualizers-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54365,9 +54653,11 @@ TEST 14: pgfmanual-en-dv-visualizers-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54500,12 +54790,14 @@ TEST 14: pgfmanual-en-dv-visualizers-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54623,9 +54915,11 @@ TEST 14: pgfmanual-en-dv-visualizers-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54743,11 +55037,13 @@ TEST 14: pgfmanual-en-dv-visualizers-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56251,12 +56547,14 @@ TEST 15: pgfmanual-en-dv-visualizers-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56376,9 +56674,11 @@ TEST 15: pgfmanual-en-dv-visualizers-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56498,11 +56798,13 @@ TEST 15: pgfmanual-en-dv-visualizers-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56622,9 +56924,11 @@ TEST 15: pgfmanual-en-dv-visualizers-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56757,12 +57061,14 @@ TEST 15: pgfmanual-en-dv-visualizers-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56880,9 +57186,11 @@ TEST 15: pgfmanual-en-dv-visualizers-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57000,11 +57308,13 @@ TEST 15: pgfmanual-en-dv-visualizers-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58510,12 +58820,14 @@ TEST 16: pgfmanual-en-dv-visualizers-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58635,9 +58947,11 @@ TEST 16: pgfmanual-en-dv-visualizers-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58757,11 +59071,13 @@ TEST 16: pgfmanual-en-dv-visualizers-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58881,9 +59197,11 @@ TEST 16: pgfmanual-en-dv-visualizers-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59016,12 +59334,14 @@ TEST 16: pgfmanual-en-dv-visualizers-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59139,9 +59459,11 @@ TEST 16: pgfmanual-en-dv-visualizers-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59259,11 +59581,13 @@ TEST 16: pgfmanual-en-dv-visualizers-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60785,12 +61109,14 @@ TEST 17: pgfmanual-en-dv-visualizers-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60910,9 +61236,11 @@ TEST 17: pgfmanual-en-dv-visualizers-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61032,11 +61360,13 @@ TEST 17: pgfmanual-en-dv-visualizers-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61156,9 +61486,11 @@ TEST 17: pgfmanual-en-dv-visualizers-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61291,12 +61623,14 @@ TEST 17: pgfmanual-en-dv-visualizers-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61414,9 +61748,11 @@ TEST 17: pgfmanual-en-dv-visualizers-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61534,11 +61870,13 @@ TEST 17: pgfmanual-en-dv-visualizers-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63293,9 +63631,11 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63415,11 +63755,13 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63539,9 +63881,11 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63661,11 +64005,13 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63785,9 +64131,11 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63907,11 +64255,13 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64031,9 +64381,11 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64166,9 +64518,11 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64286,11 +64640,13 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64408,11 +64764,13 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64530,11 +64888,13 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64652,11 +65012,13 @@ TEST 18: pgfmanual-en-dv-visualizers-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66778,9 +67140,11 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66900,11 +67264,13 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67024,9 +67390,11 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67146,11 +67514,13 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67270,9 +67640,11 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67392,11 +67764,13 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67516,9 +67890,11 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67651,9 +68027,11 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67771,11 +68149,13 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67893,9 +68273,11 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68013,11 +68395,13 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68135,9 +68519,11 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68255,11 +68641,13 @@ TEST 19: pgfmanual-en-dv-visualizers-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-gd-overview.tlg
+++ b/testfiles-examples/pgfmanual-en-gd-overview.tlg
@@ -643,7 +643,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -689,7 +691,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -735,7 +739,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -781,7 +787,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -827,8 +835,10 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x10.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -874,7 +884,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -920,7 +932,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -966,7 +980,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1012,7 +1028,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1058,7 +1076,9 @@ TEST 1: pgfmanual-en-gd-overview-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 9
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1531,9 +1551,11 @@ TEST 2: pgfmanual-en-gd-overview-2
 ...............\pdfliteral origin{0 G }
 ...............\pdfliteral origin{0 g }
 ...............\hbox(4.781+0.07)x13.17401, direction TLT
+................\begindir TLT
 ................\TU/lmr/m/n/7 D
 ................\TU/lmr/m/n/7 a
 ................\TU/lmr/m/n/7 s
+................\enddir TLT
 ...............\glue(\spaceskip) 0.0
 .............\pdfliteral origin{Q }
 .............\glue(\spaceskip) 0.0
@@ -1589,9 +1611,11 @@ TEST 2: pgfmanual-en-gd-overview-2
 ...............\pdfliteral origin{0 G }
 ...............\pdfliteral origin{0 g }
 ...............\hbox(4.62+0.07)x8.554, direction TLT
+................\begindir TLT
 ................\TU/lmr/m/n/7 i
 ................\TU/lmr/m/n/7 s
 ................\TU/lmr/m/n/7 t
+................\enddir TLT
 ...............\glue(\spaceskip) 0.0
 .............\pdfliteral origin{Q }
 .............\glue(\spaceskip) 0.0
@@ -1647,9 +1671,11 @@ TEST 2: pgfmanual-en-gd-overview-2
 ...............\pdfliteral origin{0 G }
 ...............\pdfliteral origin{0 g }
 ...............\hbox(4.858+0.07)x11.57101, direction TLT
+................\begindir TLT
 ................\TU/lmr/m/n/7 d
 ................\TU/lmr/m/n/7 a
 ................\TU/lmr/m/n/7 s
+................\enddir TLT
 ...............\glue(\spaceskip) 0.0
 .............\pdfliteral origin{Q }
 .............\glue(\spaceskip) 0.0
@@ -1705,10 +1731,12 @@ TEST 2: pgfmanual-en-gd-overview-2
 ...............\pdfliteral origin{0 G }
 ...............\pdfliteral origin{0 g }
 ...............\hbox(4.781+0.07)x17.47202, direction TLT
+................\begindir TLT
 ................\TU/lmr/m/n/7 H
 ................\TU/lmr/m/n/7 a
 ................\TU/lmr/m/n/7 u
 ................\TU/lmr/m/n/7 s
+................\enddir TLT
 ...............\glue(\spaceskip) 0.0
 .............\pdfliteral origin{Q }
 .............\glue(\spaceskip) 0.0
@@ -1764,10 +1792,12 @@ TEST 2: pgfmanual-en-gd-overview-2
 ...............\pdfliteral origin{0 G }
 ...............\pdfliteral origin{0 g }
 ...............\hbox(3.122+0.07)x14.539, direction TLT
+................\begindir TLT
 ................\TU/lmr/m/n/7 v
 ................\kern-0.217 (font)
 ................\TU/lmr/m/n/7 o
 ................\TU/lmr/m/n/7 m
+................\enddir TLT
 ...............\glue(\spaceskip) 0.0
 .............\pdfliteral origin{Q }
 .............\glue(\spaceskip) 0.0
@@ -1823,8 +1853,10 @@ TEST 2: pgfmanual-en-gd-overview-2
 ...............\pdfliteral origin{0 G }
 ...............\pdfliteral origin{0 g }
 ...............\hbox(4.781+0.0)x8.162, direction TLT
+................\begindir TLT
 ................\TU/lmr/m/n/7 N
 ................\TU/lmr/m/n/7 i
+................\enddir TLT
 ...............\glue(\spaceskip) 0.0
 .............\pdfliteral origin{Q }
 .............\glue(\spaceskip) 0.0
@@ -1880,9 +1912,11 @@ TEST 2: pgfmanual-en-gd-overview-2
 ...............\pdfliteral origin{0 G }
 ...............\pdfliteral origin{0 g }
 ...............\hbox(4.858+0.07)x7.966, direction TLT
+................\begindir TLT
 ................\TU/lmr/m/n/7 k
 ................\kern-0.217 (font)
 ................\TU/lmr/m/n/7 o
+................\enddir TLT
 ...............\glue(\spaceskip) 0.0
 .............\pdfliteral origin{Q }
 .............\glue(\spaceskip) 0.0
@@ -1933,10 +1967,12 @@ TEST 2: pgfmanual-en-gd-overview-2
 ...............\pdfliteral origin{0 G }
 ...............\pdfliteral origin{0 g }
 ...............\hbox(4.858+0.07)x13.83202, direction TLT
+................\begindir TLT
 ................\TU/lmr/m/n/7 l
 ................\TU/lmr/m/n/7 a
 ................\TU/lmr/m/n/7 u
 ................\TU/lmr/m/n/7 s
+................\enddir TLT
 ...............\glue(\spaceskip) 0.0
 .............\pdfliteral origin{Q }
 .............\glue(\spaceskip) 0.0
@@ -1980,7 +2016,9 @@ TEST 2: pgfmanual-en-gd-overview-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2026,7 +2064,9 @@ TEST 2: pgfmanual-en-gd-overview-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2072,7 +2112,9 @@ TEST 2: pgfmanual-en-gd-overview-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2118,7 +2160,9 @@ TEST 2: pgfmanual-en-gd-overview-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2164,7 +2208,9 @@ TEST 2: pgfmanual-en-gd-overview-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3645,6 +3691,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.11)x38.73, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 ﬁ
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 s
@@ -3655,6 +3702,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 .................\kern0.28 (font)
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3702,7 +3750,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3750,7 +3800,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3798,7 +3850,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3846,7 +3900,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3894,7 +3950,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3942,7 +4000,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3990,7 +4050,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4038,6 +4100,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x50.36, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 c
@@ -4052,6 +4115,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 .................\kern0.28 (font)
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4099,7 +4163,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.0)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 x
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4147,7 +4213,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4195,7 +4263,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.42+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 u
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4243,7 +4313,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.11)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 v
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4291,7 +4363,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4339,7 +4413,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4387,7 +4463,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4435,7 +4513,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.11)x7.22, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 w
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4483,7 +4563,9 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.0)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 z
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4531,6 +4613,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x43.12999, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 t
 .................\TU/lmr/m/n/10 h
 .................\TU/lmr/m/n/10 i
@@ -4542,6 +4625,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 .................\kern0.28 (font)
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4589,12 +4673,14 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x20.84, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
 .................\kern-0.28 (font)
 .................\TU/lmr/m/n/10 h
 .................\TU/lmr/m/n/10 i
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4642,6 +4728,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.06)x45.87999, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 a
@@ -4655,6 +4742,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 .................\TU/lmr/m/n/10 i
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4702,6 +4790,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.15+2.06)x42.31, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 y
 .................\kern-0.28 (font)
 .................\TU/lmr/m/n/10 o
@@ -4714,6 +4803,7 @@ TEST 3: pgfmanual-en-gd-overview-3
 .................\TU/lmr/m/n/10 t
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 r
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5057,7 +5147,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5109,7 +5201,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 2
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5161,7 +5255,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 3
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5213,7 +5309,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.77+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 4
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5265,7 +5363,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 5
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5317,7 +5417,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 6
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5369,7 +5471,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.76+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 7
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5421,7 +5525,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 8
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5473,7 +5579,9 @@ TEST 4: pgfmanual-en-gd-overview-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 9
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6182,9 +6290,11 @@ TEST 5: pgfmanual-en-gd-overview-5
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 g 1 G}
 ...............\TU/lmr/m/n/10 1
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6239,9 +6349,11 @@ TEST 5: pgfmanual-en-gd-overview-5
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 g 1 G}
 ...............\TU/lmr/m/n/10 2
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6296,9 +6408,11 @@ TEST 5: pgfmanual-en-gd-overview-5
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 g 1 G}
 ...............\TU/lmr/m/n/10 3
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6353,9 +6467,11 @@ TEST 5: pgfmanual-en-gd-overview-5
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(6.77+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 g 1 G}
 ...............\TU/lmr/m/n/10 4
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6410,9 +6526,11 @@ TEST 5: pgfmanual-en-gd-overview-5
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 g 1 G}
 ...............\TU/lmr/m/n/10 5
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6467,9 +6585,11 @@ TEST 5: pgfmanual-en-gd-overview-5
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 g 1 G}
 ...............\TU/lmr/m/n/10 6
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-gd-usage-pgf.tlg
+++ b/testfiles-examples/pgfmanual-en-gd-usage-pgf.tlg
@@ -157,11 +157,13 @@ TEST 1: pgfmanual-en-gd-usage-pgf-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x22.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 H
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 o
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -212,12 +214,14 @@ TEST 1: pgfmanual-en-gd-usage-pgf-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.22)x26.70999, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 W
 ...............\kern-0.83 (font)
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -458,7 +462,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -504,7 +510,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -550,7 +558,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -777,7 +787,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -823,7 +835,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -869,7 +883,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1099,7 +1115,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1145,7 +1163,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1191,7 +1211,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1425,7 +1447,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.77+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 4
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1471,7 +1495,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1517,7 +1543,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1747,7 +1775,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 5
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1793,7 +1823,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1839,7 +1871,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2058,7 +2092,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 6
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2104,7 +2140,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2150,7 +2188,9 @@ TEST 2: pgfmanual-en-gd-usage-pgf-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2323,11 +2363,13 @@ TEST 3: pgfmanual-en-gd-usage-pgf-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.15+0.11)x18.09, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 o
 ...............\kern0.28 (font)
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 t
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2373,6 +2415,7 @@ TEST 3: pgfmanual-en-gd-usage-pgf-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.11)x38.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 f
@@ -2384,6 +2427,7 @@ TEST 3: pgfmanual-en-gd-usage-pgf-5
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2429,6 +2473,7 @@ TEST 3: pgfmanual-en-gd-usage-pgf-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+2.06)x45.04, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 g
@@ -2442,6 +2487,7 @@ TEST 3: pgfmanual-en-gd-usage-pgf-5
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2614,11 +2660,13 @@ TEST 4: pgfmanual-en-gd-usage-pgf-6
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.15+0.11)x18.09, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 o
 ...............\kern0.28 (font)
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 t
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2664,6 +2712,7 @@ TEST 4: pgfmanual-en-gd-usage-pgf-6
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.11)x38.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 f
@@ -2675,6 +2724,7 @@ TEST 4: pgfmanual-en-gd-usage-pgf-6
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2720,6 +2770,7 @@ TEST 4: pgfmanual-en-gd-usage-pgf-6
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+2.06)x45.04, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 g
@@ -2733,6 +2784,7 @@ TEST 4: pgfmanual-en-gd-usage-pgf-6
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2962,11 +3014,13 @@ TEST 5: pgfmanual-en-gd-usage-pgf-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.15+0.11)x18.09, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 o
 .................\kern0.28 (font)
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3012,6 +3066,7 @@ TEST 5: pgfmanual-en-gd-usage-pgf-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.11)x38.34, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 f
@@ -3023,6 +3078,7 @@ TEST 5: pgfmanual-en-gd-usage-pgf-7
 .................\TU/lmr/m/n/10 i
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3068,6 +3124,7 @@ TEST 5: pgfmanual-en-gd-usage-pgf-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.06)x45.04, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 i
 .................\TU/lmr/m/n/10 g
@@ -3081,6 +3138,7 @@ TEST 5: pgfmanual-en-gd-usage-pgf-7
 .................\TU/lmr/m/n/10 i
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-gd-usage-tikz.tlg
+++ b/testfiles-examples/pgfmanual-en-gd-usage-tikz.tlg
@@ -517,7 +517,9 @@ TEST 1: pgfmanual-en-gd-usage-tikz-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -563,7 +565,9 @@ TEST 1: pgfmanual-en-gd-usage-tikz-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -609,7 +613,9 @@ TEST 1: pgfmanual-en-gd-usage-tikz-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -655,7 +661,9 @@ TEST 1: pgfmanual-en-gd-usage-tikz-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -701,7 +709,9 @@ TEST 1: pgfmanual-en-gd-usage-tikz-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -747,7 +757,9 @@ TEST 1: pgfmanual-en-gd-usage-tikz-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1025,7 +1037,9 @@ TEST 2: pgfmanual-en-gd-usage-tikz-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1071,7 +1085,9 @@ TEST 2: pgfmanual-en-gd-usage-tikz-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1117,7 +1133,9 @@ TEST 2: pgfmanual-en-gd-usage-tikz-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1372,7 +1390,9 @@ TEST 3: pgfmanual-en-gd-usage-tikz-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1418,7 +1438,9 @@ TEST 3: pgfmanual-en-gd-usage-tikz-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 2
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1464,7 +1486,9 @@ TEST 3: pgfmanual-en-gd-usage-tikz-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1510,7 +1534,9 @@ TEST 3: pgfmanual-en-gd-usage-tikz-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1556,7 +1582,9 @@ TEST 3: pgfmanual-en-gd-usage-tikz-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1963,7 +1991,9 @@ TEST 4: pgfmanual-en-gd-usage-tikz-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2009,7 +2039,9 @@ TEST 4: pgfmanual-en-gd-usage-tikz-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2055,7 +2087,9 @@ TEST 4: pgfmanual-en-gd-usage-tikz-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2101,7 +2135,9 @@ TEST 4: pgfmanual-en-gd-usage-tikz-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2147,7 +2183,9 @@ TEST 4: pgfmanual-en-gd-usage-tikz-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3110,7 +3148,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3156,7 +3196,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3202,7 +3244,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3248,7 +3292,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3294,7 +3340,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3340,7 +3388,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3386,7 +3436,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3432,7 +3484,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3478,7 +3532,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3524,7 +3580,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3570,7 +3628,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3616,7 +3676,9 @@ TEST 5: pgfmanual-en-gd-usage-tikz-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4536,7 +4598,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4582,7 +4646,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4628,7 +4694,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4674,7 +4742,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4720,7 +4790,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4766,7 +4838,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4812,7 +4886,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4858,7 +4934,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4904,7 +4982,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4950,7 +5030,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4996,7 +5078,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5042,7 +5126,9 @@ TEST 6: pgfmanual-en-gd-usage-tikz-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6154,7 +6240,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6200,7 +6288,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6246,7 +6336,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6292,7 +6384,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6338,7 +6432,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6384,7 +6480,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6430,7 +6528,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6476,7 +6576,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6522,7 +6624,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6570,6 +6674,7 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(49.46828+35.46822)x54.74506, direction TLT
+.................\begindir TLT
 .................\vbox(49.46828+35.46822)x54.74506, direction TLT
 ..................\hbox(8.39996+3.60004)x54.74506, direction TLT
 ...................\vbox(8.39996+3.60004)x54.74506, direction TLT
@@ -6594,6 +6699,7 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ..................\hbox(35.46822+35.46822)x54.74506, glue set 54.74506fil, direction TLT
 ...................\rule(35.46822+35.46822)x0.0
 ...................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6639,7 +6745,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6685,7 +6793,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6731,7 +6841,9 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6783,6 +6895,7 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(34.5719+20.57184)x40.51869, direction TLT
+.................\begindir TLT
 .................\vbox(34.5719+20.57184)x40.51869, direction TLT
 ..................\hbox(8.39996+3.60004)x40.51869, direction TLT
 ...................\vbox(8.39996+3.60004)x40.51869, direction TLT
@@ -6807,6 +6920,7 @@ TEST 7: pgfmanual-en-gd-usage-tikz-9
 ..................\hbox(20.57184+20.57184)x40.51869, glue set 40.51869fil, direction TLT
 ...................\rule(20.57184+20.57184)x0.0
 ...................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7576,7 +7690,9 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7622,7 +7738,9 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7668,7 +7786,9 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7714,7 +7834,9 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7760,7 +7882,9 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7806,7 +7930,9 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7852,7 +7978,9 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7898,7 +8026,9 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7946,6 +8076,7 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(21.28433+34.28441)x40.51869, direction TLT
+.................\begindir TLT
 .................\vbox(21.28433+34.28441)x40.51869, direction TLT
 ..................\hbox(42.56868+0.0)x40.51869, glue set 40.51869fil, direction TLT
 ...................\rule(42.56868+*)x0.0
@@ -7969,6 +8100,7 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 .....................\penalty 10000
 .....................\glue(\parfillskip) 0.0
 .....................\glue(\rightskip) 0.0 plus 20.0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8016,6 +8148,7 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(34.86821+47.86829)x39.82869, direction TLT
+.................\begindir TLT
 .................\vbox(34.86821+47.86829)x39.82869, direction TLT
 ..................\hbox(69.73643+0.0)x39.82869, glue set 39.82869fil, direction TLT
 ...................\rule(69.73643+*)x0.0
@@ -8040,6 +8173,7 @@ TEST 8: pgfmanual-en-gd-usage-tikz-10
 .....................\penalty 10000
 .....................\glue(\parfillskip) 0.0
 .....................\glue(\rightskip) 0.0 plus 20.0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8813,7 +8947,9 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8859,7 +8995,9 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8905,7 +9043,9 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8951,7 +9091,9 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8997,7 +9139,9 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9043,7 +9187,9 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9089,7 +9235,9 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9135,7 +9283,9 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9187,6 +9337,7 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{1 0 0 RG }
 ................\pdfliteral origin{1 0 0 rg }
 ................\hbox(21.28433+34.28441)x40.51869, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .................\vbox(21.28433+34.28441)x40.51869, direction TLT
 ..................\hbox(42.56868+0.0)x40.51869, glue set 40.51869fil, direction TLT
@@ -9212,6 +9363,7 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 .....................\glue(\parfillskip) 0.0
 .....................\glue(\rightskip) 0.0 plus 20.0
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9263,6 +9415,7 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 ................\pdfliteral origin{1 0 0 RG }
 ................\pdfliteral origin{1 0 0 rg }
 ................\hbox(34.86821+47.86829)x39.82869, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .................\vbox(34.86821+47.86829)x39.82869, direction TLT
 ..................\hbox(69.73643+0.0)x39.82869, glue set 39.82869fil, direction TLT
@@ -9290,6 +9443,7 @@ TEST 9: pgfmanual-en-gd-usage-tikz-11
 .....................\glue(\parfillskip) 0.0
 .....................\glue(\rightskip) 0.0 plus 20.0
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10059,7 +10213,9 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10105,7 +10261,9 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10151,7 +10309,9 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10197,7 +10357,9 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10243,7 +10405,9 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10289,7 +10453,9 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10335,7 +10501,9 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10381,7 +10549,9 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10429,9 +10599,11 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(21.28433+21.28433)x40.51869, direction TLT
+.................\begindir TLT
 .................\hbox(21.28433+21.28433)x40.51869, glue set 40.51869fil, direction TLT
 ..................\rule(21.28433+21.28433)x0.0
 ..................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10479,9 +10651,11 @@ TEST 10: pgfmanual-en-gd-usage-tikz-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(34.86821+34.86821)x39.82869, direction TLT
+.................\begindir TLT
 .................\hbox(34.86821+34.86821)x39.82869, glue set 39.82869fil, direction TLT
 ..................\rule(34.86821+34.86821)x0.0
 ..................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11251,7 +11425,9 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11297,7 +11473,9 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11343,7 +11521,9 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11389,7 +11569,9 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11435,7 +11617,9 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11481,7 +11665,9 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11527,7 +11713,9 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11573,7 +11761,9 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11621,6 +11811,7 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(35.2844+21.28433)x40.51869, direction TLT
+.................\begindir TLT
 .................\vbox(35.2844+21.28433)x40.51869, direction TLT
 ..................\hbox(8.39996+3.60004)x40.51869, direction TLT
 ...................\vbox(8.39996+3.60004)x40.51869, direction TLT
@@ -11644,6 +11835,7 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ..................\hbox(21.28433+21.28433)x40.51869, glue set 40.51869fil, direction TLT
 ...................\rule(21.28433+21.28433)x0.0
 ...................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11691,6 +11883,7 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(48.86827+34.86821)x39.82869, direction TLT
+.................\begindir TLT
 .................\vbox(48.86827+34.86821)x39.82869, direction TLT
 ..................\hbox(8.39996+3.60004)x39.82869, direction TLT
 ...................\vbox(8.39996+3.60004)x39.82869, direction TLT
@@ -11716,6 +11909,7 @@ TEST 11: pgfmanual-en-gd-usage-tikz-13
 ..................\hbox(34.86821+34.86821)x39.82869, glue set 39.82869fil, direction TLT
 ...................\rule(34.86821+34.86821)x0.0
 ...................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12342,7 +12536,9 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12388,7 +12584,9 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12434,7 +12632,9 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12480,7 +12680,9 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12526,7 +12728,9 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12572,7 +12776,9 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12618,7 +12824,9 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12664,7 +12872,9 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12716,6 +12926,7 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(35.2844+21.28433)x40.51869, direction TLT
+.................\begindir TLT
 .................\vbox(35.2844+21.28433)x40.51869, direction TLT
 ..................\hbox(8.39996+3.60004)x40.51869, direction TLT
 ...................\vbox(8.39996+3.60004)x40.51869, direction TLT
@@ -12739,6 +12950,7 @@ TEST 12: pgfmanual-en-gd-usage-tikz-14
 ..................\hbox(21.28433+21.28433)x40.51869, glue set 40.51869fil, direction TLT
 ...................\rule(21.28433+21.28433)x0.0
 ...................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13516,7 +13728,9 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13562,7 +13776,9 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13608,7 +13824,9 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13654,7 +13872,9 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13700,7 +13920,9 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13746,7 +13968,9 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13792,7 +14016,9 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13838,7 +14064,9 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13886,11 +14114,13 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(22.2844+21.28433)x40.51869, direction TLT
+.................\begindir TLT
 .................\vbox(22.2844+21.28433)x40.51869, direction TLT
 ..................\kern1.00006
 ..................\hbox(21.28433+21.28433)x40.51869, glue set 40.51869fil, direction TLT
 ...................\rule(21.28433+21.28433)x0.0
 ...................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13926,10 +14156,12 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(7.05+0.11)x14.17, direction TLT
+..............\begindir TLT
 ..............\TU/lmr/m/n/10 l
 ..............\TU/lmr/m/n/10 e
 ..............\TU/lmr/m/n/10 f
 ..............\TU/lmr/m/n/10 t
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0
@@ -13972,11 +14204,13 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(35.86827+34.86821)x39.82869, direction TLT
+.................\begindir TLT
 .................\vbox(35.86827+34.86821)x39.82869, direction TLT
 ..................\kern1.00006
 ..................\hbox(34.86821+34.86821)x39.82869, glue set 39.82869fil, direction TLT
 ...................\rule(34.86821+34.86821)x0.0
 ...................\glue 0.0 plus 1.0fil
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14012,12 +14246,14 @@ TEST 13: pgfmanual-en-gd-usage-tikz-15
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(6.94+2.06)x20.87, direction TLT
+..............\begindir TLT
 ..............\TU/lmr/m/n/10 r
 ..............\TU/lmr/m/n/10 i
 ..............\TU/lmr/m/n/10 g
 ..............\TU/lmr/m/n/10 h
 ..............\kern-0.28 (font)
 ..............\TU/lmr/m/n/10 t
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-3d.tlg
+++ b/testfiles-examples/pgfmanual-en-library-3d.tlg
@@ -334,6 +334,7 @@ TEST 4: pgfmanual-en-library-3d-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x61.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 g
@@ -349,6 +350,7 @@ TEST 4: pgfmanual-en-library-3d-4
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -598,6 +600,7 @@ TEST 4: pgfmanual-en-library-3d-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x52.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
@@ -613,6 +616,7 @@ TEST 4: pgfmanual-en-library-3d-4
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-angles.tlg
+++ b/testfiles-examples/pgfmanual-en-library-angles.tlg
@@ -329,10 +329,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x6.43404, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^K
 .............\kern0.03702 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -443,10 +445,12 @@ TEST 4: pgfmanual-en-library-angles-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x6.43404, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^K
 .............\kern0.03702 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -558,10 +562,12 @@ TEST 5: pgfmanual-en-library-angles-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x6.43404, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^K
 .............\kern0.03702 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -731,9 +737,11 @@ TEST 6: pgfmanual-en-library-angles-6
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(1.06+0.0)x2.78, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 .
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-automata.tlg
+++ b/testfiles-examples/pgfmanual-en-library-automata.tlg
@@ -79,11 +79,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -125,11 +127,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -163,11 +167,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -199,11 +205,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -250,11 +258,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -293,7 +303,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -330,7 +342,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -367,7 +381,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -408,7 +424,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -447,7 +465,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -488,7 +508,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -587,11 +609,13 @@ TEST 2: pgfmanual-en-library-automata-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -630,11 +654,13 @@ TEST 2: pgfmanual-en-library-automata-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -648,12 +674,14 @@ TEST 2: pgfmanual-en-library-automata-2
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+0.0)x10.00003, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\mathon
 ..........\OT1/cmr/m/n/10 0
 ..........\OT1/cmr/m/n/10 0
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -719,11 +747,13 @@ TEST 3: pgfmanual-en-library-automata-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -737,12 +767,14 @@ TEST 3: pgfmanual-en-library-automata-3
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+0.0)x10.00003, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\mathon
 ..........\OT1/cmr/m/n/10 1
 ..........\OT1/cmr/m/n/10 1
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -780,11 +812,13 @@ TEST 3: pgfmanual-en-library-automata-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -798,12 +832,14 @@ TEST 3: pgfmanual-en-library-automata-3
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+0.0)x10.00003, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\mathon
 ..........\OT1/cmr/m/n/10 0
 ..........\OT1/cmr/m/n/10 0
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -870,11 +906,13 @@ TEST 4: pgfmanual-en-library-automata-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -924,11 +962,13 @@ TEST 4: pgfmanual-en-library-automata-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -970,11 +1010,13 @@ TEST 4: pgfmanual-en-library-automata-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1014,11 +1056,13 @@ TEST 4: pgfmanual-en-library-automata-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1057,7 +1101,9 @@ TEST 4: pgfmanual-en-library-automata-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1094,7 +1140,9 @@ TEST 4: pgfmanual-en-library-automata-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1135,7 +1183,9 @@ TEST 4: pgfmanual-en-library-automata-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1176,7 +1226,9 @@ TEST 4: pgfmanual-en-library-automata-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1238,11 +1290,13 @@ TEST 5: pgfmanual-en-library-automata-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1281,6 +1335,7 @@ TEST 5: pgfmanual-en-library-automata-5
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
@@ -1288,6 +1343,7 @@ TEST 5: pgfmanual-en-library-automata-5
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1357,11 +1413,13 @@ TEST 6: pgfmanual-en-library-automata-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1396,6 +1454,8 @@ TEST 6: pgfmanual-en-library-automata-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1437,11 +1497,13 @@ TEST 6: pgfmanual-en-library-automata-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1481,11 +1543,13 @@ TEST 6: pgfmanual-en-library-automata-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1525,11 +1589,13 @@ TEST 6: pgfmanual-en-library-automata-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1566,6 +1632,8 @@ TEST 6: pgfmanual-en-library-automata-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1606,7 +1674,9 @@ TEST 6: pgfmanual-en-library-automata-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1643,7 +1713,9 @@ TEST 6: pgfmanual-en-library-automata-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1680,7 +1752,9 @@ TEST 6: pgfmanual-en-library-automata-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1721,7 +1795,9 @@ TEST 6: pgfmanual-en-library-automata-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1760,7 +1836,9 @@ TEST 6: pgfmanual-en-library-automata-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1801,7 +1879,9 @@ TEST 6: pgfmanual-en-library-automata-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1893,6 +1973,7 @@ TEST 7: pgfmanual-en-library-automata-7
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -1900,6 +1981,7 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1957,6 +2039,7 @@ TEST 7: pgfmanual-en-library-automata-7
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -1964,6 +2047,7 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2020,6 +2104,7 @@ TEST 7: pgfmanual-en-library-automata-7
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -2027,6 +2112,7 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2086,6 +2172,7 @@ TEST 7: pgfmanual-en-library-automata-7
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -2093,6 +2180,7 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2148,7 +2236,9 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2185,7 +2275,9 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2222,7 +2314,9 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2263,7 +2357,9 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2302,7 +2398,9 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2343,7 +2441,9 @@ TEST 7: pgfmanual-en-library-automata-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2406,11 +2506,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.30177, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(3.01389+0.0)x4.83765, shifted 1.49998, direction TLT
 ............\OML/cmm/m/it/7 a
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2460,11 +2562,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2498,11 +2602,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.48079, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.8611+0.0)x4.01666, shifted 1.49998, direction TLT
 ............\OML/cmm/m/it/7 b
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2534,11 +2640,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.8611+0.0)x4.66287, shifted 1.49998, direction TLT
 ............\OML/cmm/m/it/7 d
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2570,11 +2678,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.53787, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(3.01389+0.0)x4.07375, shifted 1.49998, direction TLT
 ............\OML/cmm/m/it/7 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2606,11 +2716,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.75824, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(3.01389+0.0)x4.29411, shifted 1.49998, direction TLT
 ............\OML/cmm/m/it/7 e
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2649,11 +2761,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x18.528, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 0
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 L
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2692,11 +2806,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x19.472, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2737,11 +2853,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x18.528, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 L
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2778,11 +2896,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x18.528, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 0
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 L
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2821,11 +2941,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x18.528, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 0
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 L
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2867,11 +2989,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x19.472, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 0
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2912,11 +3036,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x19.472, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2953,11 +3079,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x19.472, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 0
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2997,11 +3125,13 @@ TEST 8: pgfmanual-en-library-automata-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.464+1.552)x19.472, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 1
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 0
 .............\TU/lmr/m/n/8 ,
 .............\TU/lmr/m/n/8 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-babel.tlg
+++ b/testfiles-examples/pgfmanual-en-library-babel.tlg
@@ -37,6 +37,7 @@ TEST 1: pgfmanual-en-library-babel-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x52.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
@@ -52,6 +53,7 @@ TEST 1: pgfmanual-en-library-babel-1
 ...........\TU/lmr/m/n/10 p
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -112,6 +114,7 @@ TEST 2: pgfmanual-en-library-babel-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x52.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
@@ -127,6 +130,7 @@ TEST 2: pgfmanual-en-library-babel-2
 ...........\TU/lmr/m/n/10 p
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -152,10 +156,12 @@ TEST 2: pgfmanual-en-library-babel-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.02)x13.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 ^^f8
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 ^^f8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-backgrounds.tlg
+++ b/testfiles-examples/pgfmanual-en-library-backgrounds.tlg
@@ -258,8 +258,10 @@ TEST 4: pgfmanual-en-library-backgrounds-4
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }

--- a/testfiles-examples/pgfmanual-en-library-calendar.tlg
+++ b/testfiles-examples/pgfmanual-en-library-calendar.tlg
@@ -34,7 +34,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63,7 +65,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -93,7 +97,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -122,7 +128,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -151,7 +159,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -180,7 +190,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -209,7 +221,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -238,7 +252,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -267,7 +283,9 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -297,8 +315,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -327,8 +347,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -357,8 +379,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -387,8 +411,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -417,8 +443,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -447,8 +475,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -477,8 +507,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -508,8 +540,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -538,8 +572,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -568,8 +604,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -598,8 +636,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -628,8 +668,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -658,8 +700,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -688,8 +732,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -719,8 +765,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -749,8 +797,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -779,8 +829,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -809,8 +861,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -839,8 +893,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -869,8 +925,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -899,8 +957,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -930,8 +990,10 @@ TEST 1: pgfmanual-en-library-calendar-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -988,7 +1050,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1017,7 +1081,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1047,7 +1113,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1076,7 +1144,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1105,7 +1175,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1134,7 +1206,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1163,7 +1237,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1192,7 +1268,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1221,7 +1299,9 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1251,8 +1331,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1281,8 +1363,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1311,8 +1395,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1341,8 +1427,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1371,8 +1459,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1401,8 +1491,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1431,8 +1523,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1462,8 +1556,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1492,8 +1588,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1522,8 +1620,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1552,8 +1652,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1582,8 +1684,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1612,8 +1716,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1642,8 +1748,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1673,8 +1781,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1703,8 +1813,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1733,8 +1845,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1763,8 +1877,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1793,8 +1909,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1823,8 +1941,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1853,8 +1973,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1884,8 +2006,10 @@ TEST 2: pgfmanual-en-library-calendar-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1942,7 +2066,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1971,7 +2097,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2001,7 +2129,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2030,7 +2160,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2059,7 +2191,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2088,7 +2222,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2117,7 +2253,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2146,7 +2284,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2175,7 +2315,9 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2205,8 +2347,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2235,8 +2379,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2265,8 +2411,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2295,8 +2443,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2325,8 +2475,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2355,8 +2507,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2385,8 +2539,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2416,8 +2572,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2446,8 +2604,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2476,8 +2636,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2506,8 +2668,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2536,8 +2700,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2566,8 +2732,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2596,8 +2764,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2627,8 +2797,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2657,8 +2829,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2687,8 +2861,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2717,8 +2893,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2747,8 +2925,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2777,8 +2957,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2807,8 +2989,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2838,8 +3022,10 @@ TEST 3: pgfmanual-en-library-calendar-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2896,7 +3082,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2925,7 +3113,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2955,7 +3145,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2984,7 +3176,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3013,7 +3207,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3042,7 +3238,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3071,7 +3269,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3100,7 +3300,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3129,7 +3331,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3159,8 +3363,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3189,8 +3395,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3219,8 +3427,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3249,8 +3459,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3279,8 +3491,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3309,8 +3523,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3339,8 +3555,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3370,8 +3588,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3400,8 +3620,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3430,8 +3652,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3460,8 +3684,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3490,8 +3716,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3520,8 +3748,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3550,8 +3780,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3581,8 +3813,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3611,8 +3845,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3641,8 +3877,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3671,8 +3909,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3701,8 +3941,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3731,8 +3973,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3761,8 +4005,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3792,8 +4038,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3823,7 +4071,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3852,7 +4102,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3881,7 +4133,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3910,7 +4164,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3939,7 +4195,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3968,7 +4226,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3998,7 +4258,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4027,7 +4289,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4056,7 +4320,9 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4085,8 +4351,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4115,8 +4383,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4145,8 +4415,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4175,8 +4447,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4206,8 +4480,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4236,8 +4512,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4266,8 +4544,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4296,8 +4576,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4326,8 +4608,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4356,8 +4640,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4386,8 +4672,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4417,8 +4705,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4447,8 +4737,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4477,8 +4769,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4507,8 +4801,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4537,8 +4833,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4567,8 +4865,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4597,8 +4897,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4628,8 +4930,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4658,8 +4962,10 @@ TEST 4: pgfmanual-en-library-calendar-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4716,7 +5022,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4745,7 +5053,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4775,7 +5085,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4804,7 +5116,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4833,7 +5147,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4862,7 +5178,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4891,7 +5209,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4920,7 +5240,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4949,7 +5271,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4979,8 +5303,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5009,8 +5335,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5039,8 +5367,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5069,8 +5399,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5099,8 +5431,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5129,8 +5463,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5159,8 +5495,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5190,8 +5528,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5220,8 +5560,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5250,8 +5592,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5280,8 +5624,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5310,8 +5656,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5340,8 +5688,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5370,8 +5720,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5401,8 +5753,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5431,8 +5785,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5461,8 +5817,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5491,8 +5849,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5521,8 +5881,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5551,8 +5913,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5581,8 +5945,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5612,8 +5978,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5643,7 +6011,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5672,7 +6042,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5701,7 +6073,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5730,7 +6104,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5759,7 +6135,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5788,7 +6166,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5818,7 +6198,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5847,7 +6229,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5876,7 +6260,9 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5905,8 +6291,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5935,8 +6323,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5965,8 +6355,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5995,8 +6387,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6026,8 +6420,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6056,8 +6452,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6086,8 +6484,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6116,8 +6516,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6146,8 +6548,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6176,8 +6580,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6206,8 +6612,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6237,8 +6645,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6267,8 +6677,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6297,8 +6709,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6327,8 +6741,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6357,8 +6773,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6387,8 +6805,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6417,8 +6837,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6448,8 +6870,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6478,8 +6902,10 @@ TEST 5: pgfmanual-en-library-calendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6597,7 +7023,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6626,7 +7054,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6656,7 +7086,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6685,7 +7117,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6714,7 +7148,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6743,7 +7179,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6772,7 +7210,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6801,7 +7241,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6830,7 +7272,9 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6860,8 +7304,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6890,8 +7336,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6920,8 +7368,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6950,8 +7400,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6980,8 +7432,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7010,8 +7464,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7040,8 +7496,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7071,8 +7529,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7101,8 +7561,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7131,8 +7593,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7161,8 +7625,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7191,8 +7657,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7221,8 +7689,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7251,8 +7721,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7282,8 +7754,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7312,8 +7786,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7342,8 +7818,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7372,8 +7850,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7402,8 +7882,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7432,8 +7914,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7462,8 +7946,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7493,8 +7979,10 @@ TEST 6: pgfmanual-en-library-calendar-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8125,7 +8613,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8154,7 +8644,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8184,7 +8676,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8213,7 +8707,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8242,7 +8738,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8271,7 +8769,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8300,7 +8800,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8329,7 +8831,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8358,7 +8862,9 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8388,8 +8894,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8418,8 +8926,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8448,8 +8958,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8478,8 +8990,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8508,8 +9022,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8538,8 +9054,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8568,8 +9086,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8599,8 +9119,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8629,8 +9151,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8659,8 +9183,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8689,8 +9215,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8719,8 +9247,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8749,8 +9279,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8779,8 +9311,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8810,8 +9344,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8840,8 +9376,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8870,8 +9408,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8900,8 +9440,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8930,8 +9472,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8960,8 +9504,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8990,8 +9536,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9021,8 +9569,10 @@ TEST 8: pgfmanual-en-library-calendar-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9095,7 +9645,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9124,7 +9676,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9154,7 +9708,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9183,7 +9739,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9212,7 +9770,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9241,7 +9801,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9270,7 +9832,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9299,7 +9863,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9328,7 +9894,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9358,7 +9926,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9387,7 +9957,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9416,7 +9988,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9445,7 +10019,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9474,7 +10050,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9503,7 +10081,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9532,7 +10112,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9562,7 +10144,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9591,7 +10175,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9620,7 +10206,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9649,7 +10237,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9678,7 +10268,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9707,7 +10299,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9736,7 +10330,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9766,7 +10362,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9795,7 +10393,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9824,7 +10424,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9853,7 +10455,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9882,7 +10486,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9911,7 +10517,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9940,7 +10548,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9970,7 +10580,9 @@ TEST 9: pgfmanual-en-library-calendar-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10027,8 +10639,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10057,8 +10671,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10088,8 +10704,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10118,8 +10736,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10148,8 +10768,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10178,8 +10800,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10208,8 +10832,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10238,8 +10864,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10268,8 +10896,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10299,8 +10929,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10329,8 +10961,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10359,8 +10993,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10389,8 +11025,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10419,8 +11057,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10449,8 +11089,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10479,8 +11121,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10510,8 +11154,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10540,8 +11186,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10570,8 +11218,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10600,8 +11250,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10630,8 +11282,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10660,8 +11314,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10690,8 +11346,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10721,8 +11379,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10751,8 +11411,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10781,8 +11443,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10811,8 +11475,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10841,8 +11507,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10871,8 +11539,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10901,8 +11571,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10932,8 +11604,10 @@ TEST 10: pgfmanual-en-library-calendar-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10997,9 +11671,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11036,9 +11712,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11076,9 +11754,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11115,9 +11795,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11154,9 +11836,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11193,9 +11877,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11232,9 +11918,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11271,9 +11959,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11310,9 +12000,11 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11350,10 +12042,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11390,10 +12084,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11430,10 +12126,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11470,10 +12168,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11510,10 +12210,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11550,10 +12252,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11590,10 +12294,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11631,10 +12337,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11671,10 +12379,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11711,10 +12421,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11751,10 +12463,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11791,10 +12505,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11831,10 +12547,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11871,10 +12589,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11912,10 +12632,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11952,10 +12674,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11992,10 +12716,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12032,10 +12758,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12072,10 +12800,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12112,10 +12842,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12152,10 +12884,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12193,10 +12927,12 @@ TEST 11: pgfmanual-en-library-calendar-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12255,6 +12991,7 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+2.05)x35.18, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 J
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 n
@@ -12265,6 +13002,7 @@ TEST 12: pgfmanual-en-library-calendar-13
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12292,7 +13030,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12321,7 +13061,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12351,7 +13093,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12380,7 +13124,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12409,7 +13155,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12438,7 +13186,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12467,7 +13217,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12496,7 +13248,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12525,7 +13279,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12555,8 +13311,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12585,8 +13343,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12615,8 +13375,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12645,8 +13407,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12675,8 +13439,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12705,8 +13471,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12735,8 +13503,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12766,8 +13536,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12796,8 +13568,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12826,8 +13600,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12856,8 +13632,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12886,8 +13664,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12916,8 +13696,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12946,8 +13728,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12977,8 +13761,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13007,8 +13793,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13037,8 +13825,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13067,8 +13857,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13097,8 +13889,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13127,8 +13921,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13157,8 +13953,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13188,8 +13986,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13220,6 +14020,7 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -13231,6 +14032,7 @@ TEST 12: pgfmanual-en-library-calendar-13
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13258,7 +14060,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13287,7 +14091,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13316,7 +14122,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13345,7 +14153,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13374,7 +14184,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13403,7 +14215,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13433,7 +14247,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13462,7 +14278,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13491,7 +14309,9 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13520,8 +14340,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13550,8 +14372,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13580,8 +14404,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13610,8 +14436,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13641,8 +14469,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13671,8 +14501,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13701,8 +14533,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13731,8 +14565,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13761,8 +14597,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13791,8 +14629,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13821,8 +14661,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13852,8 +14694,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13882,8 +14726,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13912,8 +14758,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13942,8 +14790,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13972,8 +14822,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14002,8 +14854,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14032,8 +14886,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14063,8 +14919,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14093,8 +14951,10 @@ TEST 12: pgfmanual-en-library-calendar-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14152,6 +15012,7 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+2.05)x58.51, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 J
 ...........\TU/lmr/m/n/10 a
@@ -14169,6 +15030,7 @@ TEST 13: pgfmanual-en-library-calendar-15
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14196,7 +15058,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14225,7 +15089,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14255,7 +15121,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14284,7 +15152,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14313,7 +15183,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14342,7 +15214,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14371,7 +15245,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14400,7 +15276,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14429,7 +15307,9 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14459,8 +15339,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14489,8 +15371,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14519,8 +15403,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14549,8 +15435,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14579,8 +15467,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14609,8 +15499,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14639,8 +15531,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14670,8 +15564,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14700,8 +15596,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14730,8 +15628,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14760,8 +15660,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14790,8 +15692,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14820,8 +15724,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14850,8 +15756,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14881,8 +15789,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14911,8 +15821,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14941,8 +15853,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14971,8 +15885,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15001,8 +15917,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15031,8 +15949,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15061,8 +15981,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15092,8 +16014,10 @@ TEST 13: pgfmanual-en-library-calendar-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15150,7 +16074,9 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15179,9 +16105,11 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15211,7 +16139,9 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15240,7 +16170,9 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15269,7 +16201,9 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15298,7 +16232,9 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15327,7 +16263,9 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15356,7 +16294,9 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15385,9 +16325,11 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15417,8 +16359,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15447,8 +16391,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15477,8 +16423,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15507,8 +16455,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15537,8 +16487,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15567,8 +16519,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15597,10 +16551,12 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15630,8 +16586,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15660,8 +16618,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15690,8 +16650,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15720,8 +16682,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15750,8 +16714,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15780,8 +16746,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15810,10 +16778,12 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15843,8 +16813,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15873,8 +16845,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15903,8 +16877,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15933,8 +16909,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15963,8 +16941,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15993,8 +16973,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16023,10 +17005,12 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16056,8 +17040,10 @@ TEST 14: pgfmanual-en-library-calendar-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16114,7 +17100,9 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16143,9 +17131,11 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16175,7 +17165,9 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16204,7 +17196,9 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16233,7 +17227,9 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16262,7 +17258,9 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16291,7 +17289,9 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16320,7 +17320,9 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16349,9 +17351,11 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16381,8 +17385,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16411,8 +17417,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16441,8 +17449,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16471,8 +17481,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16501,8 +17513,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16531,8 +17545,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16561,10 +17577,12 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16594,8 +17612,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16624,8 +17644,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16654,8 +17676,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16694,8 +17718,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16724,8 +17750,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16754,8 +17782,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16784,10 +17814,12 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16817,8 +17849,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16847,8 +17881,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16877,8 +17913,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16907,8 +17945,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16937,8 +17977,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16967,8 +18009,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16997,10 +18041,12 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17030,8 +18076,10 @@ TEST 15: pgfmanual-en-library-calendar-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17090,7 +18138,9 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17121,9 +18171,11 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17155,7 +18207,9 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17186,7 +18240,9 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17217,7 +18273,9 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17248,7 +18306,9 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17279,7 +18339,9 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17310,7 +18372,9 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17341,9 +18405,11 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17375,8 +18441,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17407,8 +18475,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17439,8 +18509,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17471,8 +18543,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17503,8 +18577,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17535,8 +18611,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17567,10 +18645,12 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17602,8 +18682,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17634,8 +18716,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17666,8 +18750,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17708,8 +18794,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17740,8 +18828,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17772,8 +18862,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17804,10 +18896,12 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17839,8 +18933,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17871,8 +18967,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17903,8 +19001,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17935,8 +19035,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17967,8 +19069,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17999,8 +19103,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18031,10 +19137,12 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18066,8 +19174,10 @@ TEST 16: pgfmanual-en-library-calendar-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18124,7 +19234,9 @@ TEST 17: pgfmanual-en-library-calendar-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18153,7 +19265,9 @@ TEST 17: pgfmanual-en-library-calendar-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18182,7 +19296,9 @@ TEST 17: pgfmanual-en-library-calendar-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18211,7 +19327,9 @@ TEST 17: pgfmanual-en-library-calendar-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18240,7 +19358,9 @@ TEST 17: pgfmanual-en-library-calendar-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18269,7 +19389,9 @@ TEST 17: pgfmanual-en-library-calendar-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18298,7 +19420,9 @@ TEST 17: pgfmanual-en-library-calendar-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18327,7 +19451,9 @@ TEST 17: pgfmanual-en-library-calendar-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18384,6 +19510,7 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+2.05)x35.18, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 J
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 n
@@ -18394,6 +19521,7 @@ TEST 18: pgfmanual-en-library-calendar-20
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18419,7 +19547,9 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18448,7 +19578,9 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18477,7 +19609,9 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18506,7 +19640,9 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18535,7 +19671,9 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18564,7 +19702,9 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18593,7 +19733,9 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18622,7 +19764,9 @@ TEST 18: pgfmanual-en-library-calendar-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18679,7 +19823,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18708,7 +19854,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18737,7 +19885,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18766,7 +19916,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18795,7 +19947,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18824,7 +19978,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18853,7 +20009,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18882,7 +20040,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18911,7 +20071,9 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18940,8 +20102,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18970,8 +20134,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19000,8 +20166,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19030,8 +20198,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19060,8 +20230,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19090,8 +20262,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19120,8 +20294,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19150,8 +20326,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19180,8 +20358,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19210,8 +20390,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19240,8 +20422,10 @@ TEST 19: pgfmanual-en-library-calendar-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19303,7 +20487,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19335,7 +20521,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19367,7 +20555,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19399,7 +20589,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19431,7 +20623,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19463,7 +20657,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19495,7 +20691,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19527,7 +20725,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19559,7 +20759,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19591,8 +20793,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19624,8 +20828,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19657,8 +20863,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19690,8 +20898,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19723,8 +20933,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19756,8 +20968,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19789,8 +21003,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19822,8 +21038,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19855,8 +21073,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19888,8 +21108,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19921,8 +21143,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19954,8 +21178,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19987,8 +21213,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20020,8 +21248,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20053,8 +21283,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20086,8 +21318,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20119,8 +21353,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20152,8 +21388,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20185,8 +21423,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20218,8 +21458,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20251,8 +21493,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20284,8 +21528,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20318,7 +21564,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20350,7 +21598,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20382,7 +21632,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20414,7 +21666,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20446,7 +21700,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20478,7 +21734,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20510,7 +21768,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20542,7 +21802,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20574,7 +21836,9 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20606,8 +21870,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20639,8 +21905,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20672,8 +21940,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20705,8 +21975,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20738,8 +22010,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20771,8 +22045,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20804,8 +22080,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20837,8 +22115,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20870,8 +22150,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20903,8 +22185,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20936,8 +22220,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20969,8 +22255,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21002,8 +22290,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21035,8 +22325,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21068,8 +22360,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21101,8 +22395,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21134,8 +22430,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21167,8 +22465,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21200,8 +22500,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21233,8 +22535,10 @@ TEST 20: pgfmanual-en-library-calendar-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21291,8 +22595,10 @@ TEST 21: pgfmanual-en-library-calendar-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21321,8 +22627,10 @@ TEST 21: pgfmanual-en-library-calendar-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21351,8 +22659,10 @@ TEST 21: pgfmanual-en-library-calendar-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21381,8 +22691,10 @@ TEST 21: pgfmanual-en-library-calendar-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21412,7 +22724,9 @@ TEST 21: pgfmanual-en-library-calendar-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21441,7 +22755,9 @@ TEST 21: pgfmanual-en-library-calendar-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21470,7 +22786,9 @@ TEST 21: pgfmanual-en-library-calendar-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21527,8 +22845,10 @@ TEST 22: pgfmanual-en-library-calendar-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21557,8 +22877,10 @@ TEST 22: pgfmanual-en-library-calendar-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21587,8 +22909,10 @@ TEST 22: pgfmanual-en-library-calendar-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21617,8 +22941,10 @@ TEST 22: pgfmanual-en-library-calendar-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21647,7 +22973,9 @@ TEST 22: pgfmanual-en-library-calendar-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21676,7 +23004,9 @@ TEST 22: pgfmanual-en-library-calendar-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21705,7 +23035,9 @@ TEST 22: pgfmanual-en-library-calendar-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21762,8 +23094,10 @@ TEST 23: pgfmanual-en-library-calendar-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21792,8 +23126,10 @@ TEST 23: pgfmanual-en-library-calendar-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21822,8 +23158,10 @@ TEST 23: pgfmanual-en-library-calendar-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21852,8 +23190,10 @@ TEST 23: pgfmanual-en-library-calendar-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21882,7 +23222,9 @@ TEST 23: pgfmanual-en-library-calendar-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21911,7 +23253,9 @@ TEST 23: pgfmanual-en-library-calendar-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21940,7 +23284,9 @@ TEST 23: pgfmanual-en-library-calendar-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21997,7 +23343,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22026,7 +23374,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22056,7 +23406,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22085,7 +23437,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22114,7 +23468,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22143,7 +23499,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22172,7 +23530,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22201,7 +23561,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22230,7 +23592,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22260,8 +23624,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22290,8 +23656,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22320,8 +23688,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22350,8 +23720,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22380,8 +23752,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22410,8 +23784,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22440,8 +23816,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22471,8 +23849,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22501,8 +23881,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22531,8 +23913,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22561,8 +23945,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22591,8 +23977,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22621,8 +24009,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22651,8 +24041,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22682,8 +24074,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22712,8 +24106,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22742,8 +24138,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22772,8 +24170,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22802,8 +24202,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22832,8 +24234,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22862,8 +24266,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22893,8 +24299,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22924,7 +24332,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22953,7 +24363,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22982,7 +24394,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23011,7 +24425,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23040,7 +24456,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23069,7 +24487,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23099,7 +24519,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23128,7 +24550,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23157,7 +24581,9 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23186,8 +24612,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23216,8 +24644,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23246,8 +24676,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23276,8 +24708,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23307,8 +24741,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23337,8 +24773,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23367,8 +24805,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23397,8 +24837,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23427,8 +24869,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23457,8 +24901,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23487,8 +24933,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23518,8 +24966,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23548,8 +24998,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23578,8 +25030,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23608,8 +25062,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23638,8 +25094,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23668,8 +25126,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23698,8 +25158,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23729,8 +25191,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23759,8 +25223,10 @@ TEST 24: pgfmanual-en-library-calendar-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23817,7 +25283,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23846,7 +25314,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23876,7 +25346,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23905,7 +25377,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23934,7 +25408,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23963,7 +25439,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23992,7 +25470,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24021,7 +25501,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24050,7 +25532,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24080,8 +25564,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24110,8 +25596,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24140,8 +25628,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24170,8 +25660,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24200,8 +25692,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24230,8 +25724,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24260,8 +25756,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24291,8 +25789,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24321,8 +25821,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24351,8 +25853,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24381,8 +25885,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24411,8 +25917,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24441,8 +25949,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24471,8 +25981,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24502,8 +26014,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24532,8 +26046,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24562,8 +26078,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24592,8 +26110,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24622,8 +26142,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24652,8 +26174,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24682,8 +26206,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24713,8 +26239,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24744,7 +26272,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24773,7 +26303,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24802,7 +26334,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24831,7 +26365,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24860,7 +26396,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24889,7 +26427,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24919,7 +26459,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24948,7 +26490,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24977,7 +26521,9 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25006,8 +26552,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25036,8 +26584,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25066,8 +26616,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25096,8 +26648,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25127,8 +26681,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25157,8 +26713,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25187,8 +26745,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25217,8 +26777,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25247,8 +26809,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25277,8 +26841,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25307,8 +26873,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25338,8 +26906,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25368,8 +26938,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25398,8 +26970,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25428,8 +27002,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25458,8 +27034,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25488,8 +27066,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25518,8 +27098,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25549,8 +27131,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25579,8 +27163,10 @@ TEST 25: pgfmanual-en-library-calendar-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25635,6 +27221,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.428)x24.10101, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 J
 ...........\TU/lmss/m/n/7 a
 ...........\TU/lmss/m/n/7 n
@@ -25645,6 +27232,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ...........\kern-0.21 (font)
 ...........\TU/lmss/m/n/7 r
 ...........\TU/lmss/m/n/7 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25671,7 +27259,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25700,9 +27290,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25731,7 +27323,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25760,7 +27354,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25789,7 +27385,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25818,7 +27416,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25847,7 +27447,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25876,7 +27478,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25905,9 +27509,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25936,8 +27542,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25966,8 +27574,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25996,8 +27606,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26026,8 +27638,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26056,8 +27670,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26086,8 +27702,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26116,10 +27734,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26148,8 +27768,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26178,8 +27800,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26208,8 +27832,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26238,8 +27864,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26268,8 +27896,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26298,8 +27928,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26328,10 +27960,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26360,8 +27994,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26390,8 +28026,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26420,8 +28058,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26450,8 +28090,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26480,8 +28122,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26510,8 +28154,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26540,10 +28186,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26572,8 +28220,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26601,6 +28251,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.428)x26.69798, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 F
 ...........\kern-0.21 (font)
 ...........\TU/lmss/m/n/7 e
@@ -26614,6 +28265,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ...........\kern-0.21 (font)
 ...........\TU/lmss/m/n/7 r
 ...........\TU/lmss/m/n/7 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26640,7 +28292,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26669,7 +28323,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26698,7 +28354,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26727,7 +28385,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26756,7 +28416,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26785,9 +28447,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26816,7 +28480,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26845,7 +28511,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26874,7 +28542,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26903,8 +28573,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26933,8 +28605,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26963,8 +28637,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26993,10 +28669,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27025,8 +28703,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27055,8 +28735,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27085,8 +28767,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27115,8 +28799,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27145,8 +28831,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27175,8 +28863,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27205,10 +28895,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27237,8 +28929,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27267,8 +28961,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27297,8 +28993,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27327,8 +29025,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27357,8 +29057,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27387,8 +29089,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27417,10 +29121,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27449,8 +29155,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27479,8 +29187,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27508,12 +29218,14 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.07)x19.537, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 M
 ...........\TU/lmss/m/n/7 a
 ...........\kern-0.21 (font)
 ...........\TU/lmss/m/n/7 r
 ...........\TU/lmss/m/n/7 c
 ...........\TU/lmss/m/n/7 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27540,7 +29252,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27569,7 +29283,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27598,7 +29314,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27627,7 +29345,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27656,9 +29376,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27687,7 +29409,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27716,7 +29440,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27745,7 +29471,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27774,7 +29502,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27803,8 +29533,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27833,8 +29565,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27863,10 +29597,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27895,8 +29631,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27925,8 +29663,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27955,8 +29695,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27985,8 +29727,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28015,8 +29759,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28045,8 +29791,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28075,10 +29823,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28107,8 +29857,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28137,8 +29889,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28167,8 +29921,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28197,8 +29953,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28227,8 +29985,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28257,8 +30017,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28287,10 +30049,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28319,8 +30083,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28349,8 +30115,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28379,8 +30147,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28409,8 +30179,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28439,8 +30211,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28468,12 +30242,14 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.358)x14.67198, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 A
 ...........\TU/lmss/m/n/7 p
 ...........\kern-0.21 (font)
 ...........\TU/lmss/m/n/7 r
 ...........\TU/lmss/m/n/7 i
 ...........\TU/lmss/m/n/7 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28500,7 +30276,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28529,9 +30307,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28560,7 +30340,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28589,7 +30371,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28618,7 +30402,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28647,7 +30433,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28676,7 +30464,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28705,7 +30495,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28734,9 +30526,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28765,8 +30559,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28795,8 +30591,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28825,8 +30623,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28855,8 +30655,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28885,8 +30687,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28915,8 +30719,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28945,10 +30751,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28977,8 +30785,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29007,8 +30817,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29037,8 +30849,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29067,8 +30881,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29097,8 +30913,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29127,8 +30945,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29157,10 +30977,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29189,8 +31011,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29219,8 +31043,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29249,8 +31075,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29279,8 +31107,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29309,8 +31139,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29339,8 +31171,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29369,10 +31203,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29400,10 +31236,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.428)x13.27899, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 M
 ...........\TU/lmss/m/n/7 a
 ...........\kern-0.21 (font)
 ...........\TU/lmss/m/n/7 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29430,7 +31268,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29459,7 +31299,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29488,7 +31330,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29517,7 +31361,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29546,7 +31392,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29575,7 +31423,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29604,9 +31454,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29635,7 +31487,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29664,7 +31518,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29693,8 +31549,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29723,8 +31581,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29753,8 +31613,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29783,8 +31645,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29813,10 +31677,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29845,8 +31711,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29875,8 +31743,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29905,8 +31775,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29935,8 +31807,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29965,8 +31839,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29995,8 +31871,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30025,10 +31903,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30057,8 +31937,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30087,8 +31969,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30117,8 +32001,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30147,8 +32033,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30177,8 +32065,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30207,8 +32097,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30237,10 +32129,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30269,8 +32163,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30299,8 +32195,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30329,8 +32227,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30358,10 +32258,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.147)x14.50401, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 J
 ...........\TU/lmss/m/n/7 u
 ...........\TU/lmss/m/n/7 n
 ...........\TU/lmss/m/n/7 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30388,7 +32290,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30417,7 +32321,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30446,7 +32352,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30475,9 +32383,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30506,7 +32416,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30535,7 +32447,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30564,7 +32478,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30593,7 +32509,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30622,7 +32540,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30651,8 +32571,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30681,10 +32603,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30713,8 +32637,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30743,8 +32669,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30773,8 +32701,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30803,8 +32733,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30833,8 +32765,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30863,8 +32797,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30893,10 +32829,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30925,8 +32863,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30955,8 +32895,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30985,8 +32927,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31015,8 +32959,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31045,8 +32991,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31075,8 +33023,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31105,10 +33055,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31137,8 +33089,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31167,8 +33121,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31197,8 +33153,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31227,8 +33185,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31257,8 +33217,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31286,10 +33248,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.428)x12.558, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 J
 ...........\TU/lmss/m/n/7 u
 ...........\TU/lmss/m/n/7 l
 ...........\TU/lmss/m/n/7 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31316,7 +33280,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31345,9 +33311,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31376,7 +33344,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31405,7 +33375,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31434,7 +33406,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31463,7 +33437,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31492,7 +33468,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31521,7 +33499,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31550,9 +33530,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31581,8 +33563,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31611,8 +33595,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31641,8 +33627,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31671,8 +33659,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31701,8 +33691,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31731,8 +33723,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31761,10 +33755,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31793,8 +33789,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31823,8 +33821,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31853,8 +33853,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31883,8 +33885,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31913,8 +33917,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31943,8 +33949,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31973,10 +33981,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32005,8 +34015,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32035,8 +34047,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32065,8 +34079,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32095,8 +34111,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32125,8 +34143,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32155,8 +34175,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32185,10 +34207,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32217,8 +34241,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32246,6 +34272,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.435)x21.68599, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 A
 ...........\kern-0.21 (font)
 ...........\TU/lmss/m/n/7 u
@@ -32255,6 +34282,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ...........\TU/lmss/m/n/7 u
 ...........\TU/lmss/m/n/7 s
 ...........\TU/lmss/m/n/7 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32281,7 +34309,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32310,7 +34340,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32339,7 +34371,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32368,7 +34402,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32397,7 +34433,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32426,9 +34464,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32457,7 +34497,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32486,7 +34528,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32515,7 +34559,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32544,8 +34590,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32574,8 +34622,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32604,8 +34654,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32634,10 +34686,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32666,8 +34720,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32696,8 +34752,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32726,8 +34784,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32756,8 +34816,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32786,8 +34848,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32816,8 +34880,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32846,10 +34912,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32878,8 +34946,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32908,8 +34978,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32938,8 +35010,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32968,8 +35042,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32998,8 +35074,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33028,8 +35106,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33058,10 +35138,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33090,8 +35172,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33120,8 +35204,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33150,8 +35236,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33180,8 +35268,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33209,6 +35299,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.005+1.358)x33.07503, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 S
 ...........\TU/lmss/m/n/7 e
 ...........\TU/lmss/m/n/7 p
@@ -33221,6 +35312,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ...........\kern0.21 (font)
 ...........\TU/lmss/m/n/7 e
 ...........\TU/lmss/m/n/7 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33247,7 +35339,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33276,7 +35370,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33305,9 +35401,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33336,7 +35434,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33365,7 +35465,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33394,7 +35496,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33423,7 +35527,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33452,7 +35558,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33481,7 +35589,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33510,10 +35620,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33542,8 +35654,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33572,8 +35686,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33602,8 +35718,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33632,8 +35750,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33662,8 +35782,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33692,8 +35814,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33722,10 +35846,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33754,8 +35880,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33784,8 +35912,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33814,8 +35944,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33844,8 +35976,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33874,8 +36008,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33904,8 +36040,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33934,10 +36072,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33966,8 +36106,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33996,8 +36138,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34026,8 +36170,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34056,8 +36202,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34086,8 +36234,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34116,8 +36266,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34145,6 +36297,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.005+0.147)x25.102, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 O
 ...........\TU/lmss/m/n/7 c
 ...........\discretionary (penalty 50)
@@ -34157,6 +36310,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ...........\kern0.21 (font)
 ...........\TU/lmss/m/n/7 e
 ...........\TU/lmss/m/n/7 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34183,9 +36337,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34214,7 +36370,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34243,7 +36401,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34272,7 +36432,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34301,7 +36463,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34330,7 +36494,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34359,7 +36525,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34388,9 +36556,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34419,7 +36589,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34448,8 +36620,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34478,8 +36652,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34508,8 +36684,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34538,8 +36716,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34568,8 +36748,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34598,10 +36780,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34630,8 +36814,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34660,8 +36846,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34690,8 +36878,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34720,8 +36910,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34750,8 +36942,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34780,8 +36974,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34810,10 +37006,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34842,8 +37040,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34872,8 +37072,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34902,8 +37104,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34932,8 +37136,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34962,8 +37168,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34992,8 +37200,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35022,10 +37232,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35054,8 +37266,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35084,8 +37298,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35113,6 +37329,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.07)x31.507, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 N
 ...........\TU/lmss/m/n/7 o
 ...........\TU/lmss/m/n/7 v
@@ -35124,6 +37341,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ...........\kern0.21 (font)
 ...........\TU/lmss/m/n/7 e
 ...........\TU/lmss/m/n/7 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35150,7 +37368,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35179,7 +37399,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35208,7 +37430,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35237,7 +37461,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35266,9 +37492,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35297,7 +37525,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35326,7 +37556,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35355,7 +37587,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35384,7 +37618,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35413,8 +37649,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35443,8 +37681,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35473,10 +37713,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35505,8 +37747,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35535,8 +37779,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35565,8 +37811,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35595,8 +37843,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35625,8 +37875,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35655,8 +37907,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35685,10 +37939,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35717,8 +37973,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35747,8 +38005,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35777,8 +38037,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35807,8 +38069,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35837,8 +38101,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35867,8 +38133,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35897,10 +38165,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35929,8 +38199,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35959,8 +38231,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35989,8 +38263,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36019,8 +38295,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36048,6 +38326,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.07)x31.08702, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 D
 ...........\TU/lmss/m/n/7 e
 ...........\discretionary (penalty 50)
@@ -36061,6 +38340,7 @@ TEST 26: pgfmanual-en-library-calendar-28
 ...........\kern0.21 (font)
 ...........\TU/lmss/m/n/7 e
 ...........\TU/lmss/m/n/7 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36087,7 +38367,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36116,7 +38398,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36145,9 +38429,11 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36176,7 +38462,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.0)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36205,7 +38493,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36234,7 +38524,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36263,7 +38555,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.592+0.07)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36292,7 +38586,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36321,7 +38617,9 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x3.717, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36350,10 +38648,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36382,8 +38682,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36412,8 +38714,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36442,8 +38746,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36472,8 +38778,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36502,8 +38810,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36532,8 +38842,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36562,10 +38874,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36594,8 +38908,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36624,8 +38940,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 1
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36654,8 +38972,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36684,8 +39004,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36714,8 +39036,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36744,8 +39068,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36774,10 +39100,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.0)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36806,8 +39134,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36836,8 +39166,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36866,8 +39198,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.07)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36896,8 +39230,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36926,8 +39262,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 2
 ...........\TU/lmss/m/n/7 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36956,8 +39294,10 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36986,10 +39326,12 @@ TEST 26: pgfmanual-en-library-calendar-28
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.739+0.147)x7.43399, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/7 3
 ...........\TU/lmss/m/n/7 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37046,8 +39388,10 @@ TEST 27: pgfmanual-en-library-calendar-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37076,8 +39420,10 @@ TEST 27: pgfmanual-en-library-calendar-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37106,8 +39452,10 @@ TEST 27: pgfmanual-en-library-calendar-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37136,8 +39484,10 @@ TEST 27: pgfmanual-en-library-calendar-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37165,6 +39515,7 @@ TEST 27: pgfmanual-en-library-calendar-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -37176,6 +39527,7 @@ TEST 27: pgfmanual-en-library-calendar-29
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37202,7 +39554,9 @@ TEST 27: pgfmanual-en-library-calendar-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37231,7 +39585,9 @@ TEST 27: pgfmanual-en-library-calendar-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37260,7 +39616,9 @@ TEST 27: pgfmanual-en-library-calendar-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37317,8 +39675,10 @@ TEST 28: pgfmanual-en-library-calendar-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37347,8 +39707,10 @@ TEST 28: pgfmanual-en-library-calendar-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37377,8 +39739,10 @@ TEST 28: pgfmanual-en-library-calendar-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37407,8 +39771,10 @@ TEST 28: pgfmanual-en-library-calendar-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37436,6 +39802,7 @@ TEST 28: pgfmanual-en-library-calendar-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -37447,6 +39814,7 @@ TEST 28: pgfmanual-en-library-calendar-30
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37473,7 +39841,9 @@ TEST 28: pgfmanual-en-library-calendar-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37502,7 +39872,9 @@ TEST 28: pgfmanual-en-library-calendar-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37531,7 +39903,9 @@ TEST 28: pgfmanual-en-library-calendar-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37588,8 +39962,10 @@ TEST 29: pgfmanual-en-library-calendar-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37618,8 +39994,10 @@ TEST 29: pgfmanual-en-library-calendar-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37648,8 +40026,10 @@ TEST 29: pgfmanual-en-library-calendar-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37678,8 +40058,10 @@ TEST 29: pgfmanual-en-library-calendar-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37707,6 +40089,7 @@ TEST 29: pgfmanual-en-library-calendar-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -37718,6 +40101,7 @@ TEST 29: pgfmanual-en-library-calendar-31
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37744,7 +40128,9 @@ TEST 29: pgfmanual-en-library-calendar-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37773,7 +40159,9 @@ TEST 29: pgfmanual-en-library-calendar-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37802,7 +40190,9 @@ TEST 29: pgfmanual-en-library-calendar-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37859,8 +40249,10 @@ TEST 30: pgfmanual-en-library-calendar-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37889,8 +40281,10 @@ TEST 30: pgfmanual-en-library-calendar-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37919,8 +40313,10 @@ TEST 30: pgfmanual-en-library-calendar-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37949,8 +40345,10 @@ TEST 30: pgfmanual-en-library-calendar-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37978,6 +40376,7 @@ TEST 30: pgfmanual-en-library-calendar-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -37989,6 +40388,7 @@ TEST 30: pgfmanual-en-library-calendar-32
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38015,7 +40415,9 @@ TEST 30: pgfmanual-en-library-calendar-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38044,7 +40446,9 @@ TEST 30: pgfmanual-en-library-calendar-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38073,7 +40477,9 @@ TEST 30: pgfmanual-en-library-calendar-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38130,8 +40536,10 @@ TEST 31: pgfmanual-en-library-calendar-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38160,8 +40568,10 @@ TEST 31: pgfmanual-en-library-calendar-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38190,8 +40600,10 @@ TEST 31: pgfmanual-en-library-calendar-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38220,8 +40632,10 @@ TEST 31: pgfmanual-en-library-calendar-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38250,6 +40664,7 @@ TEST 31: pgfmanual-en-library-calendar-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -38261,6 +40676,7 @@ TEST 31: pgfmanual-en-library-calendar-33
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38288,7 +40704,9 @@ TEST 31: pgfmanual-en-library-calendar-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38317,7 +40735,9 @@ TEST 31: pgfmanual-en-library-calendar-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38346,7 +40766,9 @@ TEST 31: pgfmanual-en-library-calendar-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38403,8 +40825,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38433,8 +40857,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38463,8 +40889,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38493,8 +40921,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38524,8 +40954,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38554,8 +40986,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38584,8 +41018,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38614,8 +41050,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38644,8 +41082,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38674,8 +41114,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38704,8 +41146,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38735,8 +41179,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38765,6 +41211,7 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -38776,6 +41223,7 @@ TEST 32: pgfmanual-en-library-calendar-34
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38803,7 +41251,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38832,7 +41282,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38861,7 +41313,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38890,7 +41344,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38919,7 +41375,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38948,7 +41406,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38978,7 +41438,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39007,7 +41469,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39036,7 +41500,9 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39065,8 +41531,10 @@ TEST 32: pgfmanual-en-library-calendar-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39124,6 +41592,7 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -39135,6 +41604,7 @@ TEST 33: pgfmanual-en-library-calendar-35
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39162,7 +41632,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39191,7 +41663,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39220,7 +41694,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39249,7 +41725,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39278,7 +41756,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39307,7 +41787,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39336,7 +41818,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39365,7 +41849,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39394,7 +41880,9 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39423,8 +41911,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39453,8 +41943,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39483,8 +41975,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39513,8 +42007,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39543,8 +42039,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39573,8 +42071,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39603,8 +42103,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39633,8 +42135,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39663,8 +42167,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39693,8 +42199,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39723,8 +42231,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39753,8 +42263,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39783,8 +42295,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39813,8 +42327,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39843,8 +42359,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39873,8 +42391,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39903,8 +42423,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39933,8 +42455,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39963,8 +42487,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39993,8 +42519,10 @@ TEST 33: pgfmanual-en-library-calendar-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40051,8 +42579,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40081,8 +42611,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40111,8 +42643,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40141,8 +42675,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40172,8 +42708,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40202,8 +42740,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40232,8 +42772,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40262,8 +42804,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40292,8 +42836,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40322,8 +42868,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40352,8 +42900,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40383,8 +42933,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40415,6 +42967,7 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -40426,6 +42979,7 @@ TEST 34: pgfmanual-en-library-calendar-36
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40453,7 +43007,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40482,7 +43038,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40511,7 +43069,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40540,7 +43100,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40569,7 +43131,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40598,7 +43162,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40628,7 +43194,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40657,7 +43225,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40686,7 +43256,9 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40715,8 +43287,10 @@ TEST 34: pgfmanual-en-library-calendar-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40773,8 +43347,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40803,8 +43379,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40833,8 +43411,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40863,8 +43443,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40894,8 +43476,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40924,8 +43508,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40954,8 +43540,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40984,8 +43572,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41014,8 +43604,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41044,8 +43636,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41074,8 +43668,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41105,8 +43701,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41135,6 +43733,7 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -41146,6 +43745,7 @@ TEST 35: pgfmanual-en-library-calendar-37
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41173,7 +43773,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41202,7 +43804,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41231,7 +43835,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41260,7 +43866,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41289,7 +43897,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41318,7 +43928,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41348,7 +43960,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41377,7 +43991,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41406,7 +44022,9 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41435,8 +44053,10 @@ TEST 35: pgfmanual-en-library-calendar-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41492,6 +44112,7 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -41503,6 +44124,7 @@ TEST 36: pgfmanual-en-library-calendar-38
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41530,7 +44152,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41559,7 +44183,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41588,7 +44214,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41617,7 +44245,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41646,7 +44276,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41675,7 +44307,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41704,7 +44338,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41733,7 +44369,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41762,7 +44400,9 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41791,8 +44431,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41821,8 +44463,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41851,8 +44495,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41881,8 +44527,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41911,8 +44559,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41941,8 +44591,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41971,8 +44623,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42001,8 +44655,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42031,8 +44687,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42061,8 +44719,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42091,8 +44751,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42121,8 +44783,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42151,8 +44815,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42181,8 +44847,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42211,8 +44879,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42241,8 +44911,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42271,8 +44943,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42301,8 +44975,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42331,8 +45007,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42361,8 +45039,10 @@ TEST 36: pgfmanual-en-library-calendar-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42420,6 +45100,7 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.37999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -42431,6 +45112,7 @@ TEST 37: pgfmanual-en-library-calendar-39
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42458,7 +45140,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42487,7 +45171,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42516,7 +45202,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42545,7 +45233,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42574,7 +45264,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42603,7 +45295,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42632,7 +45326,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42661,7 +45357,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42690,7 +45388,9 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42719,8 +45419,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42749,8 +45451,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42779,8 +45483,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42809,8 +45515,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42839,8 +45547,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42869,8 +45579,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42899,8 +45611,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42929,8 +45643,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42959,8 +45675,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42989,8 +45707,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43019,8 +45739,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43049,8 +45771,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43079,8 +45803,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43109,8 +45835,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43139,8 +45867,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43169,8 +45899,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43199,8 +45931,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43229,8 +45963,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43259,8 +45995,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43289,8 +46027,10 @@ TEST 37: pgfmanual-en-library-calendar-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43348,6 +46088,7 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x66.54001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
 ...........\TU/lmr/m/n/10 e
 ...........\discretionary (penalty 50)
@@ -43367,6 +46108,7 @@ TEST 38: pgfmanual-en-library-calendar-40
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43391,7 +46133,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43426,7 +46170,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43461,7 +46207,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43496,7 +46244,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43531,9 +46281,11 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43565,9 +46317,11 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43600,7 +46354,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43635,7 +46391,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43670,7 +46428,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43705,8 +46465,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43741,8 +46503,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43777,10 +46541,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43812,10 +46578,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43848,8 +46616,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43884,8 +46654,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43920,8 +46692,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43956,8 +46730,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43992,8 +46768,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44028,10 +46806,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44063,10 +46843,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44099,8 +46881,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44135,8 +46919,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44171,8 +46957,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44207,8 +46995,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44243,8 +47033,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44279,10 +47071,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44314,10 +47108,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44350,8 +47146,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44386,8 +47184,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44425,8 +47225,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44455,8 +47257,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44487,6 +47291,7 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+2.05)x58.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 J
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 n
@@ -44502,6 +47307,7 @@ TEST 38: pgfmanual-en-library-calendar-40
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44529,7 +47335,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44558,9 +47366,11 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44589,9 +47399,11 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44621,7 +47433,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44650,7 +47464,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44679,7 +47495,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44708,7 +47526,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44737,7 +47557,9 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44766,9 +47588,11 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44797,10 +47621,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44830,8 +47656,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44860,8 +47688,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44890,8 +47720,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44920,8 +47752,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44950,8 +47784,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44980,10 +47816,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45012,10 +47850,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45045,8 +47885,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45075,8 +47917,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45105,8 +47949,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45135,8 +47981,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45165,8 +48013,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45195,10 +48045,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45227,10 +48079,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45260,8 +48114,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45290,8 +48146,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45320,8 +48178,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45350,8 +48210,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45380,8 +48242,10 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45410,10 +48274,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45442,10 +48308,12 @@ TEST 38: pgfmanual-en-library-calendar-40
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45501,10 +48369,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45539,10 +48409,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45577,10 +48449,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45615,10 +48489,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45653,10 +48529,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45691,10 +48569,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45734,6 +48614,7 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+2.05)x43.73001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 M
 ...........\TU/lmr/m/it/10 a
 ...........\TU/lmr/m/it/10 y
@@ -45743,6 +48624,7 @@ TEST 39: pgfmanual-en-library-calendar-41
 ...........\TU/lmr/m/it/10 1
 ...........\TU/lmr/m/it/10 6
 ...........\kern0.77 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45767,9 +48649,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45802,9 +48686,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45839,9 +48725,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45876,9 +48764,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45913,9 +48803,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45950,9 +48842,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45987,9 +48881,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46024,9 +48920,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46059,9 +48957,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46096,10 +48996,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46134,10 +49036,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46172,10 +49076,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46210,10 +49116,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46248,10 +49156,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46286,10 +49196,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46322,10 +49234,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46360,10 +49274,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46398,10 +49314,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46436,10 +49354,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46477,10 +49397,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46509,10 +49431,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46541,10 +49465,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46574,10 +49500,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46606,10 +49534,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46638,10 +49568,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46670,10 +49602,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46702,10 +49636,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46734,10 +49670,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46766,10 +49704,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46799,10 +49739,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46831,8 +49773,10 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46863,6 +49807,7 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.22)x45.63, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 J
 ...........\TU/lmr/m/it/10 u
 ...........\TU/lmr/m/it/10 n
@@ -46873,6 +49818,7 @@ TEST 39: pgfmanual-en-library-calendar-41
 ...........\TU/lmr/m/it/10 1
 ...........\TU/lmr/m/it/10 6
 ...........\kern0.77 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46900,7 +49846,9 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46929,7 +49877,9 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46958,7 +49908,9 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46987,7 +49939,9 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47016,9 +49970,11 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47048,7 +50004,9 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47077,7 +50035,9 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47106,7 +50066,9 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47135,7 +50097,9 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47164,8 +50128,10 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47194,8 +50160,10 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47224,10 +50192,12 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47257,8 +50227,10 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47287,8 +50259,10 @@ TEST 39: pgfmanual-en-library-calendar-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47352,10 +50326,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.22)x20.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 2
 ...........\TU/lmss/m/n/10 0
 ...........\TU/lmss/m/n/10 1
 ...........\TU/lmss/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47387,6 +50363,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.94+2.05)x32.43, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 J
 ...........\TU/lmss/m/n/10 a
 ...........\TU/lmss/m/n/10 n
@@ -47397,6 +50374,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ...........\kern-0.28 (font)
 ...........\TU/lmss/m/n/10 r
 ...........\TU/lmss/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47426,7 +50404,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47460,7 +50440,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47493,9 +50475,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47528,7 +50512,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47561,7 +50547,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47594,7 +50582,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47627,7 +50617,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47660,7 +50652,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47693,7 +50687,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47726,10 +50722,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47762,8 +50760,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47796,8 +50796,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47830,8 +50832,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47864,8 +50868,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47898,8 +50904,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47932,8 +50940,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47966,10 +50976,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48002,8 +51014,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48036,8 +51050,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48070,8 +51086,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48104,8 +51122,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48138,8 +51158,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48172,8 +51194,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48206,10 +51230,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48242,8 +51268,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48276,8 +51304,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48310,8 +51340,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48344,8 +51376,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48378,8 +51412,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48412,8 +51448,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48446,10 +51484,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48484,6 +51524,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.94+2.05)x35.89, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 F
 ...........\kern-0.28 (font)
 ...........\TU/lmss/m/n/10 e
@@ -48497,6 +51538,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ...........\kern-0.28 (font)
 ...........\TU/lmss/m/n/10 r
 ...........\TU/lmss/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48526,7 +51568,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48560,7 +51604,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48593,7 +51639,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48626,7 +51674,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48659,7 +51709,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48692,7 +51744,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48725,9 +51779,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48760,7 +51816,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48793,7 +51851,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48826,8 +51886,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48860,8 +51922,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48894,8 +51958,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48928,8 +51994,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48962,10 +52030,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48998,8 +52068,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49032,8 +52104,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49066,8 +52140,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49100,8 +52176,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49134,8 +52212,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49168,8 +52248,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49202,10 +52284,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49238,8 +52322,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49272,8 +52358,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49306,8 +52394,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49340,8 +52430,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49374,8 +52466,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49408,8 +52502,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49442,10 +52538,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49478,8 +52576,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49514,12 +52614,14 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0.6 0 RG }
 ..........\pdfliteral origin{0 0.6 0 rg }
 ..........\hbox(6.94+0.11)x26.31, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 M
 ...........\TU/lmss/m/n/10 a
 ...........\kern-0.28 (font)
 ...........\TU/lmss/m/n/10 r
 ...........\TU/lmss/m/n/10 c
 ...........\TU/lmss/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49549,7 +52651,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0.6 0 RG }
 ..........\pdfliteral origin{0 0.6 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49583,7 +52687,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49616,7 +52722,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49649,7 +52757,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49682,7 +52792,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49715,9 +52827,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49750,7 +52864,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49783,7 +52899,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49816,7 +52934,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49849,8 +52969,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49883,8 +53005,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49917,8 +53041,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49951,10 +53077,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49987,8 +53115,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50021,8 +53151,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50055,8 +53187,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50089,8 +53223,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50123,8 +53259,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50157,8 +53295,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50191,10 +53331,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50227,8 +53369,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50261,8 +53405,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50295,8 +53441,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50329,8 +53477,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50363,8 +53513,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50397,8 +53549,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50431,10 +53585,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50467,8 +53623,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50501,8 +53659,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50535,8 +53695,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50569,8 +53731,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50605,12 +53769,14 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0.6 0 RG }
 ..........\pdfliteral origin{0 0.6 0 rg }
 ..........\hbox(6.94+1.94)x19.76, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 A
 ...........\TU/lmss/m/n/10 p
 ...........\kern-0.28 (font)
 ...........\TU/lmss/m/n/10 r
 ...........\TU/lmss/m/n/10 i
 ...........\TU/lmss/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50640,7 +53806,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0.6 0 RG }
 ..........\pdfliteral origin{0 0.6 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50674,7 +53842,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50707,9 +53877,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50742,7 +53914,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50775,7 +53949,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50808,7 +53984,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50841,7 +54019,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50874,7 +54054,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50907,7 +54089,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50940,10 +54124,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50976,8 +54162,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51010,8 +54198,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51044,8 +54234,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51078,8 +54270,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51112,8 +54306,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51146,8 +54342,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51180,10 +54378,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51216,8 +54416,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51250,8 +54452,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51284,8 +54488,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51318,8 +54524,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51352,8 +54560,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51386,8 +54596,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51420,10 +54632,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51456,8 +54670,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51490,8 +54706,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51524,8 +54742,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51558,8 +54778,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51592,8 +54814,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51626,8 +54850,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51662,10 +54888,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0.6 0 RG }
 ..........\pdfliteral origin{0 0.6 0 rg }
 ..........\hbox(6.94+2.05)x17.89, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 M
 ...........\TU/lmss/m/n/10 a
 ...........\kern-0.28 (font)
 ...........\TU/lmss/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51695,9 +54923,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51731,7 +54961,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51764,7 +54996,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51797,7 +55031,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51830,7 +55066,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51863,7 +55101,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51896,7 +55136,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51929,9 +55171,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51964,7 +55208,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51997,8 +55243,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52031,8 +55279,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52065,8 +55315,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52099,8 +55351,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52133,8 +55387,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52167,10 +55423,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52203,8 +55461,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52237,8 +55497,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52271,8 +55533,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52305,8 +55569,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52339,8 +55605,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52373,8 +55641,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52407,10 +55677,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52443,8 +55715,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52477,8 +55751,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52511,8 +55787,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52545,8 +55823,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52579,8 +55859,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52613,8 +55895,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52647,10 +55931,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52683,8 +55969,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52717,8 +56005,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52753,10 +56043,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(6.94+0.22)x19.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 J
 ...........\TU/lmss/m/n/10 u
 ...........\TU/lmss/m/n/10 n
 ...........\TU/lmss/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52786,7 +56078,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52820,7 +56114,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52853,7 +56149,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52886,7 +56184,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52919,9 +56219,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52954,7 +56256,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52987,7 +56291,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53020,7 +56326,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53053,7 +56361,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53086,8 +56396,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53120,8 +56432,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53154,10 +56468,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53190,8 +56506,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53224,8 +56542,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53258,8 +56578,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53292,8 +56614,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53326,8 +56650,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53360,8 +56686,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53394,10 +56722,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53430,8 +56760,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53464,8 +56796,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53498,8 +56832,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53532,8 +56868,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53566,8 +56904,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53600,8 +56940,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53634,10 +56976,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53670,8 +57014,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53704,8 +57050,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53738,8 +57086,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53772,8 +57122,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53808,10 +57160,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(6.94+2.05)x16.89, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 J
 ...........\TU/lmss/m/n/10 u
 ...........\TU/lmss/m/n/10 l
 ...........\TU/lmss/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53841,7 +57195,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53875,7 +57231,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53908,9 +57266,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53943,7 +57303,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53976,7 +57338,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54009,7 +57373,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54042,7 +57408,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54075,7 +57443,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54108,7 +57478,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54141,10 +57513,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54177,8 +57551,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54211,8 +57587,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54245,8 +57623,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54279,8 +57659,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54313,8 +57695,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54347,8 +57731,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54381,10 +57767,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54417,8 +57805,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54451,8 +57841,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54485,8 +57877,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54519,8 +57913,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54553,8 +57949,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54587,8 +57985,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54621,10 +58021,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54657,8 +58059,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54691,8 +58095,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54725,8 +58131,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54759,8 +58167,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54793,8 +58203,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54827,8 +58239,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54861,10 +58275,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54899,6 +58315,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(6.94+2.06)x29.17, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 A
 ...........\kern-0.28 (font)
 ...........\TU/lmss/m/n/10 u
@@ -54908,6 +58325,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ...........\TU/lmss/m/n/10 u
 ...........\TU/lmss/m/n/10 s
 ...........\TU/lmss/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54937,7 +58355,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54971,7 +58391,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55004,7 +58426,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55037,7 +58461,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55070,7 +58496,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55103,7 +58531,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55136,9 +58566,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55171,7 +58603,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55204,7 +58638,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55237,8 +58673,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55271,8 +58709,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55305,8 +58745,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55339,8 +58781,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55373,10 +58817,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55409,8 +58855,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55443,8 +58891,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55477,8 +58927,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55511,8 +58963,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55545,8 +58999,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55579,8 +59035,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55613,10 +59071,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55649,8 +59109,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55683,8 +59145,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55717,8 +59181,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55751,8 +59217,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55785,8 +59253,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55819,8 +59289,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55853,10 +59325,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55889,8 +59363,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55923,8 +59399,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55957,8 +59435,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55993,6 +59473,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(7.16+1.94)x44.47, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 S
 ...........\TU/lmss/m/n/10 e
 ...........\TU/lmss/m/n/10 p
@@ -56005,6 +59486,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ...........\kern0.28 (font)
 ...........\TU/lmss/m/n/10 e
 ...........\TU/lmss/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56034,7 +59516,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56068,7 +59552,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56101,7 +59587,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56134,9 +59622,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56169,7 +59659,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56202,7 +59694,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56235,7 +59729,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56268,7 +59764,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56301,7 +59799,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56334,8 +59834,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56368,10 +59870,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56404,8 +59908,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56438,8 +59944,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56472,8 +59980,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56506,8 +60016,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56540,8 +60052,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56574,8 +60088,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56608,10 +60124,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56644,8 +60162,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56678,8 +60198,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56712,8 +60234,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56746,8 +60270,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56780,8 +60306,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56814,8 +60342,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56848,10 +60378,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56884,8 +60416,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56918,8 +60452,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56952,8 +60488,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -56986,8 +60524,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57020,8 +60560,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57056,6 +60598,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(7.16+0.22)x33.72, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 O
 ...........\TU/lmss/m/n/10 c
 ...........\discretionary (penalty 50)
@@ -57068,6 +60611,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ...........\kern0.28 (font)
 ...........\TU/lmss/m/n/10 e
 ...........\TU/lmss/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57097,7 +60641,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57131,9 +60677,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57166,7 +60714,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57199,7 +60749,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57232,7 +60784,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57265,7 +60819,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57298,7 +60854,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57331,7 +60889,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57364,9 +60924,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57399,8 +60961,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57433,8 +60997,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57467,8 +61033,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57501,8 +61069,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57535,8 +61105,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57569,8 +61141,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57603,10 +61177,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57639,8 +61215,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57673,8 +61251,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57707,8 +61287,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57741,8 +61323,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57775,8 +61359,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57809,8 +61395,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57843,10 +61431,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57879,8 +61469,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57913,8 +61505,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57947,8 +61541,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -57981,8 +61577,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58015,8 +61613,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58049,8 +61649,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58083,10 +61685,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58119,8 +61723,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58155,6 +61761,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+0.11)x42.38, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 N
 ...........\TU/lmss/m/n/10 o
 ...........\TU/lmss/m/n/10 v
@@ -58166,6 +61773,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ...........\kern0.28 (font)
 ...........\TU/lmss/m/n/10 e
 ...........\TU/lmss/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58195,7 +61803,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58229,7 +61839,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58262,7 +61874,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58295,7 +61909,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58328,7 +61944,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58361,9 +61979,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58396,7 +62016,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58429,7 +62051,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58462,7 +62086,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58495,8 +62121,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58529,8 +62157,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58563,8 +62193,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58597,10 +62229,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58633,8 +62267,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58667,8 +62303,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58701,8 +62339,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58735,8 +62375,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58769,8 +62411,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58803,8 +62447,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58837,10 +62483,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58873,8 +62521,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58907,8 +62557,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58941,8 +62593,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -58975,8 +62629,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59009,8 +62665,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59043,8 +62701,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59077,10 +62737,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59113,8 +62775,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59147,8 +62811,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59181,8 +62847,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59217,6 +62885,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.94+0.11)x41.79001, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 D
 ...........\TU/lmss/m/n/10 e
 ...........\discretionary (penalty 50)
@@ -59230,6 +62899,7 @@ TEST 40: pgfmanual-en-library-calendar-42
 ...........\kern0.28 (font)
 ...........\TU/lmss/m/n/10 e
 ...........\TU/lmss/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59259,7 +62929,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59293,7 +62965,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59326,7 +63000,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59359,9 +63035,11 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(3.936+0.0)x3.186, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59394,7 +63072,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59427,7 +63107,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59460,7 +63142,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.936+0.06)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59493,7 +63177,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59526,7 +63212,9 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x3.186, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59559,8 +63247,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59593,10 +63283,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59629,8 +63321,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59663,8 +63357,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59697,8 +63393,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59731,8 +63429,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59765,8 +63465,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59799,8 +63501,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59833,10 +63537,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59869,8 +63575,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 1
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59903,8 +63611,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59937,8 +63647,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -59971,8 +63683,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60005,8 +63719,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60039,8 +63755,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.0)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60073,10 +63791,12 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60109,8 +63829,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60143,8 +63865,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.06)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60177,8 +63901,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60211,8 +63937,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 2
 ...........\TU/lmss/m/n/6 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60245,8 +63973,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60279,8 +64009,10 @@ TEST 40: pgfmanual-en-library-calendar-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.062+0.126)x6.37201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/6 3
 ...........\TU/lmss/m/n/6 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60338,10 +64070,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60368,7 +64102,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60397,7 +64133,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60426,9 +64164,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60458,7 +64198,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60487,7 +64229,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60516,7 +64260,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60545,7 +64291,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60574,7 +64322,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60603,7 +64353,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60632,10 +64384,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60665,8 +64419,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60695,8 +64451,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60725,8 +64483,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60755,8 +64515,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60785,8 +64547,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60815,8 +64579,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60845,10 +64611,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60878,8 +64646,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60908,8 +64678,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60938,8 +64710,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60968,8 +64742,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -60998,8 +64774,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61028,8 +64806,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61058,10 +64838,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61091,8 +64873,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61121,8 +64905,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61151,8 +64937,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61181,8 +64969,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61211,8 +65001,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61241,8 +65033,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61271,10 +65065,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61302,10 +65098,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61332,7 +65130,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61361,7 +65161,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61390,7 +65192,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61419,7 +65223,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61448,7 +65254,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61477,7 +65285,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61506,9 +65316,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61538,7 +65350,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61567,7 +65381,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61596,8 +65412,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61626,8 +65444,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61656,8 +65476,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61686,8 +65508,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61716,10 +65540,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61749,8 +65575,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61779,8 +65607,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61809,8 +65639,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61839,8 +65671,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61869,8 +65703,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61899,8 +65735,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61929,10 +65767,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61962,8 +65802,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -61992,8 +65834,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62022,8 +65866,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62052,8 +65898,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62082,8 +65930,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62112,8 +65962,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62142,10 +65994,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62175,8 +66029,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62204,10 +66060,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62234,7 +66092,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62263,7 +66123,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62292,7 +66154,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62321,7 +66185,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62350,7 +66216,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62379,9 +66247,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62411,7 +66281,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62440,7 +66312,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62469,7 +66343,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62498,8 +66374,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62528,8 +66406,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62558,8 +66438,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62588,10 +66470,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62621,8 +66505,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62651,8 +66537,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62681,8 +66569,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62711,8 +66601,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62741,8 +66633,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62771,8 +66665,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62801,10 +66697,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62834,8 +66732,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62864,8 +66764,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62894,8 +66796,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62924,8 +66828,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62954,8 +66860,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -62984,8 +66892,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63014,10 +66924,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63047,8 +66959,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63077,8 +66991,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63107,8 +67023,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63137,8 +67055,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63166,10 +67086,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63196,7 +67118,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63225,7 +67149,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63254,9 +67180,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63286,7 +67214,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63315,7 +67245,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63344,7 +67276,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63373,7 +67307,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63402,7 +67338,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63431,7 +67369,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63460,10 +67400,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63493,8 +67435,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63523,8 +67467,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63553,8 +67499,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63583,8 +67531,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63613,8 +67563,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63643,8 +67595,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63673,10 +67627,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63706,8 +67662,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63736,8 +67694,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63766,8 +67726,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63796,8 +67758,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63826,8 +67790,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63856,8 +67822,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63886,10 +67854,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63919,8 +67889,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63949,8 +67921,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -63979,8 +67953,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64009,8 +67985,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64039,8 +68017,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64069,8 +68049,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64098,10 +68080,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64128,9 +68112,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64160,7 +68146,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64189,7 +68177,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64218,7 +68208,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64247,7 +68239,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64276,7 +68270,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64305,7 +68301,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64334,9 +68332,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64366,7 +68366,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64395,8 +68397,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64425,8 +68429,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64455,8 +68461,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64485,8 +68493,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64515,8 +68525,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64545,10 +68557,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64578,8 +68592,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64608,8 +68624,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64638,8 +68656,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64668,8 +68688,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64698,8 +68720,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64728,8 +68752,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64758,10 +68784,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64791,8 +68819,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64821,8 +68851,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64851,8 +68883,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64881,8 +68915,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64911,8 +68947,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64941,8 +68979,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -64971,10 +69011,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65004,8 +69046,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65034,8 +69078,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65063,10 +69109,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65093,7 +69141,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65122,7 +69172,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65151,7 +69203,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65180,7 +69234,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65209,9 +69265,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65241,7 +69299,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65270,7 +69330,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65299,7 +69361,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65328,7 +69392,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65357,8 +69423,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65387,8 +69455,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65417,10 +69487,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65450,8 +69522,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65480,8 +69554,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65510,8 +69586,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65540,8 +69618,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65570,8 +69650,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65600,8 +69682,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65630,10 +69714,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65663,8 +69749,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65693,8 +69781,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65723,8 +69813,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65753,8 +69845,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65783,8 +69877,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65813,8 +69909,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65843,10 +69941,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65876,8 +69976,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65906,8 +70008,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65936,8 +70040,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65966,8 +70072,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -65995,10 +70103,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66025,7 +70135,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66054,7 +70166,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66083,9 +70197,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66115,7 +70231,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66144,7 +70262,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66173,7 +70293,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66202,7 +70324,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66231,7 +70355,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66260,7 +70386,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66289,10 +70417,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66322,8 +70452,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66352,8 +70484,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66382,8 +70516,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66412,8 +70548,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66442,8 +70580,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66472,8 +70612,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66502,10 +70644,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66535,8 +70679,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66565,8 +70711,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66595,8 +70743,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66625,8 +70775,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66655,8 +70807,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66685,8 +70839,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66715,10 +70871,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66748,8 +70906,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66778,8 +70938,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66808,8 +70970,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66838,8 +71002,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66868,8 +71034,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66898,8 +71066,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66928,10 +71098,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66959,10 +71131,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -66989,7 +71163,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67018,7 +71194,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67047,7 +71225,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67076,7 +71256,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67105,7 +71287,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67134,7 +71318,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67163,9 +71349,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67195,7 +71383,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67224,7 +71414,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67253,8 +71445,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67283,8 +71477,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67313,8 +71509,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67343,8 +71541,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67373,10 +71573,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67406,8 +71608,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67436,8 +71640,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67466,8 +71672,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67496,8 +71704,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67526,8 +71736,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67556,8 +71768,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67586,10 +71800,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67619,8 +71835,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67649,8 +71867,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67679,8 +71899,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67709,8 +71931,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67739,8 +71963,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67769,8 +71995,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67799,10 +72027,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67832,8 +72062,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67862,8 +72094,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67892,8 +72126,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67921,10 +72157,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 0
 ...........\TU/lmss/m/n/9 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67951,7 +72189,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67980,7 +72220,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68009,7 +72251,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68038,9 +72282,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68070,7 +72316,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68099,7 +72347,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68128,7 +72378,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68157,7 +72409,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68186,7 +72440,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68215,8 +72471,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68245,10 +72503,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68278,8 +72538,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68308,8 +72570,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68338,8 +72602,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68368,8 +72634,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68398,8 +72666,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68428,8 +72698,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68458,10 +72730,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68491,8 +72765,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68521,8 +72797,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68551,8 +72829,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68581,8 +72861,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68611,8 +72893,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68641,8 +72925,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68671,10 +72957,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68704,8 +72992,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68734,8 +73024,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68764,8 +73056,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68794,8 +73088,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68824,8 +73120,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68853,10 +73151,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68883,7 +73183,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68912,9 +73214,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68944,7 +73248,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68973,7 +73279,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69002,7 +73310,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69031,7 +73341,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69060,7 +73372,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69089,7 +73403,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69118,9 +73434,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69150,8 +73468,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69180,8 +73500,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69210,8 +73532,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69240,8 +73564,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69270,8 +73596,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69300,8 +73628,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69330,10 +73660,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69363,8 +73695,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69393,8 +73727,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69423,8 +73759,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69453,8 +73791,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69483,8 +73823,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69513,8 +73855,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69543,10 +73887,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69576,8 +73922,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69606,8 +73954,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69636,8 +73986,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69666,8 +74018,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69696,8 +74050,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69726,8 +74082,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69756,10 +74114,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69789,8 +74149,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69818,10 +74180,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69848,7 +74212,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69877,7 +74243,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69906,7 +74274,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69935,7 +74305,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69964,7 +74336,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69993,9 +74367,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70025,7 +74401,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70054,7 +74432,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70083,7 +74463,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70112,8 +74494,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70142,8 +74526,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70172,8 +74558,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70202,10 +74590,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70235,8 +74625,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70265,8 +74657,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70295,8 +74689,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70325,8 +74721,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70355,8 +74753,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70385,8 +74785,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70415,10 +74817,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70448,8 +74852,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70478,8 +74884,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70508,8 +74916,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70538,8 +74948,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70568,8 +74980,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70598,8 +75012,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70628,10 +75044,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70661,8 +75079,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70691,8 +75111,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70721,8 +75143,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70750,10 +75174,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70780,7 +75206,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70809,7 +75237,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70838,7 +75268,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70867,9 +75299,11 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.886+0.0)x4.626, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70899,7 +75333,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70928,7 +75364,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70957,7 +75395,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.886+0.099)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70986,7 +75426,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71015,7 +75457,9 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x4.626, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71044,8 +75488,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71074,10 +75520,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71107,8 +75555,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71137,8 +75587,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71167,8 +75619,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71197,8 +75651,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71227,8 +75683,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71257,8 +75715,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71287,10 +75747,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71320,8 +75782,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 1
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71350,8 +75814,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71380,8 +75846,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71410,8 +75878,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71440,8 +75910,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71470,8 +75942,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.0)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71500,10 +75974,12 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71533,8 +76009,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71563,8 +76041,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.099)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71593,8 +76073,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71623,8 +76105,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 2
 ...........\TU/lmss/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71653,8 +76137,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71683,8 +76169,10 @@ TEST 41: pgfmanual-en-library-calendar-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.084+0.198)x9.25201, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/9 3
 ...........\TU/lmss/m/n/9 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-chains.tlg
+++ b/testfiles-examples/pgfmanual-en-library-chains.tlg
@@ -37,7 +37,9 @@ TEST 1: pgfmanual-en-library-chains-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68,7 +70,9 @@ TEST 1: pgfmanual-en-library-chains-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -99,7 +103,9 @@ TEST 1: pgfmanual-en-library-chains-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -158,7 +164,9 @@ TEST 2: pgfmanual-en-library-chains-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -189,7 +197,9 @@ TEST 2: pgfmanual-en-library-chains-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -220,7 +230,9 @@ TEST 2: pgfmanual-en-library-chains-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -282,7 +294,9 @@ TEST 3: pgfmanual-en-library-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -315,7 +329,9 @@ TEST 3: pgfmanual-en-library-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -348,7 +364,9 @@ TEST 3: pgfmanual-en-library-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -381,7 +399,9 @@ TEST 3: pgfmanual-en-library-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -415,7 +435,9 @@ TEST 3: pgfmanual-en-library-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -449,7 +471,9 @@ TEST 3: pgfmanual-en-library-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -482,7 +506,9 @@ TEST 3: pgfmanual-en-library-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -542,11 +568,13 @@ TEST 4: pgfmanual-en-library-chains-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -579,12 +607,14 @@ TEST 4: pgfmanual-en-library-chains-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x26.70999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 W
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -618,7 +648,9 @@ TEST 4: pgfmanual-en-library-chains-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(1.06+1.93)x2.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ,
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -652,10 +684,12 @@ TEST 4: pgfmanual-en-library-chains-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x16.17, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -689,8 +723,10 @@ TEST 4: pgfmanual-en-library-chains-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+0.11)x6.72, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -751,7 +787,9 @@ TEST 5: pgfmanual-en-library-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -784,7 +822,9 @@ TEST 5: pgfmanual-en-library-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -817,7 +857,9 @@ TEST 5: pgfmanual-en-library-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -853,7 +895,9 @@ TEST 5: pgfmanual-en-library-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -887,7 +931,9 @@ TEST 5: pgfmanual-en-library-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -921,7 +967,9 @@ TEST 5: pgfmanual-en-library-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -957,7 +1005,9 @@ TEST 5: pgfmanual-en-library-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1017,7 +1067,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1047,7 +1099,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1077,7 +1131,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1107,7 +1163,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1137,7 +1195,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1167,7 +1227,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1197,7 +1259,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1227,7 +1291,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1257,7 +1323,9 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1287,8 +1355,10 @@ TEST 6: pgfmanual-en-library-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1358,6 +1428,8 @@ TEST 7: pgfmanual-en-library-chains-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1390,11 +1462,13 @@ TEST 7: pgfmanual-en-library-chains-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x23.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1427,11 +1501,13 @@ TEST 7: pgfmanual-en-library-chains-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x20.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 W
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1491,11 +1567,13 @@ TEST 8: pgfmanual-en-library-chains-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1528,12 +1606,14 @@ TEST 8: pgfmanual-en-library-chains-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x26.70999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 W
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1568,7 +1648,9 @@ TEST 8: pgfmanual-en-library-chains-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(1.06+1.93)x2.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ,
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1601,10 +1683,12 @@ TEST 8: pgfmanual-en-library-chains-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x16.17, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1637,8 +1721,10 @@ TEST 8: pgfmanual-en-library-chains-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+0.11)x6.72, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1736,7 +1822,9 @@ TEST 9: pgfmanual-en-library-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1769,11 +1857,13 @@ TEST 9: pgfmanual-en-library-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1806,12 +1896,14 @@ TEST 9: pgfmanual-en-library-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x26.70999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 W
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1844,7 +1936,9 @@ TEST 9: pgfmanual-en-library-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(1.06+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1944,6 +2038,7 @@ TEST 10: pgfmanual-en-library-chains-10
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.57+2.06)x33.67, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 x
@@ -1958,6 +2053,7 @@ TEST 10: pgfmanual-en-library-chains-10
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 g
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1992,11 +2088,13 @@ TEST 10: pgfmanual-en-library-chains-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2030,12 +2128,14 @@ TEST 10: pgfmanual-en-library-chains-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x26.70999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 W
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2111,10 +2211,12 @@ TEST 10: pgfmanual-en-library-chains-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x16.17, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2165,8 +2267,10 @@ TEST 10: pgfmanual-en-library-chains-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+0.11)x6.72, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2269,12 +2373,14 @@ TEST 11: pgfmanual-en-library-chains-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.22)x26.70999, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 W
 .....................\kern-0.83 (font)
 .....................\TU/lmr/m/n/10 o
 .....................\TU/lmr/m/n/10 r
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 d
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2317,12 +2423,14 @@ TEST 11: pgfmanual-en-library-chains-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+1.94)x24.16, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 p
 .....................\kern0.28 (font)
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 a
 .....................\TU/lmr/m/n/10 c
 .....................\TU/lmr/m/n/10 e
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2367,9 +2475,11 @@ TEST 11: pgfmanual-en-library-chains-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x10.28, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 b
 .....................\kern0.28 (font)
 .....................\TU/lmr/m/n/10 e
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2409,12 +2519,14 @@ TEST 11: pgfmanual-en-library-chains-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x25.84, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 w
 .....................\kern-0.28 (font)
 .....................\TU/lmr/m/n/10 o
 .....................\TU/lmr/m/n/10 u
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 d
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2462,11 +2574,13 @@ TEST 11: pgfmanual-en-library-chains-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.15+2.06)x22.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 g
 .....................\TU/lmr/m/n/10 r
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 a
 .....................\TU/lmr/m/n/10 t
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2507,7 +2621,9 @@ TEST 11: pgfmanual-en-library-chains-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(7.16+0.0)x2.78, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 !
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2684,6 +2800,8 @@ TEST 12: pgfmanual-en-library-chains-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2717,11 +2835,13 @@ TEST 12: pgfmanual-en-library-chains-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x23.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2776,11 +2896,13 @@ TEST 12: pgfmanual-en-library-chains-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x20.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 W
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2838,10 +2960,12 @@ TEST 12: pgfmanual-en-library-chains-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x13.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2946,7 +3070,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2978,7 +3104,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3033,7 +3161,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3083,7 +3213,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3133,7 +3265,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3190,10 +3324,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x6.43404, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 ^^K
 ...........\kern0.03702 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3243,10 +3379,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+1.94444)x6.18402, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 ^^L
 ...........\kern0.52777 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3296,10 +3434,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x5.73285, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 
 ...........\kern0.55554 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3352,7 +3492,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3441,9 +3583,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.65279+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 ?
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3493,9 +3637,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3545,10 +3691,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.0556+3.05562)x6.66667, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(0.0+11.11122)x6.66667, shifted -8.0556, direction TLT
 ............\OMX/cmex/m/n/10 R
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3628,7 +3776,9 @@ TEST 14: pgfmanual-en-library-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3660,7 +3810,9 @@ TEST 14: pgfmanual-en-library-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3723,7 +3875,9 @@ TEST 14: pgfmanual-en-library-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3774,7 +3928,9 @@ TEST 14: pgfmanual-en-library-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3824,7 +3980,9 @@ TEST 14: pgfmanual-en-library-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3877,10 +4035,12 @@ TEST 14: pgfmanual-en-library-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x6.43404, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 ^^K
 ...........\kern0.03702 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3930,10 +4090,12 @@ TEST 14: pgfmanual-en-library-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+1.94444)x6.18402, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 ^^L
 ...........\kern0.52777 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-circuits.tlg
+++ b/testfiles-examples/pgfmanual-en-library-circuits.tlg
@@ -48,6 +48,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -84,6 +86,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -121,6 +125,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -157,6 +163,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -194,6 +202,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -230,6 +240,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -267,6 +279,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -303,6 +317,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -340,6 +356,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -376,6 +394,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -463,6 +483,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -537,6 +559,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -578,12 +602,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.73488, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.73488, direction TLT
 ............\OT1/cmr/m/n/8 3
 ............\OT1/cmr/m/n/8 V
 ............\kern0.11806 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -639,6 +665,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -664,11 +692,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 3
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -758,6 +788,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -783,11 +815,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 4
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -867,6 +901,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -890,11 +926,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 3
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -976,6 +1014,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1015,12 +1055,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.73488, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.73488, direction TLT
 ............\OT1/cmr/m/n/8 8
 ............\OT1/cmr/m/n/8 V
 ............\kern0.11806 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1076,6 +1118,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1101,11 +1145,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 2
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1190,6 +1236,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1213,11 +1261,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 1
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1273,6 +1323,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1303,6 +1355,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(5.46666+1.1111)x9.33612, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/8 S
@@ -1310,6 +1363,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OT1/cmr/m/n/6 1
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1409,9 +1463,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.44444+0.0)x3.0093, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/8 ^^S
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1469,6 +1525,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1494,6 +1552,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x28.174, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/8 R
 ...........\kern0.04965 (italic)
@@ -1503,6 +1562,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OT1/cmr/m/n/8 4
 ...........\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1586,6 +1646,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1625,12 +1687,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.73488, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.73488, direction TLT
 ............\OT1/cmr/m/n/8 8
 ............\OT1/cmr/m/n/8 V
 ............\kern0.11806 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1686,6 +1750,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1711,11 +1777,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 2
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1797,6 +1865,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1820,11 +1890,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 1
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1904,6 +1976,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1927,11 +2001,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 3
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2011,6 +2087,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2036,11 +2114,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 4
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2133,6 +2213,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2207,6 +2289,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2246,12 +2330,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.73488, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.73488, direction TLT
 ............\OT1/cmr/m/n/8 3
 ............\OT1/cmr/m/n/8 V
 ............\kern0.11806 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2307,6 +2393,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2332,11 +2420,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.46666+0.0)x10.38904, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(5.46666+0.0)x10.38904, direction TLT
 ............\OT1/cmr/m/n/8 3
 ............\OT1/cmr/m/n/8 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2446,7 +2536,9 @@ TEST 2: pgfmanual-en-library-circuits-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2527,6 +2619,8 @@ TEST 2: pgfmanual-en-library-circuits-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2580,7 +2674,9 @@ TEST 2: pgfmanual-en-library-circuits-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2638,6 +2734,8 @@ TEST 2: pgfmanual-en-library-circuits-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2702,6 +2800,8 @@ TEST 2: pgfmanual-en-library-circuits-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2755,7 +2855,9 @@ TEST 2: pgfmanual-en-library-circuits-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2917,7 +3019,9 @@ TEST 3: pgfmanual-en-library-circuits-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2993,6 +3097,8 @@ TEST 3: pgfmanual-en-library-circuits-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3006,9 +3112,11 @@ TEST 3: pgfmanual-en-library-circuits-5
 ..................\pdfliteral origin{q }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
 ...................\hbox(4.8611+0.0)x6.13892, direction TLT
+....................\begindir TLT
 ....................\mathon
 ....................\OT1/cmr/m/n/7 &
 ....................\mathoff
+....................\enddir TLT
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
 .................\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3063,7 +3171,9 @@ TEST 3: pgfmanual-en-library-circuits-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3113,6 +3223,8 @@ TEST 3: pgfmanual-en-library-circuits-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3126,10 +3238,12 @@ TEST 3: pgfmanual-en-library-circuits-5
 ..................\pdfliteral origin{q }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
 ...................\hbox(4.79828+1.29828)x10.23615, direction TLT
+....................\begindir TLT
 ....................\mathon
 ....................\OMS/cmsy/m/n/7 ^^U
 ....................\OT1/cmr/m/n/7 1
 ....................\mathoff
+....................\enddir TLT
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
 .................\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3191,6 +3305,8 @@ TEST 3: pgfmanual-en-library-circuits-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3204,9 +3320,11 @@ TEST 3: pgfmanual-en-library-circuits-5
 ..................\pdfliteral origin{q }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
 ...................\hbox(4.8611+0.0)x6.13892, direction TLT
+....................\begindir TLT
 ....................\mathon
 ....................\OT1/cmr/m/n/7 &
 ....................\mathoff
+....................\enddir TLT
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
 .................\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3261,7 +3379,9 @@ TEST 3: pgfmanual-en-library-circuits-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3440,6 +3560,8 @@ TEST 4: pgfmanual-en-library-circuits-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3530,6 +3652,8 @@ TEST 4: pgfmanual-en-library-circuits-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3636,6 +3760,8 @@ TEST 5: pgfmanual-en-library-circuits-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3696,6 +3822,8 @@ TEST 5: pgfmanual-en-library-circuits-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3784,6 +3912,8 @@ TEST 6: pgfmanual-en-library-circuits-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3849,6 +3979,8 @@ TEST 6: pgfmanual-en-library-circuits-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3913,6 +4045,8 @@ TEST 6: pgfmanual-en-library-circuits-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3978,6 +4112,8 @@ TEST 6: pgfmanual-en-library-circuits-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4061,6 +4197,8 @@ TEST 7: pgfmanual-en-library-circuits-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4096,8 +4234,10 @@ TEST 7: pgfmanual-en-library-circuits-11
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4170,6 +4310,8 @@ TEST 8: pgfmanual-en-library-circuits-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4210,6 +4352,8 @@ TEST 8: pgfmanual-en-library-circuits-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4304,6 +4448,8 @@ TEST 9: pgfmanual-en-library-circuits-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4356,6 +4502,8 @@ TEST 9: pgfmanual-en-library-circuits-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4435,6 +4583,8 @@ TEST 10: pgfmanual-en-library-circuits-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4498,6 +4648,8 @@ TEST 10: pgfmanual-en-library-circuits-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4605,6 +4757,8 @@ TEST 11: pgfmanual-en-library-circuits-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4690,6 +4844,8 @@ TEST 12: pgfmanual-en-library-circuits-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4775,6 +4931,8 @@ TEST 13: pgfmanual-en-library-circuits-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4860,6 +5018,8 @@ TEST 14: pgfmanual-en-library-circuits-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4921,6 +5081,8 @@ TEST 15: pgfmanual-en-library-circuits-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4951,12 +5113,14 @@ TEST 15: pgfmanual-en-library-circuits-19
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\OT1/cmr/m/n/10 
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5018,6 +5182,8 @@ TEST 16: pgfmanual-en-library-circuits-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5048,12 +5214,14 @@ TEST 16: pgfmanual-en-library-circuits-20
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\OT1/cmr/m/n/10 
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5092,6 +5260,8 @@ TEST 16: pgfmanual-en-library-circuits-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5122,6 +5292,7 @@ TEST 16: pgfmanual-en-library-circuits-20
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+1.49998)x12.07903, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 R
@@ -5129,6 +5300,7 @@ TEST 16: pgfmanual-en-library-circuits-20
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5204,6 +5376,8 @@ TEST 17: pgfmanual-en-library-circuits-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5234,12 +5408,14 @@ TEST 17: pgfmanual-en-library-circuits-21
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\OT1/cmr/m/n/10 
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5271,6 +5447,7 @@ TEST 17: pgfmanual-en-library-circuits-21
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+1.49998)x12.07903, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 R
@@ -5278,6 +5455,7 @@ TEST 17: pgfmanual-en-library-circuits-21
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5343,6 +5521,8 @@ TEST 17: pgfmanual-en-library-circuits-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5371,12 +5551,14 @@ TEST 17: pgfmanual-en-library-circuits-21
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 4
 ...........\OT1/cmr/m/n/10 
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5408,6 +5590,7 @@ TEST 17: pgfmanual-en-library-circuits-21
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+1.49998)x12.07903, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 R
@@ -5415,6 +5598,7 @@ TEST 17: pgfmanual-en-library-circuits-21
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5511,6 +5695,8 @@ TEST 18: pgfmanual-en-library-circuits-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5541,12 +5727,14 @@ TEST 18: pgfmanual-en-library-circuits-22
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\OT1/cmr/m/n/10 
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5609,6 +5797,8 @@ TEST 18: pgfmanual-en-library-circuits-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5637,12 +5827,14 @@ TEST 18: pgfmanual-en-library-circuits-22
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 4
 ...........\OT1/cmr/m/n/10 
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5739,6 +5931,8 @@ TEST 19: pgfmanual-en-library-circuits-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5769,12 +5963,14 @@ TEST 19: pgfmanual-en-library-circuits-23
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\OT1/cmr/m/n/10 
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5837,6 +6033,8 @@ TEST 19: pgfmanual-en-library-circuits-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5867,12 +6065,14 @@ TEST 19: pgfmanual-en-library-circuits-23
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 4
 ...........\OT1/cmr/m/n/10 
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5974,6 +6174,8 @@ TEST 20: pgfmanual-en-library-circuits-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5999,11 +6201,13 @@ TEST 20: pgfmanual-en-library-circuits-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x12.77782, direction TLT
 ............\OT1/cmr/m/n/10 3
 ............\OT1/cmr/m/n/10 O
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6100,6 +6304,8 @@ TEST 21: pgfmanual-en-library-circuits-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6189,6 +6395,8 @@ TEST 22: pgfmanual-en-library-circuits-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6274,6 +6482,8 @@ TEST 22: pgfmanual-en-library-circuits-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6400,6 +6610,8 @@ TEST 23: pgfmanual-en-library-circuits-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6425,11 +6637,13 @@ TEST 23: pgfmanual-en-library-circuits-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x12.22224, direction TLT
 ............\OT1/cmr/m/n/10 5
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6494,6 +6708,8 @@ TEST 23: pgfmanual-en-library-circuits-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6519,11 +6735,13 @@ TEST 23: pgfmanual-en-library-circuits-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x12.22224, direction TLT
 ............\OT1/cmr/m/n/10 5
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6630,6 +6848,8 @@ TEST 24: pgfmanual-en-library-circuits-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6693,8 +6913,10 @@ TEST 24: pgfmanual-en-library-circuits-29
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6799,6 +7021,8 @@ TEST 25: pgfmanual-en-library-circuits-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6861,6 +7085,8 @@ TEST 25: pgfmanual-en-library-circuits-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6966,6 +7192,8 @@ TEST 26: pgfmanual-en-library-circuits-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7024,6 +7252,8 @@ TEST 26: pgfmanual-en-library-circuits-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7130,6 +7360,8 @@ TEST 27: pgfmanual-en-library-circuits-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7173,6 +7405,8 @@ TEST 27: pgfmanual-en-library-circuits-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7271,6 +7505,8 @@ TEST 28: pgfmanual-en-library-circuits-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7316,6 +7552,8 @@ TEST 28: pgfmanual-en-library-circuits-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7404,6 +7642,8 @@ TEST 29: pgfmanual-en-library-circuits-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7482,6 +7722,8 @@ TEST 29: pgfmanual-en-library-circuits-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7542,6 +7784,8 @@ TEST 29: pgfmanual-en-library-circuits-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7644,7 +7888,9 @@ TEST 30: pgfmanual-en-library-circuits-37
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7728,6 +7974,8 @@ TEST 30: pgfmanual-en-library-circuits-37
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7741,11 +7989,13 @@ TEST 30: pgfmanual-en-library-circuits-37
 ..................\pdfliteral origin{q }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
 ...................\hbox(4.8611+0.0)x6.13892, direction TLT
+....................\begindir TLT
 ....................\pdfcolorstack 0 push {0 g 0 G}
 ....................\mathon
 ....................\OT1/cmr/m/n/7 &
 ....................\mathoff
 ....................\pdfcolorstack 0 pop
+....................\enddir TLT
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
 .................\glue 0.0 plus 1.0fil minus 1.0fil
@@ -7805,7 +8055,9 @@ TEST 30: pgfmanual-en-library-circuits-37
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7863,6 +8115,8 @@ TEST 30: pgfmanual-en-library-circuits-37
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7876,12 +8130,14 @@ TEST 30: pgfmanual-en-library-circuits-37
 ..................\pdfliteral origin{q }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
 ...................\hbox(4.79828+1.29828)x10.23615, direction TLT
+....................\begindir TLT
 ....................\pdfcolorstack 0 push {0 g 0 G}
 ....................\mathon
 ....................\OMS/cmsy/m/n/7 ^^U
 ....................\OT1/cmr/m/n/7 1
 ....................\mathoff
 ....................\pdfcolorstack 0 pop
+....................\enddir TLT
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
 .................\glue 0.0 plus 1.0fil minus 1.0fil
@@ -7956,6 +8212,8 @@ TEST 30: pgfmanual-en-library-circuits-37
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7969,11 +8227,13 @@ TEST 30: pgfmanual-en-library-circuits-37
 ..................\pdfliteral origin{q }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
 ...................\hbox(4.8611+0.0)x6.13892, direction TLT
+....................\begindir TLT
 ....................\pdfcolorstack 0 push {0 g 0 G}
 ....................\mathon
 ....................\OT1/cmr/m/n/7 &
 ....................\mathoff
 ....................\pdfcolorstack 0 pop
+....................\enddir TLT
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
 .................\glue 0.0 plus 1.0fil minus 1.0fil
@@ -8033,7 +8293,9 @@ TEST 30: pgfmanual-en-library-circuits-37
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8195,7 +8457,9 @@ TEST 31: pgfmanual-en-library-circuits-39
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8281,6 +8545,8 @@ TEST 31: pgfmanual-en-library-circuits-39
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8334,7 +8600,9 @@ TEST 31: pgfmanual-en-library-circuits-39
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8396,6 +8664,8 @@ TEST 31: pgfmanual-en-library-circuits-39
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8464,6 +8734,8 @@ TEST 31: pgfmanual-en-library-circuits-39
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8517,7 +8789,9 @@ TEST 31: pgfmanual-en-library-circuits-39
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8654,9 +8928,11 @@ TEST 32: pgfmanual-en-library-circuits-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8670,9 +8946,11 @@ TEST 32: pgfmanual-en-library-circuits-40
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.8611+0.0)x6.13892, direction TLT
+..........\begindir TLT
 ..........\mathon
 ..........\OT1/cmr/m/n/7 &
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -8734,9 +9012,11 @@ TEST 33: pgfmanual-en-library-circuits-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8770,6 +9050,8 @@ TEST 33: pgfmanual-en-library-circuits-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8795,9 +9077,11 @@ TEST 33: pgfmanual-en-library-circuits-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8874,6 +9158,8 @@ TEST 34: pgfmanual-en-library-circuits-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8887,9 +9173,11 @@ TEST 34: pgfmanual-en-library-circuits-42
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.8611+0.0)x6.13892, direction TLT
+..........\begindir TLT
 ..........\mathon
 ..........\OT1/cmr/m/n/7 &
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -8990,6 +9278,8 @@ TEST 35: pgfmanual-en-library-circuits-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9003,9 +9293,11 @@ TEST 35: pgfmanual-en-library-circuits-43
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94444+0.0)x7.7778, direction TLT
+..........\begindir TLT
 ..........\mathon
 ..........\OT1/cmr/m/n/10 &
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -9107,6 +9399,8 @@ TEST 36: pgfmanual-en-library-circuits-44
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9217,7 +9511,9 @@ TEST 37: pgfmanual-en-library-circuits-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9269,7 +9565,9 @@ TEST 37: pgfmanual-en-library-circuits-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9376,7 +9674,9 @@ TEST 38: pgfmanual-en-library-circuits-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9390,9 +9690,11 @@ TEST 38: pgfmanual-en-library-circuits-46
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94444+0.0)x7.7778, direction TLT
+..........\begindir TLT
 ..........\mathon
 ..........\OT1/cmr/m/n/10 &
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -9434,7 +9736,9 @@ TEST 38: pgfmanual-en-library-circuits-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9448,9 +9752,11 @@ TEST 38: pgfmanual-en-library-circuits-46
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94444+0.0)x7.7778, direction TLT
+..........\begindir TLT
 ..........\mathon
 ..........\OT1/cmr/m/n/10 &
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -9672,8 +9978,10 @@ TEST 39: pgfmanual-en-library-circuits-47
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9981,6 +10289,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x110.9945, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 N
 ...........\TU/lmr/m/n/24.88 a
@@ -9993,6 +10302,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10030,6 +10340,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10041,6 +10352,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10078,6 +10390,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10087,6 +10400,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10121,6 +10435,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10128,6 +10443,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10165,6 +10481,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10173,6 +10490,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10208,6 +10526,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10221,6 +10540,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10258,6 +10578,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10271,6 +10592,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10308,6 +10630,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10317,6 +10640,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10354,6 +10678,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10368,6 +10693,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10403,6 +10729,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10417,6 +10744,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10454,6 +10782,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10464,6 +10793,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10501,6 +10831,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10511,6 +10842,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10548,6 +10880,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10557,6 +10890,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10594,6 +10928,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10603,6 +10938,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10640,6 +10976,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10655,6 +10992,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10692,6 +11030,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10707,6 +11046,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10744,6 +11084,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10759,6 +11100,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10796,6 +11138,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10811,6 +11154,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10848,6 +11192,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10859,6 +11204,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10896,6 +11242,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10908,6 +11255,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10945,6 +11293,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10957,6 +11306,7 @@ TEST 40: pgfmanual-en-library-circuits-48
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11020,6 +11370,8 @@ TEST 41: pgfmanual-en-library-circuits-49
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11033,11 +11385,13 @@ TEST 41: pgfmanual-en-library-circuits-49
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+1.35971)x15.55553, direction TLT
+..........\begindir TLT
 ..........\mathon
 ..........\OMS/cmsy/m/n/10 ^^U
 ..........\glue(\thickmuskip) 2.77771 plus 2.77771
 ..........\OT1/cmr/m/n/10 1
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -11072,6 +11426,8 @@ TEST 41: pgfmanual-en-library-circuits-49
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11085,11 +11441,13 @@ TEST 41: pgfmanual-en-library-circuits-49
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+1.35971)x15.55553, direction TLT
+..........\begindir TLT
 ..........\mathon
 ..........\OMS/cmsy/m/n/10 ^^U
 ..........\glue(\thickmuskip) 2.77771 plus 2.77771
 ..........\OT1/cmr/m/n/10 1
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -11197,6 +11555,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x110.9945, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 N
 ...........\TU/lmr/m/n/24.88 a
@@ -11209,6 +11568,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11222,9 +11582,11 @@ TEST 42: pgfmanual-en-library-circuits-50
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(17.66481+0.39809)x17.9136, direction TLT
+..........\begindir TLT
 ..........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ..........\TU/lmr/m/n/24.88 &
 ..........\pdfcolorstack 0 pop
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -11269,6 +11631,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11280,6 +11643,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11317,6 +11681,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11326,6 +11691,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11361,6 +11727,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11368,6 +11735,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11405,6 +11773,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11413,6 +11782,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11448,6 +11818,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11461,6 +11832,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11498,6 +11870,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11511,6 +11884,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11548,6 +11922,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11557,6 +11932,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11594,6 +11970,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11608,6 +11985,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11643,6 +12021,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11657,6 +12036,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11694,6 +12074,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11704,6 +12085,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11741,6 +12123,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11751,6 +12134,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11788,6 +12172,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11797,6 +12182,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11834,6 +12220,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11843,6 +12230,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11880,6 +12268,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11895,6 +12284,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11932,6 +12322,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11947,6 +12338,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11984,6 +12376,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11999,6 +12392,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12036,6 +12430,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12051,6 +12446,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12088,6 +12484,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12099,6 +12496,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12136,6 +12534,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12148,6 +12547,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12185,6 +12585,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12197,6 +12598,7 @@ TEST 42: pgfmanual-en-library-circuits-50
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12255,6 +12657,8 @@ TEST 43: pgfmanual-en-library-circuits-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12315,6 +12719,8 @@ TEST 44: pgfmanual-en-library-circuits-52
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12340,11 +12746,13 @@ TEST 44: pgfmanual-en-library-circuits-52
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x12.22224, direction TLT
 ............\OT1/cmr/m/n/10 5
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12405,6 +12813,8 @@ TEST 45: pgfmanual-en-library-circuits-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12430,11 +12840,13 @@ TEST 45: pgfmanual-en-library-circuits-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x12.22224, direction TLT
 ............\OT1/cmr/m/n/10 5
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12501,6 +12913,8 @@ TEST 46: pgfmanual-en-library-circuits-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12524,11 +12938,13 @@ TEST 46: pgfmanual-en-library-circuits-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x12.22224, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x12.22224, direction TLT
 ............\OT1/cmr/m/n/10 5
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12562,6 +12978,8 @@ TEST 46: pgfmanual-en-library-circuits-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12587,6 +13005,7 @@ TEST 46: pgfmanual-en-library-circuits-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x22.50006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.94444+0.0)x22.50006, direction TLT
 ............\OT1/cmr/m/n/10 1
@@ -12594,6 +13013,7 @@ TEST 46: pgfmanual-en-library-circuits-54
 ............\OT1/cmr/m/n/10 k
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12675,8 +13095,10 @@ TEST 47: pgfmanual-en-library-circuits-55
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12739,6 +13161,8 @@ TEST 47: pgfmanual-en-library-circuits-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12762,12 +13186,14 @@ TEST 47: pgfmanual-en-library-circuits-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+1.94444)x18.24773, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+1.94444)x18.24773, direction TLT
 ............\OT1/cmr/m/n/10 2
 ............\OML/cmm/m/it/10 ^^V
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12867,6 +13293,8 @@ TEST 48: pgfmanual-en-library-circuits-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12890,12 +13318,14 @@ TEST 48: pgfmanual-en-library-circuits-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x21.38893, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x21.38893, direction TLT
 ............\OT1/cmr/m/n/10 5
 ............\OT1/cmr/m/n/10 M
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12991,6 +13421,8 @@ TEST 49: pgfmanual-en-library-circuits-57
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13016,12 +13448,14 @@ TEST 49: pgfmanual-en-library-circuits-57
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x21.38893, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x21.38893, direction TLT
 ............\OT1/cmr/m/n/10 5
 ............\OT1/cmr/m/n/10 M
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13117,6 +13551,8 @@ TEST 50: pgfmanual-en-library-circuits-58
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13140,12 +13576,14 @@ TEST 50: pgfmanual-en-library-circuits-58
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x21.38893, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.83331+0.0)x21.38893, direction TLT
 ............\OT1/cmr/m/n/10 5
 ............\OT1/cmr/m/n/10 M
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13207,6 +13645,8 @@ TEST 50: pgfmanual-en-library-circuits-58
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13232,6 +13672,7 @@ TEST 50: pgfmanual-en-library-circuits-58
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x16.0556, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.94444+0.0)x16.0556, direction TLT
 ............\OT1/cmr/m/n/10 6
@@ -13239,6 +13680,7 @@ TEST 50: pgfmanual-en-library-circuits-58
 ............\kern0.77779 (italic)
 ............\OT1/cmr/m/n/10 
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13360,6 +13802,8 @@ TEST 51: pgfmanual-en-library-circuits-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13508,6 +13952,8 @@ TEST 52: pgfmanual-en-library-circuits-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13561,6 +14007,7 @@ TEST 52: pgfmanual-en-library-circuits-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x38.9, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
@@ -13571,6 +14018,7 @@ TEST 52: pgfmanual-en-library-circuits-60
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13666,6 +14114,8 @@ TEST 52: pgfmanual-en-library-circuits-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13719,6 +14169,7 @@ TEST 52: pgfmanual-en-library-circuits-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x26.42, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 e
@@ -13728,6 +14179,7 @@ TEST 52: pgfmanual-en-library-circuits-60
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13753,6 +14205,7 @@ TEST 52: pgfmanual-en-library-circuits-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x41.17, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 s
@@ -13764,6 +14217,7 @@ TEST 52: pgfmanual-en-library-circuits-60
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13889,6 +14343,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13900,6 +14355,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13935,6 +14391,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13942,6 +14399,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13980,6 +14438,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13990,6 +14449,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14028,6 +14488,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14038,6 +14499,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14073,6 +14535,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14082,6 +14545,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14120,6 +14584,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14129,6 +14594,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14166,6 +14632,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14181,6 +14648,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14219,6 +14687,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14234,6 +14703,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14271,6 +14741,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14286,6 +14757,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14324,6 +14796,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14339,6 +14812,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14375,6 +14849,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14385,6 +14860,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14422,6 +14898,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14433,6 +14910,7 @@ TEST 53: pgfmanual-en-library-circuits-62
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14539,6 +15017,7 @@ TEST 54: pgfmanual-en-library-circuits-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14549,6 +15028,7 @@ TEST 54: pgfmanual-en-library-circuits-63
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14587,6 +15067,7 @@ TEST 54: pgfmanual-en-library-circuits-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14597,6 +15078,7 @@ TEST 54: pgfmanual-en-library-circuits-63
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14634,6 +15116,7 @@ TEST 54: pgfmanual-en-library-circuits-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14645,6 +15128,7 @@ TEST 54: pgfmanual-en-library-circuits-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14681,6 +15165,7 @@ TEST 54: pgfmanual-en-library-circuits-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14691,6 +15176,7 @@ TEST 54: pgfmanual-en-library-circuits-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14768,6 +15254,7 @@ TEST 55: pgfmanual-en-library-circuits-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x50.03, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -14780,6 +15267,7 @@ TEST 55: pgfmanual-en-library-circuits-64
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14869,8 +15357,10 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14909,6 +15399,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14920,6 +15411,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14955,6 +15447,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14962,6 +15455,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15000,6 +15494,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15010,6 +15505,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15048,6 +15544,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15058,6 +15555,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15093,6 +15591,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15102,6 +15601,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15140,6 +15640,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15149,6 +15650,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15186,6 +15688,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15201,6 +15704,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15239,6 +15743,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15254,6 +15759,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15291,6 +15797,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15306,6 +15813,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15344,6 +15852,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15359,6 +15868,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15395,6 +15905,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15405,6 +15916,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15442,6 +15954,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15453,6 +15966,7 @@ TEST 56: pgfmanual-en-library-circuits-65
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15546,6 +16060,8 @@ TEST 57: pgfmanual-en-library-circuits-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15650,8 +16166,10 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15690,6 +16208,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15701,6 +16220,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15736,6 +16256,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15743,6 +16264,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15781,6 +16303,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15791,6 +16314,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15829,6 +16353,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15839,6 +16364,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15874,6 +16400,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15883,6 +16410,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15921,6 +16449,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15930,6 +16459,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15967,6 +16497,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15982,6 +16513,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16020,6 +16552,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16035,6 +16568,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16072,6 +16606,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16087,6 +16622,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16125,6 +16661,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16140,6 +16677,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16176,6 +16714,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16186,6 +16725,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16223,6 +16763,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16234,6 +16775,7 @@ TEST 58: pgfmanual-en-library-circuits-67
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16313,8 +16855,10 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16353,6 +16897,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16364,6 +16909,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16399,6 +16945,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16406,6 +16953,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16444,6 +16992,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16454,6 +17003,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16492,6 +17042,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16502,6 +17053,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16537,6 +17089,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16546,6 +17099,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16584,6 +17138,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16593,6 +17148,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16630,6 +17186,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16645,6 +17202,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16683,6 +17241,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16698,6 +17257,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16735,6 +17295,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16750,6 +17311,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16788,6 +17350,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16803,6 +17366,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16839,6 +17403,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16849,6 +17414,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16886,6 +17452,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16897,6 +17464,7 @@ TEST 59: pgfmanual-en-library-circuits-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16970,8 +17538,10 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17009,6 +17579,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17020,6 +17591,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17055,6 +17627,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17062,6 +17635,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17100,6 +17674,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17110,6 +17685,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17148,6 +17724,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17158,6 +17735,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17193,6 +17771,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17202,6 +17781,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17240,6 +17820,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17249,6 +17830,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17286,6 +17868,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17301,6 +17884,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17339,6 +17923,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17354,6 +17939,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17391,6 +17977,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17406,6 +17993,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17444,6 +18032,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17459,6 +18048,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17495,6 +18085,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17505,6 +18096,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17542,6 +18134,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17553,6 +18146,7 @@ TEST 60: pgfmanual-en-library-circuits-69
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17628,8 +18222,10 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17668,6 +18264,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17679,6 +18276,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17714,6 +18312,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17721,6 +18320,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17759,6 +18359,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17769,6 +18370,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17807,6 +18409,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17817,6 +18420,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17852,6 +18456,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17861,6 +18466,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17899,6 +18505,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17908,6 +18515,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17945,6 +18553,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17960,6 +18569,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17998,6 +18608,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18013,6 +18624,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18050,6 +18662,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18065,6 +18678,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18103,6 +18717,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18118,6 +18733,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18154,6 +18770,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18164,6 +18781,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18201,6 +18819,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18212,6 +18831,7 @@ TEST 61: pgfmanual-en-library-circuits-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18287,8 +18907,10 @@ TEST 62: pgfmanual-en-library-circuits-71
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18367,8 +18989,10 @@ TEST 63: pgfmanual-en-library-circuits-72
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18436,8 +19060,10 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18475,6 +19101,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18486,6 +19113,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18521,6 +19149,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18528,6 +19157,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18566,6 +19196,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18576,6 +19207,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18614,6 +19246,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18624,6 +19257,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18659,6 +19293,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18668,6 +19303,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18706,6 +19342,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18715,6 +19352,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18752,6 +19390,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18767,6 +19406,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18805,6 +19445,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18820,6 +19461,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18857,6 +19499,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18872,6 +19515,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18910,6 +19554,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18925,6 +19570,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18961,6 +19607,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18971,6 +19618,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19008,6 +19656,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19019,6 +19668,7 @@ TEST 64: pgfmanual-en-library-circuits-73
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19097,8 +19747,10 @@ TEST 65: pgfmanual-en-library-circuits-74
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19172,8 +19824,10 @@ TEST 66: pgfmanual-en-library-circuits-75
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-decorations.tlg
+++ b/testfiles-examples/pgfmanual-en-library-decorations.tlg
@@ -1987,7 +1987,9 @@ TEST 8: pgfmanual-en-library-decorations-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2019,7 +2021,9 @@ TEST 8: pgfmanual-en-library-decorations-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5412,6 +5416,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(3.075+0.055)x21.28499, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/5 m
 ...........\TU/lmr/m/n/5 o
@@ -5422,6 +5427,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ...........\TU/lmr/m/n/5 t
 ...........\TU/lmr/m/n/5 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5467,6 +5473,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(3.47+0.055)x16.95, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\TU/lmr/m/n/5 l
 ...........\TU/lmr/m/n/5 i
@@ -5475,6 +5482,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ...........\TU/lmr/m/n/5 t
 ...........\TU/lmr/m/n/5 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5514,6 +5522,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ..........\pdfliteral origin{0 0.75 0 RG }
 ..........\pdfliteral origin{0 0.75 0 rg }
 ..........\hbox(3.075+0.055)x22.08499, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.75 0 rg 0 0.75 0 RG}
 ...........\TU/lmr/m/n/5 c
 ...........\TU/lmr/m/n/5 u
@@ -5524,6 +5533,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ...........\TU/lmr/m/n/5 t
 ...........\TU/lmr/m/n/5 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5562,6 +5572,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ..........\pdfliteral origin{0 0.75 0 RG }
 ..........\pdfliteral origin{0 0.75 0 rg }
 ..........\hbox(3.075+0.055)x22.08499, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.75 0 rg 0 0.75 0 RG}
 ...........\TU/lmr/m/n/5 c
 ...........\TU/lmr/m/n/5 u
@@ -5572,6 +5583,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ...........\TU/lmr/m/n/5 t
 ...........\TU/lmr/m/n/5 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5612,6 +5624,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(3.47+0.97)x27.88998, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\TU/lmr/m/n/5 c
 ...........\TU/lmr/m/n/5 l
@@ -5623,6 +5636,7 @@ TEST 19: pgfmanual-en-library-decorations-19
 ...........\TU/lmr/m/n/5 t
 ...........\TU/lmr/m/n/5 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5700,8 +5714,10 @@ TEST 20: pgfmanual-en-library-decorations-20
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5756,8 +5772,10 @@ TEST 20: pgfmanual-en-library-decorations-20
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6337,11 +6355,13 @@ TEST 23: pgfmanual-en-library-decorations-24
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6380,11 +6400,13 @@ TEST 23: pgfmanual-en-library-decorations-24
 ..........\pdfliteral origin{0 1 0 RG }
 ..........\pdfliteral origin{0 1 0 rg }
 ..........\hbox(6.94+0.11)x16.67, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6421,6 +6443,7 @@ TEST 23: pgfmanual-en-library-decorations-24
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(7.05+0.11)x60.3, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
@@ -6435,6 +6458,7 @@ TEST 23: pgfmanual-en-library-decorations-24
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6557,9 +6581,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6595,6 +6621,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x19.46533, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
 ...........\kern1.0764 (italic)
@@ -6602,6 +6629,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/10 x
 ...........\OT1/cmr/m/n/10 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6667,6 +6695,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(7.5+2.5)x38.51382, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -6680,6 +6709,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6759,6 +6789,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(7.5+2.5)x52.45825, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -6778,6 +6809,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6859,6 +6891,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(8.44843+3.44841)x52.64998, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -6889,6 +6922,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OML/cmm/m/it/7 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7275,6 +7309,8 @@ TEST 26: pgfmanual-en-library-decorations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7318,6 +7354,8 @@ TEST 26: pgfmanual-en-library-decorations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7361,6 +7399,8 @@ TEST 26: pgfmanual-en-library-decorations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7404,6 +7444,8 @@ TEST 26: pgfmanual-en-library-decorations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7446,6 +7488,8 @@ TEST 26: pgfmanual-en-library-decorations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7486,6 +7530,8 @@ TEST 26: pgfmanual-en-library-decorations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7526,6 +7572,8 @@ TEST 26: pgfmanual-en-library-decorations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7566,6 +7614,8 @@ TEST 26: pgfmanual-en-library-decorations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7696,7 +7746,9 @@ TEST 27: pgfmanual-en-library-decorations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7738,7 +7790,9 @@ TEST 27: pgfmanual-en-library-decorations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7780,7 +7834,9 @@ TEST 27: pgfmanual-en-library-decorations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7822,7 +7878,9 @@ TEST 27: pgfmanual-en-library-decorations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7863,7 +7921,9 @@ TEST 27: pgfmanual-en-library-decorations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7902,7 +7962,9 @@ TEST 27: pgfmanual-en-library-decorations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7941,7 +8003,9 @@ TEST 27: pgfmanual-en-library-decorations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7980,7 +8044,9 @@ TEST 27: pgfmanual-en-library-decorations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8127,6 +8193,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(3.33+0.97)x15.285, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/5 0
 ...........\TU/lmr/m/n/5 .
@@ -8134,6 +8201,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ...........\TU/lmr/m/n/5 p
 ...........\TU/lmr/m/n/5 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8174,6 +8242,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(3.385+0.97)x18.69, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/5 4
 ...........\TU/lmr/m/n/5 0
@@ -8182,6 +8251,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ...........\TU/lmr/m/n/5 p
 ...........\TU/lmr/m/n/5 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8222,6 +8292,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(3.33+0.97)x18.69, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/5 8
 ...........\TU/lmr/m/n/5 0
@@ -8230,6 +8301,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ...........\TU/lmr/m/n/5 p
 ...........\TU/lmr/m/n/5 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8270,6 +8342,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(3.33+0.97)x22.095, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 2
@@ -8279,6 +8352,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ...........\TU/lmr/m/n/5 p
 ...........\TU/lmr/m/n/5 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8319,6 +8393,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(3.33+0.97)x22.095, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 6
@@ -8328,6 +8403,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ...........\TU/lmr/m/n/5 p
 ...........\TU/lmr/m/n/5 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8368,6 +8444,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(3.33+0.97)x22.095, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 0
@@ -8377,6 +8454,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ...........\TU/lmr/m/n/5 p
 ...........\TU/lmr/m/n/5 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8417,6 +8495,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(3.385+0.97)x35.715, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 2
@@ -8430,6 +8509,7 @@ TEST 28: pgfmanual-en-library-decorations-29
 ...........\TU/lmr/m/n/5 p
 ...........\TU/lmr/m/n/5 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8552,6 +8632,7 @@ TEST 29: pgfmanual-en-library-decorations-30
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.94+2.05)x37.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
@@ -8563,6 +8644,7 @@ TEST 29: pgfmanual-en-library-decorations-30
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8690,6 +8772,7 @@ TEST 30: pgfmanual-en-library-decorations-31
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+2.05)x37.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
@@ -8701,6 +8784,7 @@ TEST 30: pgfmanual-en-library-decorations-31
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8841,11 +8925,13 @@ TEST 31: pgfmanual-en-library-decorations-32
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18159,9 +18245,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.05+0.22)x5.56, direction TLT
 ........\hbox(7.05+0.22)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 S
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18175,9 +18263,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18191,9 +18281,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x8.33, direction TLT
 ........\hbox(4.42+0.0)x8.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 m
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18207,9 +18299,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18223,9 +18317,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18239,9 +18335,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18255,9 +18353,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18271,9 +18371,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18287,9 +18389,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18303,9 +18407,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18319,9 +18425,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18335,9 +18443,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18351,9 +18461,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+0.0)x5.28, direction TLT
 ........\hbox(4.31+0.0)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 x
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18367,9 +18479,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18383,9 +18497,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18399,9 +18515,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18415,9 +18533,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18431,9 +18551,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18447,9 +18569,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18463,9 +18587,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18479,9 +18605,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18495,9 +18623,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18511,9 +18641,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18527,9 +18659,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 r
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18543,9 +18677,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18559,9 +18695,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18575,9 +18713,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18591,9 +18731,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18607,9 +18749,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18623,9 +18767,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18639,9 +18785,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18655,9 +18803,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18671,9 +18821,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x3.94, direction TLT
 ........\hbox(4.48+0.11)x3.94, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 s
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18687,9 +18839,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18703,9 +18857,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+2.05)x5.28, direction TLT
 ........\hbox(4.31+2.05)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 y
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18719,9 +18875,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18735,9 +18893,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18751,9 +18911,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18767,9 +18929,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18783,9 +18947,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18799,9 +18965,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18815,9 +18983,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18831,9 +19001,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18847,9 +19019,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 r
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18863,9 +19037,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+0.11)x5.28, direction TLT
 ........\hbox(4.31+0.11)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 v
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18879,9 +19055,11 @@ TEST 49: pgfmanual-en-library-decorations-50
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18964,9 +19142,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18980,9 +19160,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -18996,9 +19178,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 b
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19012,9 +19196,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19028,9 +19214,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19044,9 +19232,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19060,11 +19250,13 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 g
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19078,11 +19270,13 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 r
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19096,11 +19290,13 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 e
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19114,11 +19310,13 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 e
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19132,11 +19330,13 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 n
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19150,9 +19350,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19166,9 +19368,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+2.05)x3.06, direction TLT
 ........\hbox(6.57+2.05)x3.06, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 j
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19182,9 +19386,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19198,9 +19404,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19214,9 +19422,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19230,9 +19440,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+2.05)x5.28, direction TLT
 ........\hbox(4.31+2.05)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 y
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19246,9 +19458,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19262,9 +19476,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19278,9 +19494,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19294,9 +19512,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19310,9 +19530,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19326,9 +19548,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19342,9 +19566,11 @@ TEST 50: pgfmanual-en-library-decorations-51
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(1.06+0.0)x2.78, direction TLT
 ........\hbox(1.06+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 .
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19425,9 +19651,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19441,9 +19669,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19457,9 +19687,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(8.328+0.12)x6.528, direction TLT
 ........\hbox(8.328+0.12)x6.528, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/12 b
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19473,9 +19705,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.836+0.0)x3.264, direction TLT
 ........\hbox(7.836+0.0)x3.264, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/12 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19489,9 +19723,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(5.424+2.46)x5.88, direction TLT
 ........\hbox(5.424+2.46)x5.88, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/12 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19505,9 +19741,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.912, direction TLT
 ........\hbox(0.0+0.0)x3.912, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.912 plus 1.956 minus 1.304
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19521,11 +19759,13 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(5.4+0.0)x5.52, direction TLT
 ........\hbox(5.4+0.0)x5.52, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .........\TU/lmr/bx/n/12 r
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19539,11 +19779,13 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(5.436+0.072)x6.156, direction TLT
 ........\hbox(5.436+0.072)x6.156, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .........\TU/lmr/bx/n/12 e
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19557,11 +19799,13 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(8.328+0.072)x7.5, direction TLT
 ........\hbox(8.328+0.072)x7.5, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .........\TU/lmr/bx/n/12 d
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19575,9 +19819,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19591,9 +19837,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+2.05)x3.06, direction TLT
 ........\hbox(6.57+2.05)x3.06, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 j
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19607,9 +19855,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19623,9 +19873,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19639,9 +19891,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19655,9 +19909,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+2.05)x5.28, direction TLT
 ........\hbox(4.31+2.05)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 y
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19671,9 +19927,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19687,9 +19945,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19703,9 +19963,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19719,9 +19981,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19735,9 +19999,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19751,9 +20017,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19767,9 +20035,11 @@ TEST 51: pgfmanual-en-library-decorations-52
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(1.06+0.0)x2.78, direction TLT
 ........\hbox(1.06+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 .
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19850,9 +20120,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(7.16+0.0)x7.5, direction TLT
 ........\hbox(7.16+0.0)x7.5, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 A
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19866,9 +20138,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19882,9 +20156,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 b
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19898,9 +20174,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19914,9 +20192,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19930,9 +20210,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19946,11 +20228,13 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .........\TU/lmr/m/n/10 r
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19964,11 +20248,13 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .........\TU/lmr/m/n/10 e
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -19982,11 +20268,13 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .........\TU/lmr/m/n/10 d
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20000,9 +20288,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20016,9 +20306,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20032,9 +20324,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20048,9 +20342,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20064,9 +20360,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20080,11 +20378,13 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 g
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20098,11 +20398,13 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 r
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20116,11 +20418,13 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 e
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20134,11 +20438,13 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 e
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20152,11 +20458,13 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 .........\TU/lmr/m/n/10 n
 .........\pdfcolorstack 0 pop
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20170,9 +20478,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20186,9 +20496,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20202,9 +20514,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20218,9 +20532,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20234,9 +20550,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20250,9 +20568,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20266,9 +20586,11 @@ TEST 52: pgfmanual-en-library-decorations-53
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(1.06+0.0)x2.78, direction TLT
 ........\hbox(1.06+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 .
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20359,9 +20681,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20375,9 +20699,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20391,9 +20717,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 b
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20407,9 +20735,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20423,9 +20753,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20439,9 +20771,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20455,9 +20789,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+2.05)x3.06, direction TLT
 ........\hbox(6.57+2.05)x3.06, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 j
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20471,9 +20807,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20487,9 +20825,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20503,9 +20843,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20519,9 +20861,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+2.05)x5.28, direction TLT
 ........\hbox(4.31+2.05)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 y
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20535,9 +20879,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20551,9 +20897,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20567,9 +20915,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20583,9 +20933,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20599,9 +20951,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20615,9 +20969,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{1 0 0 RG }
 .........\pdfliteral origin{1 0 0 rg }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20636,9 +20992,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20652,9 +21010,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20668,9 +21028,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 b
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20684,9 +21046,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20700,9 +21064,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20716,9 +21082,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20732,9 +21100,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+2.05)x3.06, direction TLT
 ........\hbox(6.57+2.05)x3.06, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 j
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20748,9 +21118,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20764,9 +21136,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20780,9 +21154,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20796,9 +21172,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+2.05)x5.28, direction TLT
 ........\hbox(4.31+2.05)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 y
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20812,9 +21190,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20828,9 +21208,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20844,9 +21226,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20860,9 +21244,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20876,9 +21262,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20892,9 +21280,11 @@ TEST 53: pgfmanual-en-library-decorations-54
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 0 1 RG }
 .........\pdfliteral origin{0 0 1 rg }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -20986,9 +21376,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21002,9 +21394,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21018,9 +21412,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 b
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21034,9 +21430,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21050,9 +21448,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21066,9 +21466,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21082,9 +21484,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+2.05)x3.06, direction TLT
 ........\hbox(6.57+2.05)x3.06, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 j
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21098,9 +21502,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21114,9 +21520,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21130,9 +21538,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21146,9 +21556,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+2.05)x5.28, direction TLT
 ........\hbox(4.31+2.05)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 y
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21162,9 +21574,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21178,9 +21592,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21194,9 +21610,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21210,9 +21628,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21226,9 +21646,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21242,9 +21664,11 @@ TEST 54: pgfmanual-en-library-decorations-55
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21336,9 +21760,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21352,9 +21778,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21368,9 +21796,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 b
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21384,9 +21814,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21400,9 +21832,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21416,9 +21850,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21432,9 +21868,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+2.05)x3.06, direction TLT
 ........\hbox(6.57+2.05)x3.06, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 j
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21448,9 +21886,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21464,9 +21904,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21480,9 +21922,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21496,9 +21940,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+2.05)x5.28, direction TLT
 ........\hbox(4.31+2.05)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 y
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21512,9 +21958,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21528,9 +21976,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21544,9 +21994,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21560,9 +22012,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21576,9 +22030,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21592,9 +22048,11 @@ TEST 55: pgfmanual-en-library-decorations-56
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21686,9 +22144,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21702,9 +22162,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21718,9 +22180,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 b
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21734,9 +22198,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21750,9 +22216,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21766,9 +22234,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21782,9 +22252,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+2.05)x3.06, direction TLT
 ........\hbox(6.57+2.05)x3.06, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 j
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21798,9 +22270,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21814,9 +22288,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21830,9 +22306,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 c
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21846,9 +22324,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+2.05)x5.28, direction TLT
 ........\hbox(4.31+2.05)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 y
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21862,9 +22342,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21878,9 +22360,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21894,9 +22378,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21910,9 +22396,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21926,9 +22414,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -21942,9 +22432,11 @@ TEST 56: pgfmanual-en-library-decorations-57
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -22250,10 +22742,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(7.62+0.072)x5.256, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(7.62+0.072)x5.256, direction TLT
 ............\TU/lmr/bx/n/12 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22286,10 +22780,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.436+0.072)x6.156, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.436+0.072)x6.156, direction TLT
 ............\TU/lmr/bx/n/12 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22322,10 +22818,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.328+0.0)x7.128, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.328+0.0)x7.128, direction TLT
 ............\TU/lmr/bx/n/12 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22358,10 +22856,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(7.62+0.072)x5.256, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(7.62+0.072)x5.256, direction TLT
 ............\TU/lmr/bx/n/12 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22394,10 +22894,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(0.0+0.0)x4.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(0.0+0.0)x4.5, direction TLT
 ............\glue(\spaceskip) 4.5 plus 2.25 minus 1.5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22430,10 +22932,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.436+0.072)x6.156, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.436+0.072)x6.156, direction TLT
 ............\TU/lmr/bx/n/12 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22466,10 +22970,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(8.4+0.0)x4.128, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(8.4+0.0)x4.128, direction TLT
 ............\TU/lmr/bx/n/12 f
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22502,10 +23008,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(8.4+0.0)x4.128, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(8.4+0.0)x4.128, direction TLT
 ............\TU/lmr/bx/n/12 f
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22538,10 +23046,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.436+0.072)x6.156, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.436+0.072)x6.156, direction TLT
 ............\TU/lmr/bx/n/12 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22574,10 +23084,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.436+0.072)x6.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.436+0.072)x6.0, direction TLT
 ............\TU/lmr/bx/n/12 c
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22610,10 +23122,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(7.62+0.072)x5.256, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(7.62+0.072)x5.256, direction TLT
 ............\TU/lmr/bx/n/12 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22646,10 +23160,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.436+0.072)x5.328, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.436+0.072)x5.328, direction TLT
 ............\TU/lmr/bx/n/12 s
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22682,10 +23198,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(0.0+0.0)x4.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(0.0+0.0)x4.5, direction TLT
 ............\glue(\spaceskip) 4.5 plus 2.25 minus 1.5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22718,10 +23236,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.436+0.072)x6.564, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.436+0.072)x6.564, direction TLT
 ............\TU/lmr/bx/n/12 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22754,10 +23274,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(8.328+0.0)x3.756, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(8.328+0.0)x3.756, direction TLT
 ............\TU/lmr/bx/n/12 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22790,10 +23312,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.436+0.072)x6.756, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.436+0.072)x6.756, direction TLT
 ............\TU/lmr/bx/n/12 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22826,10 +23350,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.4+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.4+0.0)x7.5, direction TLT
 ............\TU/lmr/bx/n/12 n
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22862,10 +23388,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.472+2.412)x6.756, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.472+2.412)x6.756, direction TLT
 ............\TU/lmr/bx/n/12 g
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22898,10 +23426,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(0.0+0.0)x4.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(0.0+0.0)x4.5, direction TLT
 ............\glue(\spaceskip) 4.5 plus 2.25 minus 1.5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22934,10 +23464,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.4+2.328)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.4+2.328)x7.5, direction TLT
 ............\TU/lmr/bx/n/12 p
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22970,10 +23502,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(5.436+0.072)x6.564, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(5.436+0.072)x6.564, direction TLT
 ............\TU/lmr/bx/n/12 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23006,10 +23540,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(7.62+0.072)x5.256, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(7.62+0.072)x5.256, direction TLT
 ............\TU/lmr/bx/n/12 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23042,10 +23578,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(8.328+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(8.328+0.0)x7.5, direction TLT
 ............\TU/lmr/bx/n/12 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23078,10 +23616,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(8.472+0.0)x4.116, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\hbox(8.472+0.0)x4.116, direction TLT
 ............\TU/lmr/bx/n/12 !
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23353,10 +23893,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.47917 0 RG }
 ..........\pdfliteral origin{1 0.47917 0 rg }
 ..........\hbox(7.62+0.072)x5.256, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.47917 0 rg 1 0.47917 0 RG}
 ...........\hbox(7.62+0.072)x5.256, direction TLT
 ............\TU/lmr/bx/n/12 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23383,10 +23925,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.45834 0 RG }
 ..........\pdfliteral origin{1 0.45834 0 rg }
 ..........\hbox(5.436+0.072)x6.156, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.45834 0 rg 1 0.45834 0 RG}
 ...........\hbox(5.436+0.072)x6.156, direction TLT
 ............\TU/lmr/bx/n/12 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23413,10 +23957,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.4375 0 RG }
 ..........\pdfliteral origin{1 0.4375 0 rg }
 ..........\hbox(5.328+0.0)x7.128, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.4375 0 rg 1 0.4375 0 RG}
 ...........\hbox(5.328+0.0)x7.128, direction TLT
 ............\TU/lmr/bx/n/12 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23443,10 +23989,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.41667 0 RG }
 ..........\pdfliteral origin{1 0.41667 0 rg }
 ..........\hbox(7.62+0.072)x5.256, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.41667 0 rg 1 0.41667 0 RG}
 ...........\hbox(7.62+0.072)x5.256, direction TLT
 ............\TU/lmr/bx/n/12 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23473,10 +24021,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.39584 0 RG }
 ..........\pdfliteral origin{1 0.39584 0 rg }
 ..........\hbox(0.0+0.0)x4.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.39584 0 rg 1 0.39584 0 RG}
 ...........\hbox(0.0+0.0)x4.5, direction TLT
 ............\glue(\spaceskip) 4.5 plus 2.25 minus 1.5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23503,10 +24053,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.375 0 RG }
 ..........\pdfliteral origin{1 0.375 0 rg }
 ..........\hbox(5.436+0.072)x6.156, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.375 0 rg 1 0.375 0 RG}
 ...........\hbox(5.436+0.072)x6.156, direction TLT
 ............\TU/lmr/bx/n/12 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23533,10 +24085,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.35417 0 RG }
 ..........\pdfliteral origin{1 0.35417 0 rg }
 ..........\hbox(8.4+0.0)x4.128, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.35417 0 rg 1 0.35417 0 RG}
 ...........\hbox(8.4+0.0)x4.128, direction TLT
 ............\TU/lmr/bx/n/12 f
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23563,10 +24117,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.33334 0 RG }
 ..........\pdfliteral origin{1 0.33334 0 rg }
 ..........\hbox(8.4+0.0)x4.128, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.33334 0 rg 1 0.33334 0 RG}
 ...........\hbox(8.4+0.0)x4.128, direction TLT
 ............\TU/lmr/bx/n/12 f
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23593,10 +24149,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.3125 0 RG }
 ..........\pdfliteral origin{1 0.3125 0 rg }
 ..........\hbox(5.436+0.072)x6.156, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.3125 0 rg 1 0.3125 0 RG}
 ...........\hbox(5.436+0.072)x6.156, direction TLT
 ............\TU/lmr/bx/n/12 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23623,10 +24181,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.29167 0 RG }
 ..........\pdfliteral origin{1 0.29167 0 rg }
 ..........\hbox(5.436+0.072)x6.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.29167 0 rg 1 0.29167 0 RG}
 ...........\hbox(5.436+0.072)x6.0, direction TLT
 ............\TU/lmr/bx/n/12 c
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23653,10 +24213,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.27084 0 RG }
 ..........\pdfliteral origin{1 0.27084 0 rg }
 ..........\hbox(7.62+0.072)x5.256, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.27084 0 rg 1 0.27084 0 RG}
 ...........\hbox(7.62+0.072)x5.256, direction TLT
 ............\TU/lmr/bx/n/12 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23683,10 +24245,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.25 0 RG }
 ..........\pdfliteral origin{1 0.25 0 rg }
 ..........\hbox(5.436+0.072)x5.328, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.25 0 rg 1 0.25 0 RG}
 ...........\hbox(5.436+0.072)x5.328, direction TLT
 ............\TU/lmr/bx/n/12 s
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23713,10 +24277,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.22917 0 RG }
 ..........\pdfliteral origin{1 0.22917 0 rg }
 ..........\hbox(0.0+0.0)x4.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.22917 0 rg 1 0.22917 0 RG}
 ...........\hbox(0.0+0.0)x4.5, direction TLT
 ............\glue(\spaceskip) 4.5 plus 2.25 minus 1.5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23743,10 +24309,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.20834 0 RG }
 ..........\pdfliteral origin{1 0.20834 0 rg }
 ..........\hbox(5.436+0.072)x6.564, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.20834 0 rg 1 0.20834 0 RG}
 ...........\hbox(5.436+0.072)x6.564, direction TLT
 ............\TU/lmr/bx/n/12 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23773,10 +24341,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.1875 0 RG }
 ..........\pdfliteral origin{1 0.1875 0 rg }
 ..........\hbox(8.328+0.0)x3.756, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.1875 0 rg 1 0.1875 0 RG}
 ...........\hbox(8.328+0.0)x3.756, direction TLT
 ............\TU/lmr/bx/n/12 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23803,10 +24373,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.16667 0 RG }
 ..........\pdfliteral origin{1 0.16667 0 rg }
 ..........\hbox(5.436+0.072)x6.756, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.16667 0 rg 1 0.16667 0 RG}
 ...........\hbox(5.436+0.072)x6.756, direction TLT
 ............\TU/lmr/bx/n/12 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23833,10 +24405,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.14584 0 RG }
 ..........\pdfliteral origin{1 0.14584 0 rg }
 ..........\hbox(5.4+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.14584 0 rg 1 0.14584 0 RG}
 ...........\hbox(5.4+0.0)x7.5, direction TLT
 ............\TU/lmr/bx/n/12 n
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23863,10 +24437,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.125 0 RG }
 ..........\pdfliteral origin{1 0.125 0 rg }
 ..........\hbox(5.472+2.412)x6.756, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.125 0 rg 1 0.125 0 RG}
 ...........\hbox(5.472+2.412)x6.756, direction TLT
 ............\TU/lmr/bx/n/12 g
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23893,10 +24469,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.10417 0 RG }
 ..........\pdfliteral origin{1 0.10417 0 rg }
 ..........\hbox(0.0+0.0)x4.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.10417 0 rg 1 0.10417 0 RG}
 ...........\hbox(0.0+0.0)x4.5, direction TLT
 ............\glue(\spaceskip) 4.5 plus 2.25 minus 1.5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23923,10 +24501,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.08334 0 RG }
 ..........\pdfliteral origin{1 0.08334 0 rg }
 ..........\hbox(5.4+2.328)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.08334 0 rg 1 0.08334 0 RG}
 ...........\hbox(5.4+2.328)x7.5, direction TLT
 ............\TU/lmr/bx/n/12 p
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23953,10 +24533,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.0625 0 RG }
 ..........\pdfliteral origin{1 0.0625 0 rg }
 ..........\hbox(5.436+0.072)x6.564, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.0625 0 rg 1 0.0625 0 RG}
 ...........\hbox(5.436+0.072)x6.564, direction TLT
 ............\TU/lmr/bx/n/12 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23983,10 +24565,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.04167 0 RG }
 ..........\pdfliteral origin{1 0.04167 0 rg }
 ..........\hbox(7.62+0.072)x5.256, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.04167 0 rg 1 0.04167 0 RG}
 ...........\hbox(7.62+0.072)x5.256, direction TLT
 ............\TU/lmr/bx/n/12 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24013,10 +24597,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0.02084 0 RG }
 ..........\pdfliteral origin{1 0.02084 0 rg }
 ..........\hbox(8.328+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.02084 0 rg 1 0.02084 0 RG}
 ...........\hbox(8.328+0.0)x7.5, direction TLT
 ............\TU/lmr/bx/n/12 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24043,10 +24629,12 @@ TEST 57: pgfmanual-en-library-decorations-58
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(8.472+0.0)x4.116, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\hbox(8.472+0.0)x4.116, direction TLT
 ............\TU/lmr/bx/n/12 !
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24475,8 +25063,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24512,8 +25102,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24549,8 +25141,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24578,8 +25172,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(2.45+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(2.45+0.0)x3.33, direction TLT
 ............\TU/lmr/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24615,8 +25211,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24652,8 +25250,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24689,8 +25289,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24718,8 +25320,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(2.45+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(2.45+0.0)x3.33, direction TLT
 ............\TU/lmr/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24755,8 +25359,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24792,8 +25398,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24829,8 +25437,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24858,8 +25468,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(2.45+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(2.45+0.0)x3.33, direction TLT
 ............\TU/lmr/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24895,8 +25507,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24932,8 +25546,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24969,8 +25585,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24998,8 +25616,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(2.45+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(2.45+0.0)x3.33, direction TLT
 ............\TU/lmr/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25035,8 +25655,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25072,8 +25694,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25109,8 +25733,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25138,8 +25764,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(2.45+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(2.45+0.0)x3.33, direction TLT
 ............\TU/lmr/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25175,8 +25803,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25212,8 +25842,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25249,8 +25881,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25278,8 +25912,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(2.45+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(2.45+0.0)x3.33, direction TLT
 ............\TU/lmr/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25315,8 +25951,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25352,8 +25990,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25389,8 +26029,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.22)x5.0, direction TLT
 ............\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25418,8 +26060,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(2.45+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(2.45+0.0)x3.33, direction TLT
 ............\TU/lmr/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25455,8 +26099,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25492,8 +26138,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25529,8 +26177,10 @@ TEST 58: pgfmanual-en-library-decorations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(6.66+0.0)x5.0, direction TLT
 ............\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25569,6 +26219,71 @@ TEST 59: pgfmanual-en-library-decorations-60
 ...\pdfliteral origin{0.3985 w }
 ...\hbox(0.0+0.0)x0.0, direction TLT
 ....\pdfliteral origin{q }
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
+....\begindir TLT
+....\enddir TLT
 ....\pdfliteral origin{q }
 ....\glue(\spaceskip) 0.0
 ....\glue(\spaceskip) 0.0
@@ -26309,8 +27024,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26337,8 +27054,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26365,8 +27084,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26393,8 +27114,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26421,8 +27144,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26449,8 +27174,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26477,8 +27204,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26505,8 +27234,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26533,8 +27264,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26561,8 +27294,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26842,8 +27577,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26870,8 +27607,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26898,8 +27637,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26926,8 +27667,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26954,8 +27697,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26982,8 +27727,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27010,8 +27757,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27038,8 +27787,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27066,8 +27817,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27094,8 +27847,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27122,8 +27877,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27150,8 +27907,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27178,8 +27937,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27206,8 +27967,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27234,8 +27997,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27262,8 +28027,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27290,8 +28057,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27318,8 +28087,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27346,8 +28117,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27374,8 +28147,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27402,8 +28177,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27430,8 +28207,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27458,8 +28237,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27486,8 +28267,10 @@ TEST 60: pgfmanual-en-library-decorations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27790,8 +28573,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27819,8 +28604,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27848,8 +28635,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27877,8 +28666,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27906,8 +28697,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27935,8 +28728,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27964,8 +28759,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27993,8 +28790,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28022,8 +28821,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28051,8 +28852,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28325,8 +29128,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28354,8 +29159,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28383,8 +29190,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28412,8 +29221,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28441,8 +29252,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28470,8 +29283,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28499,8 +29314,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28528,8 +29345,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28557,8 +29376,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28586,8 +29407,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28615,8 +29438,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28644,8 +29469,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28673,8 +29500,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28702,8 +29531,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28731,8 +29562,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28760,8 +29593,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28789,8 +29624,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28818,8 +29655,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28847,8 +29686,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28876,8 +29717,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28905,8 +29748,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28934,8 +29779,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28963,8 +29810,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28992,8 +29841,10 @@ TEST 61: pgfmanual-en-library-decorations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29283,8 +30134,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29310,7 +30163,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29348,8 +30203,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29375,7 +30232,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29413,8 +30272,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29440,7 +30301,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29478,8 +30341,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29505,7 +30370,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29545,8 +30412,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29572,7 +30441,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29610,8 +30481,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29637,7 +30510,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29675,8 +30550,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29702,7 +30579,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.408+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29740,8 +30619,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29767,7 +30648,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29805,8 +30688,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29832,7 +30717,9 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29870,8 +30757,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29897,8 +30786,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29936,8 +30827,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29963,8 +30856,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30002,8 +30897,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30029,8 +30926,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30070,8 +30969,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30097,8 +30998,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30136,8 +31039,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30163,8 +31068,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30202,8 +31109,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30229,8 +31138,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30268,8 +31179,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30295,8 +31208,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30334,8 +31249,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30361,8 +31278,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.408+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30400,8 +31319,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30427,8 +31348,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30468,8 +31391,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30495,8 +31420,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
 ...........\TU/lmr/m/n/8 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30534,8 +31461,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30561,8 +31490,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
 ...........\TU/lmr/m/n/8 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30600,8 +31531,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30627,8 +31560,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30666,8 +31601,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30693,8 +31630,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30732,8 +31671,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30759,8 +31700,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30798,8 +31741,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30825,8 +31770,10 @@ TEST 62: pgfmanual-en-library-decorations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x8.496, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31125,10 +32072,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.04166 0.02083 0.95834 RG }
 ..........\pdfliteral origin{0.04166 0.02083 0.95834 rg }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.04166 0.02083 0.95834 rg 0.04166 0.02083 0.95834 RG}
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31155,10 +32104,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.08333 0.04166 0.91667 RG }
 ..........\pdfliteral origin{0.08333 0.04166 0.91667 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.08333 0.04166 0.91667 rg 0.08333 0.04166 0.91667 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31185,10 +32136,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.125 0.0625 0.875 RG }
 ..........\pdfliteral origin{0.125 0.0625 0.875 rg }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.125 0.0625 0.875 rg 0.125 0.0625 0.875 RG}
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31215,10 +32168,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.16666 0.08333 0.83334 RG }
 ..........\pdfliteral origin{0.16666 0.08333 0.83334 rg }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.16666 0.08333 0.83334 rg 0.16666 0.08333 0.83334 RG}
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31245,10 +32200,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.20833 0.10416 0.79167 RG }
 ..........\pdfliteral origin{0.20833 0.10416 0.79167 rg }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.20833 0.10416 0.79167 rg 0.20833 0.10416 0.79167 RG}
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31275,10 +32232,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.25 0.125 0.75 RG }
 ..........\pdfliteral origin{0.25 0.125 0.75 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.25 0.125 0.75 rg 0.25 0.125 0.75 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31305,10 +32264,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.29166 0.14583 0.70834 RG }
 ..........\pdfliteral origin{0.29166 0.14583 0.70834 rg }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.29166 0.14583 0.70834 rg 0.29166 0.14583 0.70834 RG}
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31335,10 +32296,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.33333 0.16666 0.66667 RG }
 ..........\pdfliteral origin{0.33333 0.16666 0.66667 rg }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.33333 0.16666 0.66667 rg 0.33333 0.16666 0.66667 RG}
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31365,10 +32328,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.375 0.1875 0.625 RG }
 ..........\pdfliteral origin{0.375 0.1875 0.625 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.375 0.1875 0.625 rg 0.375 0.1875 0.625 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31395,10 +32360,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.41666 0.20833 0.58334 RG }
 ..........\pdfliteral origin{0.41666 0.20833 0.58334 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.41666 0.20833 0.58334 rg 0.41666 0.20833 0.58334 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31425,10 +32392,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.45833 0.22916 0.54167 RG }
 ..........\pdfliteral origin{0.45833 0.22916 0.54167 rg }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.45833 0.22916 0.54167 rg 0.45833 0.22916 0.54167 RG}
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31455,10 +32424,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.5 0.25 0.5 RG }
 ..........\pdfliteral origin{0.5 0.25 0.5 rg }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 0.25 0.5 rg 0.5 0.25 0.5 RG}
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31485,10 +32456,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.54166 0.27083 0.45834 RG }
 ..........\pdfliteral origin{0.54166 0.27083 0.45834 rg }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.54166 0.27083 0.45834 rg 0.54166 0.27083 0.45834 RG}
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31515,10 +32488,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.58333 0.29166 0.41667 RG }
 ..........\pdfliteral origin{0.58333 0.29166 0.41667 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.58333 0.29166 0.41667 rg 0.58333 0.29166 0.41667 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31545,10 +32520,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.625 0.3125 0.375 RG }
 ..........\pdfliteral origin{0.625 0.3125 0.375 rg }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.625 0.3125 0.375 rg 0.625 0.3125 0.375 RG}
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31575,10 +32552,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.66666 0.33333 0.33334 RG }
 ..........\pdfliteral origin{0.66666 0.33333 0.33334 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.66666 0.33333 0.33334 rg 0.66666 0.33333 0.33334 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31605,10 +32584,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.70833 0.35416 0.29167 RG }
 ..........\pdfliteral origin{0.70833 0.35416 0.29167 rg }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.70833 0.35416 0.29167 rg 0.70833 0.35416 0.29167 RG}
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31635,10 +32616,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.75 0.375 0.25 RG }
 ..........\pdfliteral origin{0.75 0.375 0.25 rg }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 0.375 0.25 rg 0.75 0.375 0.25 RG}
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31665,10 +32648,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.79166 0.39583 0.20834 RG }
 ..........\pdfliteral origin{0.79166 0.39583 0.20834 rg }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.79166 0.39583 0.20834 rg 0.79166 0.39583 0.20834 RG}
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31695,10 +32680,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.83333 0.41666 0.16667 RG }
 ..........\pdfliteral origin{0.83333 0.41666 0.16667 rg }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.83333 0.41666 0.16667 rg 0.83333 0.41666 0.16667 RG}
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31725,10 +32712,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.875 0.4375 0.125 RG }
 ..........\pdfliteral origin{0.875 0.4375 0.125 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.875 0.4375 0.125 rg 0.875 0.4375 0.125 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31755,10 +32744,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.91666 0.45833 0.08334 RG }
 ..........\pdfliteral origin{0.91666 0.45833 0.08334 rg }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.91666 0.45833 0.08334 rg 0.91666 0.45833 0.08334 RG}
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31785,10 +32776,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{0.95833 0.47916 0.04167 RG }
 ..........\pdfliteral origin{0.95833 0.47916 0.04167 rg }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.95833 0.47916 0.04167 rg 0.95833 0.47916 0.04167 RG}
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31815,10 +32808,12 @@ TEST 63: pgfmanual-en-library-decorations-64
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32107,8 +33102,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32134,7 +33131,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32172,8 +33171,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32199,7 +33200,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32237,8 +33240,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32264,7 +33269,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32302,8 +33309,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32329,7 +33338,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32369,8 +33380,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32396,7 +33409,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32434,8 +33449,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32461,7 +33478,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32499,8 +33518,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32526,7 +33547,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32564,8 +33587,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32591,7 +33616,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32629,8 +33656,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32656,7 +33685,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32694,8 +33725,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32721,7 +33754,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32759,8 +33794,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32786,7 +33823,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32824,8 +33863,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32851,7 +33892,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.408+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32891,8 +33934,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32918,7 +33963,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32956,8 +34003,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32983,7 +34032,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33021,8 +34072,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33048,7 +34101,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33086,8 +34141,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33113,7 +34170,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33151,8 +34210,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33178,7 +34239,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33216,8 +34279,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33243,7 +34308,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33283,8 +34350,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33310,7 +34379,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33348,8 +34419,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33375,7 +34448,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33413,8 +34488,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33440,7 +34517,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33478,8 +34557,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33505,7 +34586,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33543,8 +34626,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33570,7 +34655,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33608,8 +34695,10 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33635,7 +34724,9 @@ TEST 64: pgfmanual-en-library-decorations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33925,8 +35016,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33952,7 +35045,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33990,8 +35085,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34017,7 +35114,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34055,8 +35154,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34082,7 +35183,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34120,8 +35223,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34147,7 +35252,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34187,8 +35294,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34214,7 +35323,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34252,8 +35363,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34279,7 +35392,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34317,8 +35432,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34344,7 +35461,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34382,8 +35501,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34409,7 +35530,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34447,8 +35570,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34474,7 +35599,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34512,8 +35639,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34539,7 +35668,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34577,8 +35708,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34604,7 +35737,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34642,8 +35777,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34669,7 +35806,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34709,8 +35848,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34736,7 +35877,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34774,8 +35917,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34801,7 +35946,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34839,8 +35986,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34866,7 +36015,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34904,8 +36055,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34931,7 +36084,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34969,8 +36124,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34996,7 +36153,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35034,8 +36193,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35061,7 +36222,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35101,8 +36264,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35128,7 +36293,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35166,8 +36333,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35193,7 +36362,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35231,8 +36402,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35258,7 +36431,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35296,8 +36471,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35323,7 +36500,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35361,8 +36540,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35388,7 +36569,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35426,8 +36609,10 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35453,7 +36638,9 @@ TEST 65: pgfmanual-en-library-decorations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36094,8 +37281,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.8+0.0)x6.53, direction TLT
+...........\begindir TLT
 ...........\hbox(6.8+0.0)x6.53, direction TLT
 ............\TU/lmr/m/n/10 F
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36123,10 +37312,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36154,8 +37345,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36183,8 +37376,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36212,8 +37407,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36241,8 +37438,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36270,10 +37469,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36301,8 +37502,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36330,8 +37533,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36359,10 +37564,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(8.31+0.22)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(8.31+0.22)x7.5, direction TLT
 ............\TU/lmr/m/n/10 ^^dc
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36390,8 +37597,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.11)x5.56, direction TLT
 ............\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36419,10 +37628,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36450,8 +37661,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36479,8 +37692,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36508,8 +37723,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.11)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.11)x5.28, direction TLT
 ............\TU/lmr/m/n/10 v
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36537,10 +37754,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36568,8 +37787,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36597,8 +37818,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36626,8 +37849,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\hbox(6.83+0.0)x7.5, direction TLT
 ............\TU/lmr/m/n/10 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36655,8 +37880,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+2.05)x5.28, direction TLT
 ............\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36684,8 +37911,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36713,10 +37942,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36744,8 +37975,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36773,8 +38006,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36802,10 +38037,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36833,8 +38070,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36862,8 +38101,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x8.33, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x8.33, direction TLT
 ............\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36891,10 +38132,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.42+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.42+0.11)x5.56, direction TLT
 ............\TU/lmr/m/n/10 u
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36922,8 +38165,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36951,10 +38196,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.57+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 i
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36982,8 +38229,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 k
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37011,8 +38260,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37040,8 +38291,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.28, direction TLT
 ............\TU/lmr/m/n/10 q
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37069,10 +38322,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.42+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.42+0.11)x5.56, direction TLT
 ............\TU/lmr/m/n/10 u
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37100,10 +38355,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.52+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.52+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 ^^e4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37131,8 +38388,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37160,8 +38419,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37189,8 +38450,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37218,8 +38481,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+2.05)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(6.57+2.05)x3.06, direction TLT
 ............\TU/lmr/m/n/10 j
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37247,10 +38512,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37278,8 +38545,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.11)x5.56, direction TLT
 ............\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37307,10 +38576,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37338,8 +38609,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37367,8 +38640,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37396,8 +38671,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37425,8 +38702,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x3.92, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x3.92, direction TLT
 ............\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37454,10 +38733,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.52+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.52+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 ^^f6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37485,8 +38766,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 ^^df
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37514,10 +38797,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37545,8 +38830,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x3.92, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x3.92, direction TLT
 ............\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37574,10 +38861,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37605,8 +38894,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37634,8 +38925,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37663,8 +38956,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x6.11, direction TLT
+...........\begindir TLT
 ...........\hbox(6.83+0.0)x6.11, direction TLT
 ............\TU/lmr/m/n/10 Z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37692,8 +38987,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.11)x7.22, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.11)x7.22, direction TLT
 ............\TU/lmr/m/n/10 w
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37721,10 +39018,12 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37752,8 +39051,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x3.92, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x3.92, direction TLT
 ............\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37781,8 +39082,10 @@ TEST 66: pgfmanual-en-library-decorations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38083,8 +39386,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38112,8 +39417,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38141,8 +39448,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38170,8 +39479,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38199,8 +39510,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38228,8 +39541,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38257,8 +39572,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38286,8 +39603,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38315,8 +39634,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38344,8 +39665,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38373,8 +39696,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38402,8 +39727,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38431,8 +39758,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38460,8 +39789,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38489,8 +39820,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38518,8 +39851,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38547,8 +39882,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38576,8 +39913,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38605,8 +39944,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38634,8 +39975,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38663,8 +40006,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38692,8 +40037,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38721,8 +40068,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38750,8 +40099,10 @@ TEST 67: pgfmanual-en-library-decorations-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39052,8 +40403,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39081,8 +40434,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39110,8 +40465,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39139,8 +40496,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39168,8 +40527,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39197,8 +40558,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39226,8 +40589,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39255,8 +40620,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39284,8 +40651,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39313,8 +40682,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39342,8 +40713,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39371,8 +40744,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39400,8 +40775,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39429,8 +40806,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39458,8 +40837,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39487,8 +40868,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39516,8 +40899,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39545,8 +40930,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39574,8 +40961,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39603,8 +40992,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39632,8 +41023,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39661,8 +41054,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39690,8 +41085,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39719,8 +41116,10 @@ TEST 68: pgfmanual-en-library-decorations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40025,8 +41424,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40053,8 +41454,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40081,8 +41484,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40109,8 +41514,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40137,8 +41544,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40165,8 +41574,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40193,8 +41604,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40221,8 +41634,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40249,8 +41664,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40277,8 +41694,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40305,8 +41724,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40333,8 +41754,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40361,8 +41784,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40389,8 +41814,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40417,8 +41844,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40445,8 +41874,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40473,8 +41904,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40501,8 +41934,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40529,8 +41964,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40557,8 +41994,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40585,8 +42024,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40613,8 +42054,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40641,8 +42084,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40669,8 +42114,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40949,8 +42396,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40977,8 +42426,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41005,8 +42456,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41033,8 +42486,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41061,8 +42516,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41089,8 +42546,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41117,8 +42576,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41145,8 +42606,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41173,8 +42636,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41201,8 +42666,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41229,8 +42696,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41257,8 +42726,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41285,8 +42756,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41313,8 +42786,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41341,8 +42816,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41369,8 +42846,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41397,8 +42876,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41425,8 +42906,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41453,8 +42936,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41481,8 +42966,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41509,8 +42996,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41537,8 +43026,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41565,8 +43056,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41593,8 +43086,10 @@ TEST 69: pgfmanual-en-library-decorations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41901,8 +43396,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41929,8 +43426,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41957,8 +43456,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41985,8 +43486,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42013,8 +43516,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42041,8 +43546,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42069,8 +43576,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42097,8 +43606,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42125,8 +43636,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42153,8 +43666,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42181,8 +43696,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42209,8 +43726,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42237,8 +43756,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42265,8 +43786,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42293,8 +43816,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42321,8 +43846,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42349,8 +43876,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42377,8 +43906,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42405,8 +43936,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42433,8 +43966,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42461,8 +43996,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42489,8 +44026,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42517,8 +44056,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42545,8 +44086,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42825,8 +44368,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42853,8 +44398,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42881,8 +44428,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42909,8 +44458,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42937,8 +44488,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42965,8 +44518,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42993,8 +44548,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43021,8 +44578,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43049,8 +44608,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43077,8 +44638,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43105,8 +44668,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43133,8 +44698,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43161,8 +44728,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43189,8 +44758,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43217,8 +44788,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43245,8 +44818,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43273,8 +44848,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43301,8 +44878,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43329,8 +44908,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43357,8 +44938,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43385,8 +44968,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43413,8 +44998,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43441,8 +45028,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43469,8 +45058,10 @@ TEST 70: pgfmanual-en-library-decorations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43771,8 +45362,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43799,8 +45392,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43827,8 +45422,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43855,8 +45452,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43883,8 +45482,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43911,8 +45512,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43939,8 +45542,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43967,8 +45572,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43995,8 +45602,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44023,8 +45632,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44051,8 +45662,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44079,8 +45692,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44107,8 +45722,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44135,8 +45752,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44163,8 +45782,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44191,8 +45812,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44219,8 +45842,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44247,8 +45872,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44275,8 +45902,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44303,8 +45932,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44331,8 +45962,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44359,8 +45992,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44387,8 +46022,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44415,8 +46052,10 @@ TEST 71: pgfmanual-en-library-decorations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44716,8 +46355,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44745,8 +46386,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44774,8 +46417,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44803,8 +46448,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44832,8 +46479,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44861,8 +46510,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44890,8 +46541,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44919,8 +46572,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44948,8 +46603,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44977,8 +46634,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45006,8 +46665,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45035,8 +46696,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45064,8 +46727,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45093,8 +46758,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45122,8 +46789,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45151,8 +46820,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45180,8 +46851,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45209,8 +46882,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45238,8 +46913,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45267,8 +46944,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45296,8 +46975,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45325,8 +47006,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45354,8 +47037,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45383,8 +47068,10 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45659,10 +47346,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45690,10 +47379,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45721,10 +47412,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45752,10 +47445,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45783,10 +47478,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45814,10 +47511,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45845,10 +47544,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45876,10 +47577,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45907,10 +47610,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45938,10 +47643,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45969,10 +47676,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46000,10 +47709,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46031,10 +47742,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46062,10 +47775,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46093,10 +47808,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46124,10 +47841,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46155,10 +47874,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46186,10 +47907,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46217,10 +47940,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46248,10 +47973,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46279,10 +48006,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46310,10 +48039,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46341,10 +48072,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46372,10 +48105,12 @@ TEST 72: pgfmanual-en-library-decorations-73
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46715,8 +48450,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46755,8 +48492,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46795,8 +48534,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46835,8 +48576,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46868,8 +48611,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46908,8 +48653,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46948,8 +48695,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46988,8 +48737,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47028,8 +48779,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47068,8 +48821,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47108,8 +48863,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47148,8 +48905,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47181,8 +48940,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47221,8 +48982,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47261,8 +49024,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47301,8 +49066,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47341,8 +49108,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47381,8 +49150,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47414,8 +49185,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47454,8 +49227,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47494,8 +49269,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47534,8 +49311,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47574,8 +49353,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47614,8 +49395,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47745,11 +49528,13 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x17.5, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x17.5, direction TLT
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 e
 ............\TU/lmr/m/n/10 x
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47783,8 +49568,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47825,6 +49612,7 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x26.98001, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.11)x26.98001, direction TLT
 ............\TU/lmr/m/n/10 e
 ............\discretionary (penalty 50)
@@ -47836,6 +49624,7 @@ TEST 73: pgfmanual-en-library-decorations-74
 ............\TU/lmr/m/n/10 c
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47869,8 +49658,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47911,12 +49702,14 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x23.34, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+2.06)x23.34, direction TLT
 ............\TU/lmr/m/n/10 a
 ............\TU/lmr/m/n/10 l
 ............\TU/lmr/m/n/10 o
 ............\TU/lmr/m/n/10 n
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47950,8 +49743,10 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47992,12 +49787,14 @@ TEST 73: pgfmanual-en-library-decorations-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+1.94)x22.79, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+1.94)x22.79, direction TLT
 ............\TU/lmr/m/n/10 p
 ............\TU/lmr/m/n/10 a
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 h
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48146,6 +49943,7 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+1.94)x22.51, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+1.94)x22.51, direction TLT
 ............\TU/lmr/m/n/10 !
 ............\TU/lmr/m/n/10 h
@@ -48153,6 +49951,7 @@ TEST 74: pgfmanual-en-library-decorations-75
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 a
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48184,8 +49983,10 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48224,12 +50025,14 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x23.34, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+2.06)x23.34, direction TLT
 ............\TU/lmr/m/n/10 g
 ............\TU/lmr/m/n/10 n
 ............\TU/lmr/m/n/10 o
 ............\TU/lmr/m/n/10 l
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48261,8 +50064,10 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48301,6 +50106,7 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x26.98001, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.11)x26.98001, direction TLT
 ............\TU/lmr/m/n/10 s
 ............\TU/lmr/m/n/10 t
@@ -48310,6 +50116,7 @@ TEST 74: pgfmanual-en-library-decorations-75
 ............\TU/lmr/m/n/10 e
 ............\TU/lmr/m/n/10 ﬀ
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48341,8 +50148,10 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48381,11 +50190,13 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x17.5, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x17.5, direction TLT
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 x
 ............\TU/lmr/m/n/10 e
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48515,12 +50326,14 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+1.94)x22.79, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+1.94)x22.79, direction TLT
 ............\TU/lmr/m/n/10 p
 ............\TU/lmr/m/n/10 a
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 h
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48554,8 +50367,10 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48596,12 +50411,14 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x23.34, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+2.06)x23.34, direction TLT
 ............\TU/lmr/m/n/10 a
 ............\TU/lmr/m/n/10 l
 ............\TU/lmr/m/n/10 o
 ............\TU/lmr/m/n/10 n
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48635,8 +50452,10 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48677,6 +50496,7 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x26.98001, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.11)x26.98001, direction TLT
 ............\TU/lmr/m/n/10 e
 ............\discretionary (penalty 50)
@@ -48688,6 +50508,7 @@ TEST 74: pgfmanual-en-library-decorations-75
 ............\TU/lmr/m/n/10 c
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48721,8 +50542,10 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -48763,11 +50586,13 @@ TEST 74: pgfmanual-en-library-decorations-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x17.5, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x17.5, direction TLT
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 e
 ............\TU/lmr/m/n/10 x
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49173,8 +50998,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49201,8 +51028,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49229,8 +51058,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49257,8 +51088,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49285,8 +51118,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49313,8 +51148,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49341,8 +51178,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49369,8 +51208,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49397,8 +51238,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49425,8 +51268,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49453,8 +51298,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49481,8 +51328,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49509,8 +51358,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49537,8 +51388,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49565,8 +51418,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49593,8 +51448,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49621,8 +51478,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49649,8 +51508,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49677,8 +51538,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49705,8 +51568,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49733,8 +51598,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49761,8 +51628,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49789,8 +51658,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49817,8 +51688,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49845,8 +51718,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49873,8 +51748,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49901,8 +51778,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49929,8 +51808,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49957,8 +51838,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -49985,8 +51868,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50013,8 +51898,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50041,8 +51928,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50069,8 +51958,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50097,8 +51988,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50125,8 +52018,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50153,8 +52048,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50181,8 +52078,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50209,8 +52108,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50237,8 +52138,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50265,8 +52168,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50293,8 +52198,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50321,8 +52228,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50349,8 +52258,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50377,8 +52288,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50405,8 +52318,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50433,8 +52348,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50461,8 +52378,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50489,8 +52408,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50517,8 +52438,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50545,8 +52468,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50573,8 +52498,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50601,8 +52528,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50629,8 +52558,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50657,8 +52588,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50685,8 +52618,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50713,8 +52648,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50741,8 +52678,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50769,8 +52708,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50797,8 +52738,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50825,8 +52768,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50853,8 +52798,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50881,8 +52828,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50909,8 +52858,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50937,8 +52888,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50965,8 +52918,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -50993,8 +52948,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51021,8 +52978,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51049,8 +53008,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51077,8 +53038,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51105,8 +53068,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51133,8 +53098,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51161,8 +53128,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51189,8 +53158,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51217,8 +53188,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51245,8 +53218,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51273,8 +53248,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51301,8 +53278,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51329,8 +53308,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51357,8 +53338,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51385,8 +53368,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51413,8 +53398,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51441,8 +53428,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51469,8 +53458,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51497,8 +53488,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51525,8 +53518,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51553,8 +53548,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51581,8 +53578,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51609,8 +53608,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51637,8 +53638,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51665,8 +53668,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51693,8 +53698,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51721,8 +53728,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51749,8 +53758,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51777,8 +53788,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51805,8 +53818,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51833,8 +53848,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51861,8 +53878,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51889,8 +53908,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51917,8 +53938,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51945,8 +53968,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -51973,8 +53998,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52001,8 +54028,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52029,8 +54058,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52057,8 +54088,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52085,8 +54118,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52113,8 +54148,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52141,8 +54178,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52169,8 +54208,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52197,8 +54238,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52225,8 +54268,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52253,8 +54298,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52281,8 +54328,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52309,8 +54358,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52337,8 +54388,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52365,8 +54418,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52393,8 +54448,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52421,8 +54478,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52449,8 +54508,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52477,8 +54538,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52505,8 +54568,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52533,8 +54598,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52561,8 +54628,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52589,8 +54658,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52617,8 +54688,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52645,8 +54718,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52673,8 +54748,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52701,8 +54778,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52729,8 +54808,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52757,8 +54838,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52785,8 +54868,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52813,8 +54898,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52841,8 +54928,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52869,8 +54958,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52897,8 +54988,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52925,8 +55018,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52953,8 +55048,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -52981,8 +55078,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53009,8 +55108,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53037,8 +55138,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53065,8 +55168,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53093,8 +55198,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53121,8 +55228,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53149,8 +55258,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53177,8 +55288,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53205,8 +55318,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53233,8 +55348,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53261,8 +55378,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53289,8 +55408,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53317,8 +55438,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53345,8 +55468,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53373,8 +55498,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53401,8 +55528,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53429,8 +55558,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53457,8 +55588,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53485,8 +55618,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53513,8 +55648,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53541,8 +55678,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53569,8 +55708,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53597,8 +55738,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53625,8 +55768,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53653,8 +55798,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53681,8 +55828,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53709,8 +55858,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53737,8 +55888,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53765,8 +55918,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53793,8 +55948,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53821,8 +55978,10 @@ TEST 75: pgfmanual-en-library-decorations-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53956,6 +56115,7 @@ TEST 76: pgfmanual-en-library-decorations-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+1.49998)x21.98613, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+1.49998)x21.98613, direction TLT
 ............\TU/lmr/m/n/10 t
 ............\TU/lmr/m/n/10 e
@@ -53966,6 +56126,7 @@ TEST 76: pgfmanual-en-library-decorations-77
 ............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .............\OT1/cmr/m/n/7 1
 ............\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -53993,8 +56154,10 @@ TEST 76: pgfmanual-en-library-decorations-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54022,6 +56185,7 @@ TEST 76: pgfmanual-en-library-decorations-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.49998)x31.46614, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+1.49998)x31.46614, direction TLT
 ............\TU/lmr/m/n/10 e
 ............\TU/lmr/m/n/10 ﬀ
@@ -54034,6 +56198,7 @@ TEST 76: pgfmanual-en-library-decorations-77
 ............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .............\OT1/cmr/m/n/7 2
 ............\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54061,8 +56226,10 @@ TEST 76: pgfmanual-en-library-decorations-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54090,6 +56257,7 @@ TEST 76: pgfmanual-en-library-decorations-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x27.82613, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+2.06)x27.82613, direction TLT
 ............\TU/lmr/m/n/10 a
 ............\TU/lmr/m/n/10 l
@@ -54101,6 +56269,7 @@ TEST 76: pgfmanual-en-library-decorations-77
 ............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .............\OT1/cmr/m/n/7 3
 ............\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54128,8 +56297,10 @@ TEST 76: pgfmanual-en-library-decorations-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54157,6 +56328,7 @@ TEST 76: pgfmanual-en-library-decorations-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+1.94)x27.27612, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+1.94)x27.27612, direction TLT
 ............\TU/lmr/m/n/10 p
 ............\TU/lmr/m/n/10 a
@@ -54168,6 +56340,7 @@ TEST 76: pgfmanual-en-library-decorations-77
 ............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .............\OT1/cmr/m/n/7 4
 ............\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54219,6 +56392,104 @@ TEST 77: pgfmanual-en-library-decorations-78
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
+....\begindir TLT
+....\enddir TLT
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\begindir TLT
+....\enddir TLT
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\begindir TLT
+....\enddir TLT
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\begindir TLT
+....\enddir TLT
 ....\hbox(0.0+0.0)x0.0, direction TLT
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\pdfliteral origin{q }
@@ -54279,96 +56550,8 @@ TEST 77: pgfmanual-en-library-decorations-78
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
-....\hbox(0.0+0.0)x0.0, direction TLT
-.....\hbox(0.0+0.0)x0.0, direction TLT
-......\pdfliteral origin{q }
-......\pdfliteral origin{q }
-......\glue(\spaceskip) 0.0
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-......\glue(\spaceskip) 0.0
-......\pdfliteral origin{Q }
-....\glue(\spaceskip) 0.0
+....\begindir TLT
+....\enddir TLT
 ....\hbox(0.0+0.0)x0.0, direction TLT
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\pdfliteral origin{q }
@@ -54418,8 +56601,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54466,8 +56651,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\hbox(4.31+0.0)x5.28, direction TLT
 ............\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54495,8 +56682,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54524,8 +56713,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54572,8 +56763,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54601,8 +56794,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\hbox(7.05+0.0)x3.06, direction TLT
 ............\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54649,8 +56844,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x4.44, direction TLT
 ............\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54678,8 +56875,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54707,8 +56906,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x3.94, direction TLT
 ............\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54736,8 +56937,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54784,8 +56987,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54813,8 +57018,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.48+0.11)x5.0, direction TLT
 ............\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54842,8 +57049,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54871,8 +57080,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\hbox(4.53+2.06)x5.0, direction TLT
 ............\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54900,8 +57111,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\hbox(0.0+0.0)x3.33, direction TLT
 ............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54929,8 +57142,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(4.42+1.94)x5.56, direction TLT
 ............\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -54977,8 +57192,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\hbox(6.15+0.11)x3.89, direction TLT
 ............\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55006,8 +57223,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\hbox(6.94+0.0)x5.56, direction TLT
 ............\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -55035,8 +57254,10 @@ TEST 77: pgfmanual-en-library-decorations-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\hbox(7.16+0.0)x2.78, direction TLT
 ............\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-edges.tlg
+++ b/testfiles-examples/pgfmanual-en-library-edges.tlg
@@ -191,7 +191,9 @@ TEST 5: pgfmanual-en-library-edges-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -223,7 +225,9 @@ TEST 5: pgfmanual-en-library-edges-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -255,7 +259,9 @@ TEST 5: pgfmanual-en-library-edges-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -341,11 +347,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -383,11 +391,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -421,11 +431,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -472,11 +484,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -515,7 +529,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -556,7 +572,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -598,7 +616,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -642,7 +662,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -681,7 +703,9 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -744,7 +768,9 @@ TEST 7: pgfmanual-en-library-edges-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -778,8 +804,10 @@ TEST 7: pgfmanual-en-library-edges-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -813,8 +841,10 @@ TEST 7: pgfmanual-en-library-edges-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -848,9 +878,11 @@ TEST 7: pgfmanual-en-library-edges-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -884,9 +916,11 @@ TEST 7: pgfmanual-en-library-edges-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -920,9 +954,11 @@ TEST 7: pgfmanual-en-library-edges-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -956,9 +992,11 @@ TEST 7: pgfmanual-en-library-edges-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -992,9 +1030,11 @@ TEST 7: pgfmanual-en-library-edges-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1551,7 +1591,9 @@ TEST 11: pgfmanual-en-library-edges-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1624,7 +1666,9 @@ TEST 12: pgfmanual-en-library-edges-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1663,7 +1707,9 @@ TEST 12: pgfmanual-en-library-edges-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.31+0.0)x5.28, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 x
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-er.tlg
+++ b/testfiles-examples/pgfmanual-en-library-er.tlg
@@ -36,11 +36,13 @@ TEST 1: pgfmanual-en-library-er-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71,12 +73,14 @@ TEST 1: pgfmanual-en-library-er-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x35.62001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 G
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -142,11 +146,13 @@ TEST 2: pgfmanual-en-library-er-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -185,12 +191,14 @@ TEST 2: pgfmanual-en-library-er-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x35.62001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 G
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -247,11 +255,13 @@ TEST 3: pgfmanual-en-library-er-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -281,12 +291,14 @@ TEST 3: pgfmanual-en-library-er-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x35.62001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 G
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -317,9 +329,11 @@ TEST 3: pgfmanual-en-library-er-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x14.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -405,11 +419,13 @@ TEST 4: pgfmanual-en-library-er-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -447,12 +463,14 @@ TEST 4: pgfmanual-en-library-er-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x35.62001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 G
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -491,9 +509,11 @@ TEST 4: pgfmanual-en-library-er-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x14.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -571,11 +591,13 @@ TEST 5: pgfmanual-en-library-er-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -612,10 +634,12 @@ TEST 5: pgfmanual-en-library-er-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x23.33, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -662,11 +686,13 @@ TEST 5: pgfmanual-en-library-er-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x21.14, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -742,11 +768,13 @@ TEST 6: pgfmanual-en-library-er-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -783,10 +811,12 @@ TEST 6: pgfmanual-en-library-er-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x23.33, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -833,11 +863,13 @@ TEST 6: pgfmanual-en-library-er-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x21.14, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -914,11 +946,13 @@ TEST 7: pgfmanual-en-library-er-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.0)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -961,10 +995,12 @@ TEST 7: pgfmanual-en-library-er-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.42+1.0)x23.51, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/it/10 n
 .............\TU/lmr/m/it/10 a
 .............\TU/lmr/m/it/10 m
 .............\TU/lmr/m/it/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1012,12 +1048,14 @@ TEST 7: pgfmanual-en-library-er-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.0)x35.62001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 G
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1056,9 +1094,11 @@ TEST 7: pgfmanual-en-library-er-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.0)x14.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-fit.tlg
+++ b/testfiles-examples/pgfmanual-en-library-fit.tlg
@@ -82,6 +82,8 @@ TEST 1: pgfmanual-en-library-fit-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -117,6 +119,8 @@ TEST 1: pgfmanual-en-library-fit-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -152,6 +156,8 @@ TEST 1: pgfmanual-en-library-fit-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -187,6 +193,8 @@ TEST 1: pgfmanual-en-library-fit-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -222,6 +230,8 @@ TEST 1: pgfmanual-en-library-fit-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -256,6 +266,7 @@ TEST 1: pgfmanual-en-library-fit-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(26.74115+26.85115)x32.25273, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+0.11)x32.25273, direction TLT
 ............\hbox(6.94+0.11)x32.25273, glue set 8.20638fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -274,6 +285,7 @@ TEST 1: pgfmanual-en-library-fit-1
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -306,6 +318,7 @@ TEST 1: pgfmanual-en-library-fit-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(26.79614+26.79616)x32.25273, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x32.25273, direction TLT
 ............\hbox(0.0+0.0)x32.25273, glue set 16.12637fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -319,6 +332,7 @@ TEST 1: pgfmanual-en-library-fit-1
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -421,6 +435,8 @@ TEST 2: pgfmanual-en-library-fit-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -456,6 +472,8 @@ TEST 2: pgfmanual-en-library-fit-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -491,6 +509,8 @@ TEST 2: pgfmanual-en-library-fit-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -526,6 +546,8 @@ TEST 2: pgfmanual-en-library-fit-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -561,6 +583,8 @@ TEST 2: pgfmanual-en-library-fit-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -595,6 +619,7 @@ TEST 2: pgfmanual-en-library-fit-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(26.79614+26.79616)x32.25273, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x32.25273, direction TLT
 ............\hbox(0.0+0.0)x32.25273, glue set 16.12637fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -608,6 +633,7 @@ TEST 2: pgfmanual-en-library-fit-2
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -636,11 +662,13 @@ TEST 2: pgfmanual-en-library-fit-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.84, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -702,6 +730,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -737,6 +767,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -779,6 +811,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -822,6 +856,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -864,6 +900,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
+...................\begindir TLT
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -908,6 +946,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -933,9 +973,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94444+0.0)x5.20486, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 d
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -981,6 +1023,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1006,9 +1050,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+0.0)x4.65627, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 e
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1056,6 +1102,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
+...................\begindir TLT
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1081,9 +1129,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.94444+0.0)x4.29166, direction TLT
+...................\begindir TLT
 ...................\mathon
 ...................\OML/cmm/m/it/10 b
 ...................\mathoff
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1131,6 +1181,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1156,9 +1208,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.30554+0.0)x5.28589, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\OML/cmm/m/it/10 a
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1222,6 +1276,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1266,6 +1322,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
+...................\begindir TLT
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1291,9 +1349,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(4.30554+0.0)x4.32756, direction TLT
+...................\begindir TLT
 ...................\mathon
 ...................\OML/cmm/m/it/10 c
 ...................\mathoff
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1339,6 +1399,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(0.0+0.0)x0.0, direction TLT
+...................\begindir TLT
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1364,10 +1426,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\pdfliteral origin{0 G }
 ..................\pdfliteral origin{0 g }
 ..................\hbox(6.94444+1.94444)x5.97226, direction TLT
+...................\begindir TLT
 ...................\mathon
 ...................\OML/cmm/m/it/10 f
 ...................\kern1.0764 (italic)
 ...................\mathoff
+...................\enddir TLT
 ..................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
@@ -1405,9 +1469,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x5.17015, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^Z
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1457,6 +1523,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(33.2586+33.2586)x75.83287, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x75.83287, direction TLT
 ............\hbox(0.0+0.0)x75.83287, glue set 37.91644fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -1470,6 +1537,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1495,6 +1563,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.87892+0.0)x26.52124, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 F
 ...........\kern1.3889 (italic)
@@ -1506,6 +1575,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\kern0.03583 (italic)
 ............\OT1/cmr/m/n/7 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1549,6 +1619,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(23.56105+23.56107)x54.89497, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x54.89497, direction TLT
 ............\hbox(0.0+0.0)x54.89497, glue set 27.4475fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -1562,6 +1633,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1585,6 +1657,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.87892+0.0)x26.57832, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 F
 ...........\kern1.3889 (italic)
@@ -1596,6 +1669,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\kern0.03583 (italic)
 ............\OT1/cmr/m/n/7 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1698,6 +1772,8 @@ TEST 4: pgfmanual-en-library-fit-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1733,6 +1809,8 @@ TEST 4: pgfmanual-en-library-fit-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1768,6 +1846,8 @@ TEST 4: pgfmanual-en-library-fit-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1803,6 +1883,8 @@ TEST 4: pgfmanual-en-library-fit-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1838,6 +1920,8 @@ TEST 4: pgfmanual-en-library-fit-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1868,6 +1952,7 @@ TEST 4: pgfmanual-en-library-fit-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(26.79614+26.79616)x32.25273, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x32.25273, direction TLT
 ............\hbox(0.0+0.0)x32.25273, glue set 16.12637fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -1881,6 +1966,7 @@ TEST 4: pgfmanual-en-library-fit-4
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1919,6 +2005,7 @@ TEST 4: pgfmanual-en-library-fit-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(24.9845+24.98451)x46.66771, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x46.66771, direction TLT
 ............\hbox(0.0+0.0)x46.66771, glue set 23.33386fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -1932,6 +2019,7 @@ TEST 4: pgfmanual-en-library-fit-4
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-folding.tlg
+++ b/testfiles-examples/pgfmanual-en-library-folding.tlg
@@ -44,6 +44,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+1.435)x42.69304, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 J
 .............\TU/lmss/bx/n/7 a
@@ -61,6 +62,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -88,7 +90,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -117,7 +121,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -146,9 +152,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -178,7 +186,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -207,7 +217,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -236,7 +248,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -265,7 +279,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -294,7 +310,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -323,7 +341,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -352,10 +372,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -385,8 +407,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -415,8 +439,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -445,8 +471,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -475,8 +503,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -505,8 +535,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -535,8 +567,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -565,10 +599,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -598,8 +634,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -628,8 +666,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -658,8 +698,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -688,8 +730,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -718,8 +762,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -748,8 +794,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -778,10 +826,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -811,8 +861,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -841,8 +893,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -871,8 +925,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -901,8 +957,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -931,8 +989,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -961,8 +1021,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -991,10 +1053,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1032,6 +1096,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+1.435)x45.40904, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 F
 .............\kern-0.217 (font)
@@ -1052,6 +1117,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1079,7 +1145,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1108,7 +1176,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1137,7 +1207,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1166,7 +1238,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1195,7 +1269,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1224,7 +1300,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1253,9 +1331,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1285,7 +1365,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1314,7 +1396,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1343,8 +1427,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1373,8 +1459,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1403,8 +1491,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1433,8 +1523,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1463,10 +1555,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1496,8 +1590,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1526,8 +1622,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1556,8 +1654,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1586,8 +1686,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1616,8 +1718,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1646,8 +1750,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1676,10 +1782,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1709,8 +1817,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1739,8 +1849,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1769,8 +1881,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1799,8 +1913,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1829,8 +1945,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1859,8 +1977,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1889,10 +2009,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1922,8 +2044,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1960,6 +2084,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+0.154)x38.22704, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 M
 .............\TU/lmss/bx/n/7 a
@@ -1973,6 +2098,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2000,7 +2126,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2029,7 +2157,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2058,7 +2188,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2087,7 +2219,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2116,7 +2250,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2145,9 +2281,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 6
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2177,7 +2315,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2206,7 +2346,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2235,7 +2377,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2264,8 +2408,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2294,8 +2440,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2324,8 +2472,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2354,10 +2504,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2387,8 +2539,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2417,8 +2571,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2447,8 +2603,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2477,8 +2635,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2507,8 +2667,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2537,8 +2699,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2567,10 +2731,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2600,8 +2766,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2630,8 +2798,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2660,8 +2830,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2690,8 +2862,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2720,8 +2894,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2750,8 +2926,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2780,10 +2958,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2813,8 +2993,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2843,8 +3025,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2873,8 +3057,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2903,8 +3089,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3166,6 +3354,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+1.358)x32.99805, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 A
 .............\TU/lmss/bx/n/7 p
@@ -3179,6 +3368,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3206,7 +3396,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3235,7 +3427,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3264,9 +3458,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3296,7 +3492,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3325,7 +3523,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3354,7 +3554,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3383,7 +3585,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3412,7 +3616,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3441,7 +3647,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3470,10 +3678,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3503,8 +3713,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3533,8 +3745,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3563,8 +3777,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3593,8 +3809,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3623,8 +3841,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3653,8 +3873,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3683,10 +3905,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3716,8 +3940,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3746,8 +3972,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3776,8 +4004,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3806,8 +4036,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3836,8 +4068,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3866,8 +4100,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3896,10 +4132,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3929,8 +4167,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3959,8 +4199,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3989,8 +4231,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4019,8 +4263,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4049,8 +4295,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4079,8 +4327,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4117,6 +4367,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+1.435)x31.77303, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 M
 .............\TU/lmss/bx/n/7 a
@@ -4128,6 +4379,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4155,9 +4407,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4187,7 +4441,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4216,7 +4472,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4245,7 +4503,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4274,7 +4534,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4303,7 +4565,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4332,7 +4596,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4361,9 +4627,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 8
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4393,7 +4661,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4422,8 +4692,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4452,8 +4724,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4482,8 +4756,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4512,8 +4788,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4542,8 +4820,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4572,10 +4852,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4605,8 +4887,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4635,8 +4919,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4665,8 +4951,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4695,8 +4983,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4725,8 +5015,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4755,8 +5047,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4785,10 +5079,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4818,8 +5114,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4848,8 +5146,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4878,8 +5178,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4908,8 +5210,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4938,8 +5242,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4968,8 +5274,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4998,10 +5306,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5031,8 +5341,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5061,8 +5373,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5270,6 +5584,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+0.154)x33.03302, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 J
 .............\TU/lmss/bx/n/7 u
@@ -5281,6 +5596,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5308,7 +5624,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5337,7 +5655,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5366,7 +5686,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5395,7 +5717,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5424,9 +5748,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5456,7 +5782,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5485,7 +5813,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5514,7 +5844,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5543,7 +5875,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5572,8 +5906,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5602,8 +5938,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5632,10 +5970,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5665,8 +6005,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5695,8 +6037,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5725,8 +6069,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5755,8 +6101,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5785,8 +6133,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5815,8 +6165,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5845,10 +6197,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5878,8 +6232,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5908,8 +6264,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5938,8 +6296,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5968,8 +6328,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5998,8 +6360,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6028,8 +6392,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6058,10 +6424,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6091,8 +6459,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6121,8 +6491,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6151,8 +6523,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6181,8 +6555,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6219,6 +6595,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+1.435)x30.82103, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 J
 .............\TU/lmss/bx/n/7 u
@@ -6230,6 +6607,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6257,7 +6635,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6286,7 +6666,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6315,9 +6697,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6347,7 +6731,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6376,7 +6762,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6405,7 +6793,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6434,7 +6824,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6463,7 +6855,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6492,7 +6886,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6521,10 +6917,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6554,8 +6952,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6584,8 +6984,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6614,8 +7016,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6644,8 +7048,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6674,8 +7080,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6704,8 +7112,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6734,10 +7144,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6767,8 +7179,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6797,8 +7211,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6827,8 +7243,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6857,8 +7275,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6887,8 +7307,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6917,8 +7339,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6947,10 +7371,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6980,8 +7406,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7010,8 +7438,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7040,8 +7470,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7070,8 +7502,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7100,8 +7534,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7130,8 +7566,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7160,10 +7598,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7372,6 +7812,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+1.442)x40.36903, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 A
 .............\kern-0.217 (font)
@@ -7388,6 +7829,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7415,7 +7857,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7444,7 +7888,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7473,7 +7919,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7502,7 +7950,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7531,7 +7981,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7560,7 +8012,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7589,9 +8043,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7621,7 +8077,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7650,7 +8108,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7679,8 +8139,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7709,8 +8171,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7739,8 +8203,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7769,8 +8235,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7799,10 +8267,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7832,8 +8302,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7862,8 +8334,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7892,8 +8366,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7922,8 +8398,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7952,8 +8430,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7982,8 +8462,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8012,10 +8494,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8045,8 +8529,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8075,8 +8561,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8105,8 +8593,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8135,8 +8625,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8165,8 +8657,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8195,8 +8689,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8225,10 +8721,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8258,8 +8756,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8288,8 +8788,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8318,8 +8820,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8356,6 +8860,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+1.358)x52.54901, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 S
 .............\TU/lmss/bx/n/7 e
@@ -8375,6 +8880,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8402,7 +8908,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8431,7 +8939,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8460,7 +8970,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8489,9 +9001,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8521,7 +9035,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8550,7 +9066,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8579,7 +9097,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8608,7 +9128,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8637,7 +9159,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8666,8 +9190,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8696,10 +9222,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8729,8 +9257,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8759,8 +9289,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8789,8 +9321,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8819,8 +9353,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8849,8 +9385,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8879,8 +9417,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8909,10 +9449,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8942,8 +9484,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8972,8 +9516,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9002,8 +9548,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9032,8 +9580,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9062,8 +9612,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9092,8 +9644,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9122,10 +9676,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9155,8 +9711,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9185,8 +9743,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9215,8 +9775,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9245,8 +9807,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9275,8 +9839,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9484,6 +10050,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+0.154)x43.95303, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 O
 .............\TU/lmss/bx/n/7 c
@@ -9503,6 +10070,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9530,7 +10098,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9559,9 +10129,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9591,7 +10163,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9620,7 +10194,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9649,7 +10225,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9678,7 +10256,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9707,7 +10287,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9736,7 +10318,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9765,9 +10349,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 9
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9797,8 +10383,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9827,8 +10415,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9857,8 +10447,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9887,8 +10479,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9917,8 +10511,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9947,8 +10543,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9977,10 +10575,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10010,8 +10610,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10040,8 +10642,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10070,8 +10674,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10100,8 +10706,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10130,8 +10738,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10160,8 +10770,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10190,10 +10802,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10223,8 +10837,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10253,8 +10869,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10283,8 +10901,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10313,8 +10933,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10343,8 +10965,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10373,8 +10997,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10403,10 +11029,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10436,8 +11064,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10474,6 +11104,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+0.154)x50.84802, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 N
 .............\TU/lmss/bx/n/7 o
@@ -10492,6 +11123,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10519,7 +11151,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10548,7 +11182,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10577,7 +11213,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10606,7 +11244,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10635,7 +11275,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10664,9 +11306,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 6
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10696,7 +11340,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10725,7 +11371,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10754,7 +11402,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10783,8 +11433,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10813,8 +11465,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10843,8 +11497,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10873,10 +11529,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10906,8 +11564,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10936,8 +11596,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10966,8 +11628,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10996,8 +11660,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11026,8 +11692,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11056,8 +11724,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11086,10 +11756,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11119,8 +11791,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11149,8 +11823,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11179,8 +11855,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11209,8 +11887,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11239,8 +11919,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11269,8 +11951,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11299,10 +11983,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11332,8 +12018,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11362,8 +12050,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11392,8 +12082,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11471,6 +12163,7 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.012+0.154)x50.49802, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmss/bx/n/7 D
 .............\TU/lmss/bx/n/7 e
@@ -11491,6 +12184,7 @@ TEST 1: pgfmanual-en-library-folding-1
 .............\TU/lmss/bx/n/7 0
 .............\TU/lmss/bx/n/7 1
 .............\TU/lmss/bx/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11518,7 +12212,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11547,7 +12243,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11576,7 +12274,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11605,9 +12305,11 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.592+0.0)x3.717, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11637,7 +12339,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11666,7 +12370,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11695,7 +12401,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.592+0.07)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11724,7 +12432,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11753,7 +12463,9 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x3.717, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11782,8 +12494,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11812,10 +12526,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11845,8 +12561,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11875,8 +12593,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11905,8 +12625,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11935,8 +12657,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11965,8 +12689,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11995,8 +12721,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12025,10 +12753,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 8
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12058,8 +12788,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 1
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12088,8 +12820,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12118,8 +12852,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12148,8 +12884,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12178,8 +12916,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12208,8 +12948,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.0)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12238,10 +12980,12 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12271,8 +13015,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12301,8 +13047,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.07)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12331,8 +13079,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12361,8 +13111,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 2
 .............\TU/lmss/m/n/7 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12391,8 +13143,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12421,8 +13175,10 @@ TEST 1: pgfmanual-en-library-folding-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.739+0.147)x7.43399, direction TLT
+.............\begindir TLT
 .............\TU/lmss/m/n/7 3
 .............\TU/lmss/m/n/7 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12605,9 +13361,11 @@ TEST 2: pgfmanual-en-library-folding-2
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12642,7 +13400,9 @@ TEST 2: pgfmanual-en-library-folding-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12730,7 +13490,9 @@ TEST 2: pgfmanual-en-library-folding-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12819,7 +13581,9 @@ TEST 2: pgfmanual-en-library-folding-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13185,7 +13949,9 @@ TEST 4: pgfmanual-en-library-folding-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13219,7 +13985,9 @@ TEST 4: pgfmanual-en-library-folding-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13388,7 +14156,9 @@ TEST 4: pgfmanual-en-library-folding-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13458,7 +14228,9 @@ TEST 4: pgfmanual-en-library-folding-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13627,7 +14399,9 @@ TEST 4: pgfmanual-en-library-folding-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13697,7 +14471,9 @@ TEST 4: pgfmanual-en-library-folding-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13731,7 +14507,9 @@ TEST 4: pgfmanual-en-library-folding-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13909,7 +14687,9 @@ TEST 4: pgfmanual-en-library-folding-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14017,7 +14797,9 @@ TEST 5: pgfmanual-en-library-folding-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14052,7 +14834,9 @@ TEST 5: pgfmanual-en-library-folding-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14168,7 +14952,9 @@ TEST 5: pgfmanual-en-library-folding-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14248,7 +15034,9 @@ TEST 5: pgfmanual-en-library-folding-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14283,7 +15071,9 @@ TEST 5: pgfmanual-en-library-folding-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14471,7 +15261,9 @@ TEST 5: pgfmanual-en-library-folding-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14606,7 +15398,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14640,7 +15434,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14701,7 +15497,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14816,7 +15614,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14936,7 +15736,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15051,7 +15853,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15170,7 +15974,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15249,7 +16055,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15427,7 +16235,9 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15461,8 +16271,10 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15541,8 +16353,10 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15662,8 +16476,10 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15890,8 +16706,10 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15993,8 +16811,10 @@ TEST 6: pgfmanual-en-library-folding-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16187,7 +17007,9 @@ TEST 7: pgfmanual-en-library-folding-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16221,7 +17043,9 @@ TEST 7: pgfmanual-en-library-folding-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16255,7 +17079,9 @@ TEST 7: pgfmanual-en-library-folding-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16312,7 +17138,9 @@ TEST 7: pgfmanual-en-library-folding-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16400,7 +17228,9 @@ TEST 7: pgfmanual-en-library-folding-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16510,7 +17340,9 @@ TEST 7: pgfmanual-en-library-folding-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16616,7 +17448,9 @@ TEST 7: pgfmanual-en-library-folding-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16673,7 +17507,9 @@ TEST 7: pgfmanual-en-library-folding-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16803,7 +17639,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16837,7 +17675,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16871,7 +17711,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16968,7 +17810,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17155,7 +17999,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17284,7 +18130,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17399,7 +18247,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17626,7 +18476,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17660,7 +18512,9 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17694,8 +18548,10 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17828,8 +18684,10 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17926,8 +18784,10 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18038,8 +18898,10 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18136,8 +18998,10 @@ TEST 8: pgfmanual-en-library-folding-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18384,7 +19248,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18418,7 +19284,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18452,7 +19320,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18711,7 +19581,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18745,7 +19617,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18950,7 +19824,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18984,7 +19860,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19189,7 +20067,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19223,7 +20103,9 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19428,8 +20310,10 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19463,8 +20347,10 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19539,8 +20425,10 @@ TEST 9: pgfmanual-en-library-folding-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19715,7 +20603,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19749,7 +20639,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19842,7 +20734,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19876,7 +20770,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20018,7 +20914,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20174,7 +21072,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20316,7 +21216,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20493,7 +21395,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20527,7 +21431,9 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20633,8 +21539,10 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20736,8 +21644,10 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20843,8 +21753,10 @@ TEST 10: pgfmanual-en-library-folding-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21046,7 +21958,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21081,7 +21995,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21199,7 +22115,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21234,7 +22152,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21358,7 +22278,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21445,7 +22367,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21483,7 +22407,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21521,8 +22447,10 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21560,8 +22488,10 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21680,8 +22610,10 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21898,7 +22830,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22076,7 +23010,9 @@ TEST 11: pgfmanual-en-library-folding-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22193,7 +23129,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22228,7 +23166,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22334,7 +23274,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22371,7 +23313,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22491,7 +23435,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22575,7 +23521,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22612,7 +23560,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22646,8 +23596,10 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22682,8 +23634,10 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22802,8 +23756,10 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23007,7 +23963,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23173,7 +24131,9 @@ TEST 12: pgfmanual-en-library-folding-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23293,7 +24253,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23327,7 +24289,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23361,7 +24325,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23395,7 +24361,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23452,7 +24420,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23688,7 +24658,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23722,7 +24694,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23882,7 +24856,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23916,7 +24892,9 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24018,8 +24996,10 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24120,8 +25100,10 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24155,8 +25137,10 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24190,8 +25174,10 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24302,8 +25288,10 @@ TEST 13: pgfmanual-en-library-folding-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24442,7 +25430,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24476,7 +25466,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24510,7 +25502,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24544,7 +25538,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24578,7 +25574,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24621,7 +25619,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24822,7 +25822,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25022,7 +26024,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25151,7 +26155,9 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25261,8 +26267,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25463,8 +26471,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25664,8 +26674,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25794,8 +26806,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25905,8 +26919,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26093,8 +27109,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26128,8 +27146,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26163,8 +27183,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26234,8 +27256,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26364,8 +27388,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26475,8 +27501,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26677,8 +27705,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26878,8 +27908,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26913,8 +27945,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27097,8 +28131,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27132,8 +28168,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27297,8 +28335,10 @@ TEST 14: pgfmanual-en-library-folding-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27523,7 +28563,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27557,7 +28599,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27591,7 +28635,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27625,7 +28671,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27682,7 +28730,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27739,7 +28789,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27814,7 +28866,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28004,7 +29058,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28038,7 +29094,9 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28072,8 +29130,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28130,8 +29190,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28188,8 +29250,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28223,8 +29287,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28308,8 +29374,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28499,8 +29567,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28534,8 +29604,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28569,8 +29641,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28627,8 +29701,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28685,8 +29761,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28761,8 +29839,10 @@ TEST 15: pgfmanual-en-library-folding-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28990,7 +30070,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29024,7 +30106,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29058,7 +30142,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29092,7 +30178,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29126,7 +30214,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29169,7 +30259,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29298,7 +30390,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29417,7 +30511,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29519,7 +30615,9 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29611,8 +30709,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29741,8 +30841,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29861,8 +30963,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29964,8 +31068,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30057,8 +31163,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30092,8 +31200,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30226,8 +31336,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30261,8 +31373,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30296,8 +31410,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30358,8 +31474,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30461,8 +31579,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30554,8 +31674,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30684,8 +31806,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30804,8 +31928,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30907,8 +32033,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31000,8 +32128,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31035,8 +32165,10 @@ TEST 16: pgfmanual-en-library-folding-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31207,7 +32339,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31242,7 +32376,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31277,7 +32413,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31312,7 +32450,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31388,7 +32528,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31423,7 +32565,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31458,7 +32602,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31579,7 +32725,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31672,7 +32820,9 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31793,8 +32943,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31927,8 +33079,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31963,8 +33117,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31999,8 +33155,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32076,8 +33234,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32112,8 +33272,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32148,8 +33310,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32270,8 +33434,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32364,8 +33530,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32486,8 +33654,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32620,8 +33790,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32656,8 +33828,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32692,8 +33866,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32769,8 +33945,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32805,8 +33983,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32841,8 +34021,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32963,8 +34145,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33057,8 +34241,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33179,8 +34365,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33313,8 +34501,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33349,8 +34539,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33385,8 +34577,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33462,8 +34656,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33498,8 +34694,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33534,8 +34732,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33656,8 +34856,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33692,8 +34894,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33804,8 +35008,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33926,8 +35132,10 @@ TEST 17: pgfmanual-en-library-folding-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34097,7 +35305,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34132,7 +35342,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34167,7 +35379,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34202,7 +35416,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34359,7 +35575,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34479,7 +35697,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34514,7 +35734,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34626,7 +35848,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34702,7 +35926,9 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34764,8 +35990,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34943,8 +36171,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35033,8 +36263,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35069,8 +36301,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35105,8 +36339,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35182,8 +36418,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35218,8 +36456,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35443,8 +36683,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35551,8 +36793,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35587,8 +36831,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35623,8 +36869,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35727,8 +36975,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35763,8 +37013,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35916,8 +37168,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36037,8 +37291,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36150,8 +37406,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36186,8 +37444,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36347,8 +37607,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36383,8 +37645,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36419,8 +37683,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36496,8 +37762,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36532,8 +37800,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36721,8 +37991,10 @@ TEST 18: pgfmanual-en-library-folding-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-lsystems.tlg
+++ b/testfiles-examples/pgfmanual-en-library-lsystems.tlg
@@ -224,8 +224,10 @@ TEST 1: pgfmanual-en-library-lsystems-1
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3376,6 +3378,7 @@ TEST 6: pgfmanual-en-library-lsystems-9
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(48.89755+0.0)x55.525, direction TLT
+........\begindir TLT
 ........\hbox(48.89755+0.0)x55.525, direction TLT
 .........\glue 55.325
 .........\hbox(0.0+0.0)x0.0, shifted -0.2, direction TLT
@@ -3638,6 +3641,7 @@ TEST 6: pgfmanual-en-library-lsystems-9
 ..........\pdfliteral origin{n }
 ..........\pdfliteral origin{Q }
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3658,6 +3662,7 @@ TEST 6: pgfmanual-en-library-lsystems-9
 ......\pdfliteral origin{q }
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(48.89755+0.0)x55.525, direction TLT
+........\begindir TLT
 ........\hbox(48.89755+0.0)x55.525, direction TLT
 .........\glue 0.2
 .........\hbox(0.0+0.0)x0.0, shifted -48.69756, direction TLT
@@ -3920,6 +3925,7 @@ TEST 6: pgfmanual-en-library-lsystems-9
 ..........\pdfliteral origin{n }
 ..........\pdfliteral origin{Q }
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
+........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil

--- a/testfiles-examples/pgfmanual-en-library-matrices.tlg
+++ b/testfiles-examples/pgfmanual-en-library-matrices.tlg
@@ -58,7 +58,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -97,7 +99,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -136,7 +140,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -179,7 +185,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -218,7 +226,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -257,7 +267,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -300,7 +312,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -339,7 +353,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -378,7 +394,9 @@ TEST 1: pgfmanual-en-library-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -493,7 +511,9 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -532,7 +552,9 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -571,7 +593,9 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -614,7 +638,9 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -653,7 +679,9 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -693,9 +721,11 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 7
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -739,7 +769,9 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -778,7 +810,9 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -817,7 +851,9 @@ TEST 2: pgfmanual-en-library-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -909,7 +945,9 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -948,7 +986,9 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -987,7 +1027,9 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1030,7 +1072,9 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1069,7 +1113,9 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1113,9 +1159,11 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 7
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1159,7 +1207,9 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1198,7 +1248,9 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1237,7 +1289,9 @@ TEST 3: pgfmanual-en-library-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1329,7 +1383,9 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1368,7 +1424,9 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1412,9 +1470,11 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 6
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1458,7 +1518,9 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1497,7 +1559,9 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1541,9 +1605,11 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 7
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1587,7 +1653,9 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1626,7 +1694,9 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1665,7 +1735,9 @@ TEST 4: pgfmanual-en-library-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1757,7 +1829,9 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1796,7 +1870,9 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1835,7 +1911,9 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1878,7 +1956,9 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1917,7 +1997,9 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1961,9 +2043,11 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 7
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2017,7 +2101,9 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2056,7 +2142,9 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2095,7 +2183,9 @@ TEST 5: pgfmanual-en-library-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2189,12 +2279,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 8
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2233,12 +2325,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 1
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2277,12 +2371,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 6
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2325,12 +2421,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 3
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2369,12 +2467,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 5
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2418,6 +2518,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
@@ -2426,6 +2527,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\OT1/cmr/m/n/7 7
 .....................\pdfcolorstack 0 pop
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2469,12 +2571,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 4
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2513,12 +2617,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 9
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2557,12 +2663,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 2
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2658,12 +2766,14 @@ TEST 7: pgfmanual-en-library-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 8
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2717,12 +2827,14 @@ TEST 7: pgfmanual-en-library-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 6
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2769,12 +2881,14 @@ TEST 7: pgfmanual-en-library-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 3
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2828,12 +2942,14 @@ TEST 7: pgfmanual-en-library-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 7
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2880,12 +2996,14 @@ TEST 7: pgfmanual-en-library-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 4
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2928,12 +3046,14 @@ TEST 7: pgfmanual-en-library-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 9
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3040,12 +3160,14 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 8
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3088,9 +3210,11 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(0.0+0.0)x0.0, direction TLT
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3133,12 +3257,14 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 6
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3185,12 +3311,14 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 3
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3233,9 +3361,11 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(0.0+0.0)x0.0, direction TLT
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3278,12 +3408,14 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 7
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3330,12 +3462,14 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 4
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3378,12 +3512,14 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 9
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3426,9 +3562,11 @@ TEST 8: pgfmanual-en-library-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(0.0+0.0)x0.0, direction TLT
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3522,6 +3660,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.11)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.66+0.11)x45.5244, direction TLT
 ......................\hbox(6.66+0.11)x45.5244, glue set 21.33142fil, direction TLT
 .......................\localpar
@@ -3540,6 +3679,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3580,6 +3720,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+1.94)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+1.94)x45.5244, direction TLT
 ......................\hbox(6.94+1.94)x45.5244, glue set 1.31143fil, direction TLT
 .......................\localpar
@@ -3605,6 +3746,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3649,6 +3791,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+0.11)x45.5244, direction TLT
 ......................\hbox(6.94+0.11)x45.5244, glue set 3.83142fil, direction TLT
 .......................\localpar
@@ -3673,6 +3816,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3717,6 +3861,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.11)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.66+0.11)x45.5244, direction TLT
 ......................\hbox(6.66+0.11)x45.5244, glue set 21.33142fil, direction TLT
 .......................\localpar
@@ -3735,6 +3880,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3775,6 +3921,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.0)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+0.0)x45.5244, direction TLT
 ......................\hbox(6.94+0.0)x45.5244, glue set 23.3044fil, direction TLT
 .......................\localpar
@@ -3790,6 +3937,7 @@ TEST 9: pgfmanual-en-library-matrices-10
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3883,6 +4031,7 @@ TEST 10: pgfmanual-en-library-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.11)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.66+0.11)x45.5244, direction TLT
 ......................\hbox(6.66+0.11)x45.5244, glue set 21.33142fil, direction TLT
 .......................\localpar
@@ -3901,6 +4050,7 @@ TEST 10: pgfmanual-en-library-matrices-11
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3941,6 +4091,7 @@ TEST 10: pgfmanual-en-library-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+12.11)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+12.11)x45.5244, direction TLT
 ......................\hbox(6.94+1.94)x45.5244, glue set 1.31143fil, direction TLT
 .......................\localpar
@@ -3992,6 +4143,7 @@ TEST 10: pgfmanual-en-library-matrices-11
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4036,6 +4188,7 @@ TEST 10: pgfmanual-en-library-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.11)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.66+0.11)x45.5244, direction TLT
 ......................\hbox(6.66+0.11)x45.5244, glue set 21.33142fil, direction TLT
 .......................\localpar
@@ -4054,6 +4207,7 @@ TEST 10: pgfmanual-en-library-matrices-11
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4094,6 +4248,7 @@ TEST 10: pgfmanual-en-library-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.0)x45.5244, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+0.0)x45.5244, direction TLT
 ......................\hbox(6.94+0.0)x45.5244, glue set 23.3044fil, direction TLT
 .......................\localpar
@@ -4109,6 +4264,7 @@ TEST 10: pgfmanual-en-library-matrices-11
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0 plus 1.0fil
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4201,12 +4357,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 8
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4245,12 +4403,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 1
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4289,12 +4449,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 6
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4337,12 +4499,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 3
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4381,12 +4545,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 5
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4425,12 +4591,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 7
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4473,12 +4641,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 4
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4517,12 +4687,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 9
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4561,12 +4733,14 @@ TEST 11: pgfmanual-en-library-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 2
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4605,6 +4779,7 @@ TEST 11: pgfmanual-en-library-matrices-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(24.74017+19.74017)x9.95001, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
@@ -4620,6 +4795,7 @@ TEST 11: pgfmanual-en-library-matrices-12
 .............\rule(22.24017+22.24017)x0.0
 ............\hbox(0.0+0.0)x1.2, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4643,6 +4819,7 @@ TEST 11: pgfmanual-en-library-matrices-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(24.74017+19.74017)x10.0889, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
@@ -4662,6 +4839,7 @@ TEST 11: pgfmanual-en-library-matrices-12
 .............\hbox(0.0+9.00009)x8.8889, direction TLT
 ..............\OMX/cmex/m/n/10 ;
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4723,6 +4901,7 @@ TEST 12: pgfmanual-en-library-matrices-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.65013+9.11122)x34.4548, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(0.0+22.22246)x5.55557, shifted -13.61122, direction TLT
 ............\OMX/cmex/m/n/10 Z
@@ -4738,6 +4917,7 @@ TEST 12: pgfmanual-en-library-matrices-13
 ...........\OML/cmm/m/it/10 d
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4763,6 +4943,7 @@ TEST 12: pgfmanual-en-library-matrices-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(18.41365+13.41365)x9.11668, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
@@ -4773,6 +4954,7 @@ TEST 12: pgfmanual-en-library-matrices-13
 .............\rule(15.91365+15.91365)x0.0
 ............\hbox(0.0+0.0)x1.2, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4796,6 +4978,7 @@ TEST 12: pgfmanual-en-library-matrices-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(18.41365+13.41365)x9.25558, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
@@ -4806,6 +4989,7 @@ TEST 12: pgfmanual-en-library-matrices-13
 ............\hbox(0.39998+29.60031)x8.05559, shifted -17.10016, direction TLT
 .............\OMX/cmex/m/n/10 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4884,12 +5068,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 8
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4928,12 +5114,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 1
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4972,12 +5160,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 6
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5020,12 +5210,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 3
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5064,12 +5256,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 5
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5108,12 +5302,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 7
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5156,12 +5352,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 4
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5200,12 +5398,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 9
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5244,12 +5444,14 @@ TEST 13: pgfmanual-en-library-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 2
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5293,6 +5495,7 @@ TEST 13: pgfmanual-en-library-matrices-14
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(24.74017+19.74017)x9.95001, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\glue(\spaceskip) 0.0
 ...........\glue(\spaceskip) 0.0
@@ -5310,6 +5513,7 @@ TEST 13: pgfmanual-en-library-matrices-14
 ............\hbox(0.0+0.0)x1.2, direction TLT
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5334,6 +5538,7 @@ TEST 13: pgfmanual-en-library-matrices-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(24.74017+19.74017)x10.0889, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
@@ -5353,6 +5558,7 @@ TEST 13: pgfmanual-en-library-matrices-14
 .............\hbox(0.0+9.00009)x8.8889, direction TLT
 ..............\OMX/cmex/m/n/10 ;
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5433,12 +5639,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 8
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5477,12 +5685,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 1
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5521,12 +5731,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 6
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5569,12 +5781,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 3
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5613,12 +5827,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 5
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5657,12 +5873,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 7
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5705,12 +5923,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 4
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5749,12 +5969,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 9
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5793,12 +6015,14 @@ TEST 14: pgfmanual-en-library-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.30554+1.49998)x9.77202, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(4.30554+1.49998)x9.77202, direction TLT
 ......................\OML/cmm/m/it/10 a
 ......................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 .......................\OT1/cmr/m/n/7 2
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5837,6 +6061,7 @@ TEST 14: pgfmanual-en-library-matrices-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(24.74017+19.74017)x6.75557, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
@@ -5860,6 +6085,7 @@ TEST 14: pgfmanual-en-library-matrices-15
 .............\rule(22.24017+22.24017)x0.0
 ............\hbox(0.0+0.0)x1.2, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5883,6 +6109,7 @@ TEST 14: pgfmanual-en-library-matrices-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(24.74017+19.74017)x10.0889, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
@@ -5912,6 +6139,7 @@ TEST 14: pgfmanual-en-library-matrices-15
 .............\hbox(0.0+9.00009)x8.8889, direction TLT
 ..............\OMX/cmex/m/n/10 :
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5937,6 +6165,7 @@ TEST 14: pgfmanual-en-library-matrices-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(30.68991+25.68991)x9.95001, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
 ...........\hbox(30.68991+25.68991)x9.95001, direction TLT
@@ -5955,6 +6184,7 @@ TEST 14: pgfmanual-en-library-matrices-15
 .............\rule(28.18991+28.18991)x0.0
 ............\hbox(0.0+0.0)x1.2, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5978,6 +6208,7 @@ TEST 14: pgfmanual-en-library-matrices-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(30.68991+25.68991)x10.0889, direction TLT
+...........\begindir TLT
 ...........\glue(\spaceskip) 0.0
 ...........\mathon
 ...........\hbox(30.68991+25.68991)x10.0889, direction TLT
@@ -6004,6 +6235,7 @@ TEST 14: pgfmanual-en-library-matrices-15
 .............\hbox(0.0+9.00009)x8.8889, direction TLT
 ..............\OMX/cmex/m/n/10 ;
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-mindmaps.tlg
+++ b/testfiles-examples/pgfmanual-en-library-mindmaps.tlg
@@ -48,6 +48,7 @@ TEST 1: pgfmanual-en-library-mindmaps-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.196+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.196+2.328)x99.58464, direction TLT
 ............\hbox(8.196+2.328)x99.58464, glue set 0.6481, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -76,6 +77,7 @@ TEST 1: pgfmanual-en-library-mindmaps-1
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -117,6 +119,7 @@ TEST 1: pgfmanual-en-library-mindmaps-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+1.746)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+1.746)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, glue set 0.02663, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -145,6 +148,7 @@ TEST 1: pgfmanual-en-library-mindmaps-1
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -257,6 +261,7 @@ TEST 2: pgfmanual-en-library-mindmaps-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(9.83519+2.7936)x128.0374, direction TLT
+...........\begindir TLT
 ...........\vbox(9.83519+2.7936)x128.0374, direction TLT
 ............\hbox(9.83519+2.7936)x128.0374, glue set 0.7963, direction TLT
 .............\glue(\leftskip) 0.0 plus 28.79999
@@ -285,6 +290,7 @@ TEST 2: pgfmanual-en-library-mindmaps-2
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 28.79999
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -326,6 +332,7 @@ TEST 2: pgfmanual-en-library-mindmaps-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+1.94)x79.6678, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+1.94)x79.6678, direction TLT
 ..............\hbox(7.05+1.94)x79.6678, glue set 0.47762, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -354,6 +361,7 @@ TEST 2: pgfmanual-en-library-mindmaps-2
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -465,6 +473,7 @@ TEST 3: pgfmanual-en-library-mindmaps-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.448+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.448+2.328)x99.58464, direction TLT
 ............\hbox(8.448+2.328)x99.58464, glue set 0.60411, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -492,6 +501,7 @@ TEST 3: pgfmanual-en-library-mindmaps-3
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -561,6 +571,7 @@ TEST 4: pgfmanual-en-library-mindmaps-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.196+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.196+2.328)x99.58464, direction TLT
 ............\hbox(8.196+2.328)x99.58464, glue set 0.6481, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -589,6 +600,7 @@ TEST 4: pgfmanual-en-library-mindmaps-4
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -627,6 +639,7 @@ TEST 4: pgfmanual-en-library-mindmaps-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.92+11.052)x42.67912, direction TLT
+...........\begindir TLT
 ...........\vbox(4.92+11.052)x42.67912, direction TLT
 ............\hbox(4.92+0.08)x42.67912, glue set 0.73598, direction TLT
 .............\glue(\leftskip) 0.0 plus 16.0
@@ -661,6 +674,7 @@ TEST 4: pgfmanual-en-library-mindmaps-4
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 16.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -729,6 +743,7 @@ TEST 5: pgfmanual-en-library-mindmaps-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.196+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.196+2.328)x99.58464, direction TLT
 ............\hbox(8.196+2.328)x99.58464, glue set 0.6481, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -757,6 +772,7 @@ TEST 5: pgfmanual-en-library-mindmaps-5
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -826,6 +842,7 @@ TEST 6: pgfmanual-en-library-mindmaps-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.196+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.196+2.328)x99.58464, direction TLT
 ............\hbox(8.196+2.328)x99.58464, glue set 0.6481, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -854,6 +871,7 @@ TEST 6: pgfmanual-en-library-mindmaps-6
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -895,6 +913,7 @@ TEST 6: pgfmanual-en-library-mindmaps-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 1.04521, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -914,6 +933,7 @@ TEST 6: pgfmanual-en-library-mindmaps-6
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1003,6 +1023,7 @@ TEST 6: pgfmanual-en-library-mindmaps-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 1.04521, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -1022,6 +1043,7 @@ TEST 6: pgfmanual-en-library-mindmaps-6
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1135,6 +1157,7 @@ TEST 7: pgfmanual-en-library-mindmaps-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.196+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.196+2.328)x99.58464, direction TLT
 ............\hbox(8.196+2.328)x99.58464, glue set 0.6481, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -1163,6 +1186,7 @@ TEST 7: pgfmanual-en-library-mindmaps-7
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1205,6 +1229,7 @@ TEST 7: pgfmanual-en-library-mindmaps-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+1.746)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+1.746)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, glue set 0.02663, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -1233,6 +1258,7 @@ TEST 7: pgfmanual-en-library-mindmaps-7
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1327,8 +1353,10 @@ TEST 7: pgfmanual-en-library-mindmaps-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -1371,6 +1399,7 @@ TEST 7: pgfmanual-en-library-mindmaps-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+1.746)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+1.746)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, glue set 0.02663, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -1399,6 +1428,7 @@ TEST 7: pgfmanual-en-library-mindmaps-7
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1488,8 +1518,10 @@ TEST 7: pgfmanual-en-library-mindmaps-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -1559,6 +1591,7 @@ TEST 8: pgfmanual-en-library-mindmaps-8
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(8.196+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.196+2.328)x99.58464, direction TLT
 ............\hbox(8.196+2.328)x99.58464, glue set 0.6481, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -1589,6 +1622,7 @@ TEST 8: pgfmanual-en-library-mindmaps-8
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1631,6 +1665,7 @@ TEST 8: pgfmanual-en-library-mindmaps-8
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 1.04521, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -1652,6 +1687,7 @@ TEST 8: pgfmanual-en-library-mindmaps-8
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1746,8 +1782,10 @@ TEST 8: pgfmanual-en-library-mindmaps-8
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -1790,6 +1828,7 @@ TEST 8: pgfmanual-en-library-mindmaps-8
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 1.04521, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -1811,6 +1850,7 @@ TEST 8: pgfmanual-en-library-mindmaps-8
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1900,8 +1940,10 @@ TEST 8: pgfmanual-en-library-mindmaps-8
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -2006,6 +2048,7 @@ TEST 9: pgfmanual-en-library-mindmaps-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.196+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.196+2.328)x99.58464, direction TLT
 ............\hbox(8.196+2.328)x99.58464, glue set 0.6481, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -2034,6 +2077,7 @@ TEST 9: pgfmanual-en-library-mindmaps-9
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2076,6 +2120,7 @@ TEST 9: pgfmanual-en-library-mindmaps-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 1.04521, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -2095,6 +2140,7 @@ TEST 9: pgfmanual-en-library-mindmaps-9
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2185,6 +2231,7 @@ TEST 9: pgfmanual-en-library-mindmaps-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 1.04521, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -2204,6 +2251,7 @@ TEST 9: pgfmanual-en-library-mindmaps-9
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2289,6 +2337,7 @@ TEST 9: pgfmanual-en-library-mindmaps-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 1.04521, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -2308,6 +2357,7 @@ TEST 9: pgfmanual-en-library-mindmaps-9
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2711,8 +2761,10 @@ TEST 13: pgfmanual-en-library-mindmaps-13
 ..........\pdfliteral origin{0.5 0.5 1 RG }
 ..........\pdfliteral origin{0.5 0.5 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 0.5 1 rg 0.5 0.5 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2748,8 +2800,10 @@ TEST 13: pgfmanual-en-library-mindmaps-13
 ..........\pdfliteral origin{0.5 0.5 1 RG }
 ..........\pdfliteral origin{0.5 0.5 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 0.5 1 rg 0.5 0.5 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2859,8 +2913,10 @@ TEST 14: pgfmanual-en-library-mindmaps-14
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2900,8 +2956,10 @@ TEST 14: pgfmanual-en-library-mindmaps-14
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2996,8 +3054,10 @@ TEST 14: pgfmanual-en-library-mindmaps-14
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\glue(\spaceskip) 0.0
@@ -3070,6 +3130,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(8.448+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.448+2.328)x99.58464, direction TLT
 ............\hbox(8.448+2.328)x99.58464, glue set 0.14186, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -3105,6 +3166,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3147,6 +3209,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.246+1.746)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+1.746)x56.9055, direction TLT
 ..............\hbox(6.246+1.746)x56.9055, glue set 0.60896, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -3175,6 +3238,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3264,8 +3328,10 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -3306,6 +3372,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+1.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+1.64)x42.67912, direction TLT
 ................\hbox(5.552+1.64)x42.67912, glue set 0.10773, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -3335,6 +3402,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3424,6 +3492,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.81747, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -3460,6 +3529,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3549,6 +3619,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(3.568+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(3.568+20.64)x42.67912, direction TLT
 ................\hbox(3.568+1.552)x42.67912, glue set 0.86147, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -3598,6 +3669,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3687,6 +3759,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.632+11.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+11.14)x42.67912, direction TLT
 ................\hbox(5.632+0.08)x42.67912, glue set 0.38072, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -3732,6 +3805,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3824,6 +3898,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.246+1.746)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+1.746)x56.9055, direction TLT
 ..............\hbox(6.246+1.746)x56.9055, glue set 0.76671, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -3848,6 +3923,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3942,8 +4018,10 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -3984,6 +4062,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+0.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+0.08)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.20972, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -4008,6 +4087,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4097,6 +4177,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.464+0.168)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+0.168)x42.67912, direction TLT
 ................\hbox(5.464+0.168)x42.67912, glue set 0.51547, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -4115,6 +4196,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4207,6 +4289,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 0.58821, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -4236,6 +4319,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4330,8 +4414,10 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -4374,6 +4460,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.246+0.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.246+0.099)x56.9055, direction TLT
 ..............\hbox(6.246+0.099)x56.9055, glue set 0.39471, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -4408,6 +4495,7 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4502,8 +4590,10 @@ TEST 15: pgfmanual-en-library-mindmaps-15
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -4574,6 +4664,7 @@ TEST 16: pgfmanual-en-library-mindmaps-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.196+2.328)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.196+2.328)x99.58464, direction TLT
 ............\hbox(8.196+2.328)x99.58464, glue set 0.6481, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -4602,6 +4693,7 @@ TEST 16: pgfmanual-en-library-mindmaps-16
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4645,6 +4737,7 @@ TEST 16: pgfmanual-en-library-mindmaps-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.47+6.97)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(3.47+6.97)x99.58464, direction TLT
 ............\hbox(3.47+1.03)x99.58464, glue set 5.05467fil, direction TLT
 .............\localpar
@@ -4733,6 +4826,7 @@ TEST 16: pgfmanual-en-library-mindmaps-16
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-perspective.tlg
+++ b/testfiles-examples/pgfmanual-en-library-perspective.tlg
@@ -45,7 +45,9 @@ TEST 1: pgfmanual-en-library-perspective-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -81,7 +83,9 @@ TEST 1: pgfmanual-en-library-perspective-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -117,7 +121,9 @@ TEST 1: pgfmanual-en-library-perspective-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -181,7 +187,9 @@ TEST 2: pgfmanual-en-library-perspective-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -217,7 +225,9 @@ TEST 2: pgfmanual-en-library-perspective-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -253,7 +263,9 @@ TEST 2: pgfmanual-en-library-perspective-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -424,7 +436,9 @@ TEST 3: pgfmanual-en-library-perspective-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -460,7 +474,9 @@ TEST 3: pgfmanual-en-library-perspective-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -496,7 +512,9 @@ TEST 3: pgfmanual-en-library-perspective-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -677,7 +695,9 @@ TEST 4: pgfmanual-en-library-perspective-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -713,7 +733,9 @@ TEST 4: pgfmanual-en-library-perspective-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -749,7 +771,9 @@ TEST 4: pgfmanual-en-library-perspective-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -922,7 +946,9 @@ TEST 5: pgfmanual-en-library-perspective-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -958,7 +984,9 @@ TEST 5: pgfmanual-en-library-perspective-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -994,7 +1022,9 @@ TEST 5: pgfmanual-en-library-perspective-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1167,7 +1197,9 @@ TEST 6: pgfmanual-en-library-perspective-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1203,7 +1235,9 @@ TEST 6: pgfmanual-en-library-perspective-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1239,7 +1273,9 @@ TEST 6: pgfmanual-en-library-perspective-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1412,7 +1448,9 @@ TEST 7: pgfmanual-en-library-perspective-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1448,7 +1486,9 @@ TEST 7: pgfmanual-en-library-perspective-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1484,7 +1524,9 @@ TEST 7: pgfmanual-en-library-perspective-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1657,7 +1699,9 @@ TEST 8: pgfmanual-en-library-perspective-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1693,7 +1737,9 @@ TEST 8: pgfmanual-en-library-perspective-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1729,7 +1775,9 @@ TEST 8: pgfmanual-en-library-perspective-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1902,7 +1950,9 @@ TEST 9: pgfmanual-en-library-perspective-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1938,7 +1988,9 @@ TEST 9: pgfmanual-en-library-perspective-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1974,7 +2026,9 @@ TEST 9: pgfmanual-en-library-perspective-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2147,7 +2201,9 @@ TEST 10: pgfmanual-en-library-perspective-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2183,7 +2239,9 @@ TEST 10: pgfmanual-en-library-perspective-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2219,7 +2277,9 @@ TEST 10: pgfmanual-en-library-perspective-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2438,6 +2498,8 @@ TEST 12: pgfmanual-en-library-perspective-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2463,7 +2525,9 @@ TEST 12: pgfmanual-en-library-perspective-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6323,6 +6387,8 @@ TEST 14: pgfmanual-en-library-perspective-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6348,7 +6414,9 @@ TEST 14: pgfmanual-en-library-perspective-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6382,6 +6450,8 @@ TEST 14: pgfmanual-en-library-perspective-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6405,7 +6475,9 @@ TEST 14: pgfmanual-en-library-perspective-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 q
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6439,6 +6511,8 @@ TEST 14: pgfmanual-en-library-perspective-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6464,7 +6538,9 @@ TEST 14: pgfmanual-en-library-perspective-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+0.0)x3.92, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-petri.tlg
+++ b/testfiles-examples/pgfmanual-en-library-petri.tlg
@@ -42,6 +42,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -67,11 +69,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -111,8 +115,10 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -157,8 +163,10 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -197,6 +205,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -222,6 +232,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+1.94444)x27.85062, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -231,6 +242,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -300,6 +312,8 @@ TEST 2: pgfmanual-en-library-petri-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -339,8 +353,10 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -385,8 +401,10 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -431,8 +449,10 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -477,8 +497,10 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -523,8 +545,10 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -569,8 +593,10 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -615,8 +641,10 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -647,11 +675,13 @@ TEST 2: pgfmanual-en-library-petri-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -693,6 +723,8 @@ TEST 2: pgfmanual-en-library-petri-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -732,9 +764,11 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -779,9 +813,11 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -826,9 +862,11 @@ TEST 2: pgfmanual-en-library-petri-2
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 9
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -859,6 +897,7 @@ TEST 2: pgfmanual-en-library-petri-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+1.94444)x27.85062, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -868,6 +907,7 @@ TEST 2: pgfmanual-en-library-petri-2
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -928,6 +968,8 @@ TEST 3: pgfmanual-en-library-petri-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -967,8 +1009,10 @@ TEST 3: pgfmanual-en-library-petri-3
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1013,8 +1057,10 @@ TEST 3: pgfmanual-en-library-petri-3
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1045,11 +1091,13 @@ TEST 3: pgfmanual-en-library-petri-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1083,6 +1131,8 @@ TEST 3: pgfmanual-en-library-petri-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1108,6 +1158,7 @@ TEST 3: pgfmanual-en-library-petri-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+1.94444)x27.85062, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -1117,6 +1168,7 @@ TEST 3: pgfmanual-en-library-petri-3
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1150,6 +1202,8 @@ TEST 3: pgfmanual-en-library-petri-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1175,11 +1229,13 @@ TEST 3: pgfmanual-en-library-petri-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15079+1.49998)x8.09724, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 t
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1234,7 +1290,9 @@ TEST 3: pgfmanual-en-library-petri-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1297,6 +1355,8 @@ TEST 4: pgfmanual-en-library-petri-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1322,11 +1382,13 @@ TEST 4: pgfmanual-en-library-petri-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1362,8 +1424,10 @@ TEST 4: pgfmanual-en-library-petri-4
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1397,6 +1461,8 @@ TEST 4: pgfmanual-en-library-petri-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1422,11 +1488,13 @@ TEST 4: pgfmanual-en-library-petri-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1462,12 +1530,14 @@ TEST 4: pgfmanual-en-library-petri-4
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(2.15277+0.97221)x3.8322, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/5 y
 ...........\kern0.17938 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1528,6 +1598,8 @@ TEST 5: pgfmanual-en-library-petri-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1553,11 +1625,13 @@ TEST 5: pgfmanual-en-library-petri-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1597,9 +1671,11 @@ TEST 5: pgfmanual-en-library-petri-5
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1644,9 +1720,11 @@ TEST 5: pgfmanual-en-library-petri-5
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1691,9 +1769,11 @@ TEST 5: pgfmanual-en-library-petri-5
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1759,6 +1839,8 @@ TEST 6: pgfmanual-en-library-petri-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1784,11 +1866,13 @@ TEST 6: pgfmanual-en-library-petri-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1828,9 +1912,11 @@ TEST 6: pgfmanual-en-library-petri-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1877,9 +1963,11 @@ TEST 6: pgfmanual-en-library-petri-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1926,9 +2014,11 @@ TEST 6: pgfmanual-en-library-petri-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1973,9 +2063,11 @@ TEST 6: pgfmanual-en-library-petri-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2041,6 +2133,8 @@ TEST 7: pgfmanual-en-library-petri-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2066,11 +2160,13 @@ TEST 7: pgfmanual-en-library-petri-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2110,8 +2206,10 @@ TEST 7: pgfmanual-en-library-petri-7
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2159,8 +2257,10 @@ TEST 7: pgfmanual-en-library-petri-7
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2209,8 +2309,10 @@ TEST 7: pgfmanual-en-library-petri-7
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2256,8 +2358,10 @@ TEST 7: pgfmanual-en-library-petri-7
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2321,6 +2425,8 @@ TEST 8: pgfmanual-en-library-petri-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2360,8 +2466,10 @@ TEST 8: pgfmanual-en-library-petri-8
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2406,8 +2514,10 @@ TEST 8: pgfmanual-en-library-petri-8
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2452,8 +2562,10 @@ TEST 8: pgfmanual-en-library-petri-8
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2506,6 +2618,8 @@ TEST 8: pgfmanual-en-library-petri-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2545,8 +2659,10 @@ TEST 8: pgfmanual-en-library-petri-8
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2591,8 +2707,10 @@ TEST 8: pgfmanual-en-library-petri-8
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2637,8 +2755,10 @@ TEST 8: pgfmanual-en-library-petri-8
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2703,6 +2823,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2742,8 +2864,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2780,6 +2904,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2819,8 +2945,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2865,8 +2993,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2903,6 +3033,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2942,8 +3074,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2988,8 +3122,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3034,8 +3170,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3072,6 +3210,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3111,8 +3251,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3157,8 +3299,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3203,8 +3347,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3249,8 +3395,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3287,6 +3435,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3326,8 +3476,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3372,8 +3524,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3418,8 +3572,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3464,8 +3620,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3510,8 +3668,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3548,6 +3708,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3587,8 +3749,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3633,8 +3797,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3679,8 +3845,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3725,8 +3893,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3771,8 +3941,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3817,8 +3989,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3855,6 +4029,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3894,8 +4070,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3940,8 +4118,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3986,8 +4166,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4032,8 +4214,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4078,8 +4262,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4124,8 +4310,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4170,8 +4358,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4208,6 +4398,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4247,8 +4439,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4293,8 +4487,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4339,8 +4535,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4385,8 +4583,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4431,8 +4631,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4477,8 +4679,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4523,8 +4727,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4569,8 +4775,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4607,6 +4815,8 @@ TEST 9: pgfmanual-en-library-petri-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4646,8 +4856,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4692,8 +4904,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4738,8 +4952,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4784,8 +5000,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4830,8 +5048,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4876,8 +5096,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4922,8 +5144,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4968,8 +5192,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5014,8 +5240,10 @@ TEST 9: pgfmanual-en-library-petri-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5080,6 +5308,8 @@ TEST 10: pgfmanual-en-library-petri-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5122,8 +5352,10 @@ TEST 10: pgfmanual-en-library-petri-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5172,8 +5404,10 @@ TEST 10: pgfmanual-en-library-petri-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5222,8 +5456,10 @@ TEST 10: pgfmanual-en-library-petri-10
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5272,8 +5508,10 @@ TEST 10: pgfmanual-en-library-petri-10
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5338,6 +5576,8 @@ TEST 11: pgfmanual-en-library-petri-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5377,11 +5617,13 @@ TEST 11: pgfmanual-en-library-petri-11
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(2.15277+0.0)x3.95836, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\mathon
 .............\OML/cmm/m/it/5 x
 .............\mathoff
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5426,12 +5668,14 @@ TEST 11: pgfmanual-en-library-petri-11
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(2.15277+0.97221)x3.8322, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\mathon
 .............\OML/cmm/m/it/5 y
 .............\kern0.17938 (italic)
 .............\mathoff
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5476,12 +5720,14 @@ TEST 11: pgfmanual-en-library-petri-11
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(2.15277+0.0)x3.62848, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\mathon
 .............\OML/cmm/m/it/5 z
 .............\kern0.18517 (italic)
 .............\mathoff
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5546,6 +5792,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5585,9 +5833,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5624,6 +5874,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5663,9 +5915,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5710,9 +5964,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5749,6 +6005,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5788,9 +6046,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5835,9 +6095,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5882,9 +6144,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5921,6 +6185,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5960,9 +6226,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6007,9 +6275,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6054,9 +6324,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6101,9 +6373,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.385+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6140,6 +6414,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6179,9 +6455,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6226,9 +6504,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6273,9 +6553,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6320,9 +6602,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.385+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6367,9 +6651,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6406,6 +6692,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6445,9 +6733,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6492,9 +6782,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6539,9 +6831,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6586,9 +6880,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.385+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6633,9 +6929,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6680,9 +6978,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 6
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6719,6 +7019,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6758,9 +7060,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6805,9 +7109,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6852,9 +7158,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6899,9 +7207,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.385+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6946,9 +7256,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6993,9 +7305,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 6
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7040,9 +7354,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.38+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7079,6 +7395,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7118,9 +7436,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7165,9 +7485,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7212,9 +7534,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7259,9 +7583,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.385+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7306,9 +7632,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7353,9 +7681,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 6
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7400,9 +7730,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.38+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7447,9 +7779,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 8
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7486,6 +7820,8 @@ TEST 12: pgfmanual-en-library-petri-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7525,9 +7861,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7572,9 +7910,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7619,9 +7959,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7666,9 +8008,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.385+0.0)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7713,9 +8057,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 5
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7760,9 +8106,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 6
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7807,9 +8155,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.38+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 7
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7854,9 +8204,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 8
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7901,9 +8253,11 @@ TEST 12: pgfmanual-en-library-petri-12
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(3.33+0.11)x3.405, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/5 9
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7979,6 +8333,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8002,11 +8358,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8046,6 +8404,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8071,11 +8431,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8116,6 +8478,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8139,11 +8503,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8183,6 +8549,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8208,11 +8576,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8253,6 +8623,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8276,11 +8648,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8320,6 +8694,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8345,11 +8721,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8390,6 +8768,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8413,11 +8793,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8457,6 +8839,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8482,11 +8866,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8527,6 +8913,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8550,11 +8938,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8594,6 +8984,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8619,11 +9011,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8664,6 +9058,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8687,11 +9083,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8731,6 +9129,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8756,11 +9156,13 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8802,6 +9204,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8827,6 +9231,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+1.94444)x32.57175, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 m
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -8837,6 +9242,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ...........\OML/cmm/m/it/10 f
 ...........\kern1.0764 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8875,6 +9281,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8900,6 +9308,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15079+1.49998)x30.2106, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 m
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -8909,6 +9318,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OML/cmm/m/it/10 t
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8949,6 +9359,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8974,6 +9386,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+1.94444)x32.57175, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 m
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -8984,6 +9397,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ...........\OML/cmm/m/it/10 f
 ...........\kern1.0764 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9022,6 +9436,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9047,6 +9463,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15079+1.49998)x30.2106, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 m
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -9056,6 +9473,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OML/cmm/m/it/10 t
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9096,6 +9514,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9121,6 +9541,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x39.68707, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.94444+0.0)x21.35384, direction TLT
 ............\OT1/cmr/m/it/10 h
@@ -9136,6 +9557,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9174,6 +9596,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9199,6 +9623,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x39.68707, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(6.94444+0.0)x21.35384, direction TLT
 ............\OT1/cmr/m/it/10 h
@@ -9214,6 +9639,7 @@ TEST 13: pgfmanual-en-library-petri-13
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9250,8 +9676,10 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9287,8 +9715,10 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9324,8 +9754,10 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9361,8 +9793,10 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9398,8 +9832,10 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9435,6 +9871,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9500,6 +9938,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9591,6 +10031,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9672,6 +10114,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9763,6 +10207,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9844,6 +10290,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9925,6 +10373,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10016,6 +10466,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10080,6 +10532,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10143,6 +10597,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10234,6 +10690,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10315,6 +10773,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10406,6 +10866,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10487,6 +10949,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10568,6 +11032,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10659,6 +11125,8 @@ TEST 13: pgfmanual-en-library-petri-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-plot-handlers.tlg
+++ b/testfiles-examples/pgfmanual-en-library-plot-handlers.tlg
@@ -40,9 +40,11 @@ TEST 1: pgfmanual-en-library-plot-handlers-1
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -68,9 +70,11 @@ TEST 1: pgfmanual-en-library-plot-handlers-1
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -96,9 +100,11 @@ TEST 1: pgfmanual-en-library-plot-handlers-1
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -169,9 +175,11 @@ TEST 2: pgfmanual-en-library-plot-handlers-2
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -197,9 +205,11 @@ TEST 2: pgfmanual-en-library-plot-handlers-2
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -225,9 +235,11 @@ TEST 2: pgfmanual-en-library-plot-handlers-2
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -299,9 +311,11 @@ TEST 3: pgfmanual-en-library-plot-handlers-3
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -327,9 +341,11 @@ TEST 3: pgfmanual-en-library-plot-handlers-3
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -355,9 +371,11 @@ TEST 3: pgfmanual-en-library-plot-handlers-3
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -430,9 +448,11 @@ TEST 4: pgfmanual-en-library-plot-handlers-4
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -458,9 +478,11 @@ TEST 4: pgfmanual-en-library-plot-handlers-4
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -486,9 +508,11 @@ TEST 4: pgfmanual-en-library-plot-handlers-4
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -560,9 +584,11 @@ TEST 5: pgfmanual-en-library-plot-handlers-5
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -588,9 +614,11 @@ TEST 5: pgfmanual-en-library-plot-handlers-5
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -616,9 +644,11 @@ TEST 5: pgfmanual-en-library-plot-handlers-5
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -690,9 +720,11 @@ TEST 6: pgfmanual-en-library-plot-handlers-6
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -718,9 +750,11 @@ TEST 6: pgfmanual-en-library-plot-handlers-6
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -746,9 +780,11 @@ TEST 6: pgfmanual-en-library-plot-handlers-6
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -822,9 +858,11 @@ TEST 7: pgfmanual-en-library-plot-handlers-7
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -850,9 +888,11 @@ TEST 7: pgfmanual-en-library-plot-handlers-7
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -878,9 +918,11 @@ TEST 7: pgfmanual-en-library-plot-handlers-7
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -952,9 +994,11 @@ TEST 8: pgfmanual-en-library-plot-handlers-8
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -980,9 +1024,11 @@ TEST 8: pgfmanual-en-library-plot-handlers-8
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1008,9 +1054,11 @@ TEST 8: pgfmanual-en-library-plot-handlers-8
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1082,9 +1130,11 @@ TEST 9: pgfmanual-en-library-plot-handlers-9
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1110,9 +1160,11 @@ TEST 9: pgfmanual-en-library-plot-handlers-9
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1138,9 +1190,11 @@ TEST 9: pgfmanual-en-library-plot-handlers-9
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1214,9 +1268,11 @@ TEST 10: pgfmanual-en-library-plot-handlers-10
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1242,9 +1298,11 @@ TEST 10: pgfmanual-en-library-plot-handlers-10
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1270,9 +1328,11 @@ TEST 10: pgfmanual-en-library-plot-handlers-10
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1345,9 +1405,11 @@ TEST 11: pgfmanual-en-library-plot-handlers-11
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1373,9 +1435,11 @@ TEST 11: pgfmanual-en-library-plot-handlers-11
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1401,9 +1465,11 @@ TEST 11: pgfmanual-en-library-plot-handlers-11
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1476,9 +1542,11 @@ TEST 12: pgfmanual-en-library-plot-handlers-12
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1504,9 +1572,11 @@ TEST 12: pgfmanual-en-library-plot-handlers-12
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1532,9 +1602,11 @@ TEST 12: pgfmanual-en-library-plot-handlers-12
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1607,9 +1679,11 @@ TEST 13: pgfmanual-en-library-plot-handlers-15
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1635,9 +1709,11 @@ TEST 13: pgfmanual-en-library-plot-handlers-15
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1663,9 +1739,11 @@ TEST 13: pgfmanual-en-library-plot-handlers-15
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1735,9 +1813,11 @@ TEST 14: pgfmanual-en-library-plot-handlers-16
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1763,9 +1843,11 @@ TEST 14: pgfmanual-en-library-plot-handlers-16
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1791,9 +1873,11 @@ TEST 14: pgfmanual-en-library-plot-handlers-16
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1866,6 +1950,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.30554+1.49998)x10.2014, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
@@ -1873,6 +1958,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1898,6 +1984,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.30554+1.49998)x10.2014, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
@@ -1905,6 +1992,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1930,6 +2018,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.30554+1.49998)x10.2014, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
@@ -1937,6 +2026,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1962,6 +2052,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.30554+1.49998)x10.2014, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
@@ -1969,6 +2060,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OT1/cmr/m/n/7 4
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2185,9 +2277,11 @@ TEST 19: pgfmanual-en-library-plot-handlers-21
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2213,9 +2307,11 @@ TEST 19: pgfmanual-en-library-plot-handlers-21
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2241,9 +2337,11 @@ TEST 19: pgfmanual-en-library-plot-handlers-21
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2335,9 +2433,11 @@ TEST 20: pgfmanual-en-library-plot-handlers-22
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2363,9 +2463,11 @@ TEST 20: pgfmanual-en-library-plot-handlers-22
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2391,9 +2493,11 @@ TEST 20: pgfmanual-en-library-plot-handlers-22
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2478,9 +2582,11 @@ TEST 21: pgfmanual-en-library-plot-handlers-23
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2506,9 +2612,11 @@ TEST 21: pgfmanual-en-library-plot-handlers-23
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2534,9 +2642,11 @@ TEST 21: pgfmanual-en-library-plot-handlers-23
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2605,9 +2715,11 @@ TEST 22: pgfmanual-en-library-plot-handlers-24
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2633,9 +2745,11 @@ TEST 22: pgfmanual-en-library-plot-handlers-24
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2661,9 +2775,11 @@ TEST 22: pgfmanual-en-library-plot-handlers-24
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2755,9 +2871,11 @@ TEST 23: pgfmanual-en-library-plot-handlers-25
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 x
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2783,9 +2901,11 @@ TEST 23: pgfmanual-en-library-plot-handlers-25
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 y
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2811,9 +2931,11 @@ TEST 23: pgfmanual-en-library-plot-handlers-25
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(4.31+0.0)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 z
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-shadings.tlg
+++ b/testfiles-examples/pgfmanual-en-library-shadings.tlg
@@ -35,8 +35,10 @@ TEST 1: pgfmanual-en-library-shadings-1
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -96,8 +98,10 @@ TEST 2: pgfmanual-en-library-shadings-2
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -157,8 +161,10 @@ TEST 3: pgfmanual-en-library-shadings-3
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -183,8 +189,10 @@ TEST 3: pgfmanual-en-library-shadings-3
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -209,8 +217,10 @@ TEST 3: pgfmanual-en-library-shadings-3
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -267,8 +277,10 @@ TEST 4: pgfmanual-en-library-shadings-4
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -325,9 +337,11 @@ TEST 5: pgfmanual-en-library-shadings-5
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
 .........\pdfrefobj attr  /FunctionType 4 /Domain [-50.00064 50.00064 -50.00064 50.00064] /Range [0 1 0 1 0 1]  stream { 2 copy abs exch abs add 0.0001 ge {atan 360.0 div} { pop } ifelse 1.0 1.0 3 2 roll 6.0 mul dup 4 1 roll floor cvr dup 5 1 roll 3 index sub neg 1.0 3 index sub 2 index mul 6 1 roll dup 3 index mul neg 1.0 add 2 index mul 7 1 roll neg 1.0 add 2 index mul neg 1.0 add 1 index mul 7 2 roll pop pop dup 0.5 le { pop exch pop } { dup 1.5 le { pop exch 4 1 roll exch pop } { dup 2.5 le { pop 4 1 roll pop } { dup 3.5 le { pop exch 4 2 roll pop } { dup 4.5 le { pop exch pop 3 -1 roll } { pop 3 1 roll exch pop } ifelse } ifelse } ifelse } ifelse } ifelse }
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -388,9 +402,11 @@ TEST 6: pgfmanual-en-library-shadings-6
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
 .........\pdfrefobj attr  /FunctionType 4 /Domain [-50.00064 50.00064 -50.00064 50.00064] /Range [0 1 0 1 0 1]  stream { 2 copy abs exch abs add 0.0001 ge {atan 360.0 div} { pop } ifelse 1.0 1.0 3 2 roll 6.0 mul dup 4 1 roll floor cvr dup 5 1 roll 3 index sub neg 1.0 3 index sub 2 index mul 6 1 roll dup 3 index mul neg 1.0 add 2 index mul 7 1 roll neg 1.0 add 2 index mul neg 1.0 add 1 index mul 7 2 roll pop pop dup 0.5 le { pop exch pop } { dup 1.5 le { pop exch 4 1 roll exch pop } { dup 2.5 le { pop 4 1 roll pop } { dup 3.5 le { pop exch 4 2 roll pop } { dup 4.5 le { pop exch pop 3 -1 roll } { pop 3 1 roll exch pop } ifelse } ifelse } ifelse } ifelse } ifelse }
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -443,9 +459,11 @@ TEST 7: pgfmanual-en-library-shadings-7
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
 .........\pdfrefobj attr  /FunctionType 4 /Domain [-50.00064 50.00064 -50.00064 50.00064] /Range [0 1 0 1 0 1]  stream { 2 copy 2 copy abs exch abs add 0.0001 ge {atan 360.0 div} { pop } ifelse 3 1 roll dup mul exch dup mul add sqrt 25.0 div dup 1.0 ge { pop 1.0 }{} ifelse 1.0 exch 3 2 roll 6.0 mul dup 4 1 roll floor cvr dup 5 1 roll 3 index sub neg 1.0 3 index sub 2 index mul 6 1 roll dup 3 index mul neg 1.0 add 2 index mul 7 1 roll neg 1.0 add 2 index mul neg 1.0 add 1 index mul 7 2 roll pop pop dup 0.5 le { pop exch pop } { dup 1.5 le { pop exch 4 1 roll exch pop } { dup 2.5 le { pop 4 1 roll pop } { dup 3.5 le { pop exch 4 2 roll pop } { dup 4.5 le { pop exch pop 3 -1 roll } { pop 3 1 roll exch pop } ifelse } ifelse } ifelse } ifelse } ifelse }
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -497,9 +515,11 @@ TEST 8: pgfmanual-en-library-shadings-8
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
 .........\pdfrefobj attr  /FunctionType 4 /Domain [-50.00064 50.00064 -50.00064 50.00064] /Range [0 1 0 1 0 1]  stream { 2 copy 2 copy abs exch abs add 0.0001 ge {atan 360.0 div} { pop } ifelse 3 1 roll dup mul exch dup mul add sqrt 25.0 div dup 1.0 ge { pop 1.0 }{} ifelse 1.0 3 2 roll 6.0 mul dup 4 1 roll floor cvr dup 5 1 roll 3 index sub neg 1.0 3 index sub 2 index mul 6 1 roll dup 3 index mul neg 1.0 add 2 index mul 7 1 roll neg 1.0 add 2 index mul neg 1.0 add 1 index mul 7 2 roll pop pop dup 0.5 le { pop exch pop } { dup 1.5 le { pop exch 4 1 roll exch pop } { dup 2.5 le { pop 4 1 roll pop } { dup 3.5 le { pop exch 4 2 roll pop } { dup 4.5 le { pop exch pop 3 -1 roll } { pop 3 1 roll exch pop } ifelse } ifelse } ifelse } ifelse } ifelse }
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -551,9 +571,11 @@ TEST 9: pgfmanual-en-library-shadings-9
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
 .........\pdfrefobj attr  /FunctionType 4 /Domain [-50.00064 50.00064 -50.00064 50.00064] /Range [0 1 0 1 0 1]  stream { 12.5 div exch 12.5 div exch 1 index 1 index 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul add 4 lt { 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul add 4 lt { 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add 1 index dup mul 1 index dup mul sub 4 index add 3 1 roll mul 2 mul 2 index add } { pop pop 1000.0 1000.0 } ifelse } { pop pop 1000.0 1000.0 } ifelse dup mul exch dup mul add sqrt dup 4 1 roll 2 gt { pop pop 2.0 exch div 1.0 exch sub dup dup} {pop pop pop 0.0 0.0 0.0} ifelse }
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -605,8 +627,10 @@ TEST 10: pgfmanual-en-library-shadings-10
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -666,8 +690,10 @@ TEST 11: pgfmanual-en-library-shadings-11
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }

--- a/testfiles-examples/pgfmanual-en-library-shadows.tlg
+++ b/testfiles-examples/pgfmanual-en-library-shadows.tlg
@@ -435,6 +435,7 @@ TEST 5: pgfmanual-en-library-shadows-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.11)x32.72, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 r
@@ -442,6 +443,7 @@ TEST 5: pgfmanual-en-library-shadows-6
 ...........\TU/lmr/m/n/10 t
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -585,6 +587,7 @@ TEST 5: pgfmanual-en-library-shadows-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.11)x32.72, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 r
@@ -592,6 +595,7 @@ TEST 5: pgfmanual-en-library-shadows-6
 ...........\TU/lmr/m/n/10 t
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -735,6 +739,7 @@ TEST 5: pgfmanual-en-library-shadows-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.22)x32.72, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 r
@@ -742,6 +747,7 @@ TEST 5: pgfmanual-en-library-shadows-6
 ...........\TU/lmr/m/n/10 t
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -885,6 +891,7 @@ TEST 5: pgfmanual-en-library-shadows-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.11)x32.72, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 r
@@ -892,6 +899,7 @@ TEST 5: pgfmanual-en-library-shadows-6
 ...........\TU/lmr/m/n/10 t
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1212,6 +1220,7 @@ TEST 8: pgfmanual-en-library-shadows-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -1225,6 +1234,7 @@ TEST 8: pgfmanual-en-library-shadows-10
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1273,6 +1283,7 @@ TEST 8: pgfmanual-en-library-shadows-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -1286,6 +1297,7 @@ TEST 8: pgfmanual-en-library-shadows-10
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1350,6 +1362,7 @@ TEST 8: pgfmanual-en-library-shadows-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -1363,6 +1376,7 @@ TEST 8: pgfmanual-en-library-shadows-10
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1400,8 +1414,10 @@ TEST 8: pgfmanual-en-library-shadows-10
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1426,8 +1442,10 @@ TEST 8: pgfmanual-en-library-shadows-10
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1446,6 +1464,7 @@ TEST 8: pgfmanual-en-library-shadows-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -1459,6 +1478,7 @@ TEST 8: pgfmanual-en-library-shadows-10
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1545,6 +1565,7 @@ TEST 9: pgfmanual-en-library-shadows-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -1558,6 +1579,7 @@ TEST 9: pgfmanual-en-library-shadows-11
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1617,6 +1639,7 @@ TEST 9: pgfmanual-en-library-shadows-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -1630,6 +1653,7 @@ TEST 9: pgfmanual-en-library-shadows-11
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1716,6 +1740,7 @@ TEST 9: pgfmanual-en-library-shadows-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -1729,6 +1754,7 @@ TEST 9: pgfmanual-en-library-shadows-11
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1766,8 +1792,10 @@ TEST 9: pgfmanual-en-library-shadows-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1796,8 +1824,10 @@ TEST 9: pgfmanual-en-library-shadows-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1822,8 +1852,10 @@ TEST 9: pgfmanual-en-library-shadows-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1842,6 +1874,7 @@ TEST 9: pgfmanual-en-library-shadows-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -1855,6 +1888,7 @@ TEST 9: pgfmanual-en-library-shadows-11
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1942,6 +1976,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -1952,6 +1987,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2010,6 +2046,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2020,6 +2057,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2078,6 +2116,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2088,6 +2127,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2146,6 +2186,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2156,6 +2197,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2214,6 +2256,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2224,6 +2267,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2282,6 +2326,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2292,6 +2337,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2350,6 +2396,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2360,6 +2407,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2418,6 +2466,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2428,6 +2477,7 @@ TEST 10: pgfmanual-en-library-shadows-13
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2514,6 +2564,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2524,6 +2575,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2582,6 +2634,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2592,6 +2645,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2650,6 +2704,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2660,6 +2715,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2718,6 +2774,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2728,6 +2785,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2786,6 +2844,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2796,6 +2855,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2854,6 +2914,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2864,6 +2925,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2922,6 +2984,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2932,6 +2995,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2990,6 +3054,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3000,6 +3065,7 @@ TEST 11: pgfmanual-en-library-shadows-15
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3087,6 +3153,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3097,6 +3164,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3156,6 +3224,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3166,6 +3235,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3225,6 +3295,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3235,6 +3306,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3294,6 +3366,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3304,6 +3377,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3363,6 +3437,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3373,6 +3448,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3432,6 +3508,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3442,6 +3519,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3501,6 +3579,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3511,6 +3590,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3570,6 +3650,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -3580,6 +3661,7 @@ TEST 12: pgfmanual-en-library-shadows-16
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3663,6 +3745,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
@@ -3675,6 +3758,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3730,6 +3814,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
@@ -3742,6 +3827,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3797,6 +3883,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
@@ -3809,6 +3896,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3864,6 +3952,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
@@ -3876,6 +3965,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3931,6 +4021,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
@@ -3943,6 +4034,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3998,6 +4090,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
@@ -4010,6 +4103,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4065,6 +4159,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
@@ -4077,6 +4172,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4132,6 +4228,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
@@ -4144,6 +4241,7 @@ TEST 13: pgfmanual-en-library-shadows-17
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4215,6 +4313,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -4225,6 +4324,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4268,6 +4368,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -4278,6 +4379,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4321,6 +4423,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -4331,6 +4434,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4374,6 +4478,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -4384,6 +4489,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4427,6 +4533,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -4437,6 +4544,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4480,6 +4588,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -4490,6 +4599,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4533,6 +4643,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -4543,6 +4654,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4586,6 +4698,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x33.91, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -4596,6 +4709,7 @@ TEST 14: pgfmanual-en-library-shadows-18
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-shapes.tlg
+++ b/testfiles-examples/pgfmanual-en-library-shapes.tlg
@@ -48,6 +48,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x59.06995, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 C
 ...........\TU/lmr/m/n/24.88 i
@@ -59,6 +60,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -97,6 +99,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -112,6 +115,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -149,6 +153,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -159,6 +164,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -195,6 +201,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -210,6 +217,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -245,6 +253,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -254,6 +263,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -291,6 +301,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -302,6 +313,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -339,6 +351,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -348,6 +361,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -385,6 +399,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -398,6 +413,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -435,6 +451,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -443,6 +460,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -478,6 +496,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -491,6 +510,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -526,6 +546,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -540,6 +561,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -577,6 +599,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -586,6 +609,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -623,6 +647,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -637,6 +662,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -673,6 +699,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -688,6 +715,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -725,6 +753,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -735,6 +764,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -773,6 +803,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -788,6 +819,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -823,6 +855,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -832,6 +865,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -869,6 +903,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -876,6 +911,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -913,6 +949,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -921,6 +958,7 @@ TEST 1: pgfmanual-en-library-shapes-2
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -988,6 +1026,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x98.80331, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 R
 ...........\TU/lmr/m/n/24.88 e
@@ -1004,6 +1043,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1042,6 +1082,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1057,6 +1098,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1095,6 +1137,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1105,6 +1148,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1140,6 +1184,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1155,6 +1200,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1191,6 +1237,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1200,6 +1247,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1238,6 +1286,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1249,6 +1298,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1286,6 +1336,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1295,6 +1346,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1332,6 +1384,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1345,6 +1398,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1383,6 +1437,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1391,6 +1446,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1426,6 +1482,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1439,6 +1496,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1474,6 +1532,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1488,6 +1547,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1526,6 +1586,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1535,6 +1596,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1572,6 +1634,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1586,6 +1649,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1621,6 +1685,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1636,6 +1701,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1674,6 +1740,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1684,6 +1751,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1722,6 +1790,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1737,6 +1806,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1772,6 +1842,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1781,6 +1852,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1818,6 +1890,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1825,6 +1898,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1862,6 +1936,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -1870,6 +1945,7 @@ TEST 2: pgfmanual-en-library-shapes-3
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1938,6 +2014,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.19904)x92.28474, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 D
 ...........\TU/lmr/m/n/24.88 i
@@ -1952,6 +2029,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmr/m/n/24.88 d
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1989,6 +2067,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2004,6 +2083,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2041,6 +2121,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2051,6 +2132,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2086,6 +2168,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2101,6 +2184,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2136,6 +2220,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2145,6 +2230,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2182,6 +2268,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2193,6 +2280,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2230,6 +2318,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2239,6 +2328,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2276,6 +2366,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2284,6 +2375,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2321,6 +2413,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2330,6 +2423,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2365,6 +2459,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2380,6 +2475,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2417,6 +2513,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2427,6 +2524,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2464,6 +2562,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2479,6 +2578,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2514,6 +2614,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2523,6 +2624,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2560,6 +2662,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2567,6 +2670,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2604,6 +2708,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2612,6 +2717,7 @@ TEST 3: pgfmanual-en-library-shapes-4
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2682,6 +2788,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+4.85161)x67.03154, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 E
 ...........\TU/lmr/m/n/24.88 l
@@ -2694,6 +2801,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2734,6 +2842,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2749,6 +2858,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2789,6 +2899,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2799,6 +2910,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2837,6 +2949,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2852,6 +2965,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2890,6 +3004,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2899,6 +3014,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2936,6 +3052,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2947,6 +3064,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2986,6 +3104,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -2995,6 +3114,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3034,6 +3154,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3047,6 +3168,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3084,6 +3206,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3092,6 +3215,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3129,6 +3253,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3142,6 +3267,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3179,6 +3305,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3193,6 +3320,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3230,6 +3358,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3239,6 +3368,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3278,6 +3408,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3292,6 +3423,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3330,6 +3462,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3345,6 +3478,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3385,6 +3519,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3395,6 +3530,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3435,6 +3571,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3450,6 +3587,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3485,6 +3623,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3494,6 +3633,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3531,6 +3671,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3538,6 +3679,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3575,6 +3717,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -3583,6 +3726,7 @@ TEST 4: pgfmanual-en-library-shapes-5
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3641,7 +3785,9 @@ TEST 5: pgfmanual-en-library-shapes-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3671,7 +3817,9 @@ TEST 5: pgfmanual-en-library-shapes-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3701,7 +3849,9 @@ TEST 5: pgfmanual-en-library-shapes-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3763,8 +3913,10 @@ TEST 6: pgfmanual-en-library-shapes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3811,6 +3963,7 @@ TEST 6: pgfmanual-en-library-shapes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.01, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 w
 ...........\TU/lmr/m/n/10 i
@@ -3818,6 +3971,7 @@ TEST 6: pgfmanual-en-library-shapes-7
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3861,6 +4015,7 @@ TEST 6: pgfmanual-en-library-shapes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x26.95, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
@@ -3870,6 +4025,7 @@ TEST 6: pgfmanual-en-library-shapes-7
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3972,9 +4128,11 @@ TEST 7: pgfmanual-en-library-shapes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 A
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4010,9 +4168,11 @@ TEST 7: pgfmanual-en-library-shapes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 B
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4048,9 +4208,11 @@ TEST 7: pgfmanual-en-library-shapes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 C
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4152,9 +4314,11 @@ TEST 8: pgfmanual-en-library-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 A
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4190,9 +4354,11 @@ TEST 8: pgfmanual-en-library-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 B
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4228,9 +4394,11 @@ TEST 8: pgfmanual-en-library-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 C
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4331,9 +4499,11 @@ TEST 9: pgfmanual-en-library-shapes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 A
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4369,9 +4539,11 @@ TEST 9: pgfmanual-en-library-shapes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 B
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4407,9 +4579,11 @@ TEST 9: pgfmanual-en-library-shapes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 C
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4476,6 +4650,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+4.85161)x107.61084, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 T
 ...........\kern-1.94064 (font)
@@ -4492,6 +4667,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmr/m/n/24.88 m
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4529,6 +4705,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x81.7739, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4552,6 +4729,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4589,6 +4767,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4610,6 +4789,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4645,6 +4825,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4665,6 +4846,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4702,6 +4884,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x85.49089, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4726,6 +4909,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4763,6 +4947,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4779,6 +4964,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4814,6 +5000,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4828,6 +5015,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4865,6 +5053,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4880,6 +5069,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4917,6 +5107,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4930,6 +5121,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4967,6 +5159,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -4978,6 +5171,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5015,6 +5209,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5024,6 +5219,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5061,6 +5257,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5069,6 +5266,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5106,6 +5304,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5115,6 +5314,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5152,6 +5352,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5165,6 +5366,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5202,6 +5404,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5216,6 +5419,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5251,6 +5455,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5264,6 +5469,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5301,6 +5507,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5315,6 +5522,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5352,6 +5560,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5361,6 +5570,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5398,6 +5608,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5407,6 +5618,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5444,6 +5656,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5454,6 +5667,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5491,6 +5705,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5501,6 +5716,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5538,6 +5754,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5553,6 +5770,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5590,6 +5808,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5605,6 +5824,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5642,6 +5862,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5657,6 +5878,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5694,6 +5916,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5709,6 +5932,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5746,6 +5970,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5754,6 +5979,7 @@ TEST 10: pgfmanual-en-library-shapes-11
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5821,6 +6047,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x100.79373, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 S
 ...........\TU/lmr/m/n/24.88 e
@@ -5838,6 +6065,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5875,6 +6103,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5884,6 +6113,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 x
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5921,6 +6151,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5935,6 +6166,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5972,6 +6204,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -5984,6 +6217,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6021,6 +6255,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6038,6 +6273,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6075,6 +6311,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6086,6 +6323,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6123,6 +6361,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6132,6 +6371,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6169,6 +6409,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6177,6 +6418,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6212,6 +6454,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6221,6 +6464,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6258,6 +6502,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6272,6 +6517,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6309,6 +6555,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6323,6 +6570,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6358,6 +6606,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6371,6 +6620,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6408,6 +6658,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6421,6 +6672,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6458,6 +6710,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6468,6 +6721,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6505,6 +6759,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6515,6 +6770,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6552,6 +6808,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6561,6 +6818,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6598,6 +6856,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6607,6 +6866,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6644,6 +6904,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6659,6 +6920,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6694,6 +6956,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6709,6 +6972,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6746,6 +7010,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6761,6 +7026,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6798,6 +7064,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6813,6 +7080,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6850,6 +7118,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -6857,6 +7126,7 @@ TEST 11: pgfmanual-en-library-shapes-12
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6929,6 +7199,8 @@ TEST 12: pgfmanual-en-library-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6974,6 +7246,8 @@ TEST 12: pgfmanual-en-library-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7020,6 +7294,8 @@ TEST 12: pgfmanual-en-library-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7067,6 +7343,8 @@ TEST 12: pgfmanual-en-library-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7115,6 +7393,8 @@ TEST 12: pgfmanual-en-library-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7187,6 +7467,8 @@ TEST 13: pgfmanual-en-library-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7232,6 +7514,8 @@ TEST 13: pgfmanual-en-library-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7278,6 +7562,8 @@ TEST 13: pgfmanual-en-library-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7325,6 +7611,8 @@ TEST 13: pgfmanual-en-library-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7373,6 +7661,8 @@ TEST 13: pgfmanual-en-library-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7441,6 +7731,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x166.35252, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 R
 ...........\TU/lmr/m/n/24.88 e
@@ -7466,6 +7757,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmr/m/n/24.88 n
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7503,6 +7795,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7516,6 +7809,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7553,6 +7847,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7566,6 +7861,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7601,6 +7897,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7614,6 +7911,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 3
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7651,6 +7949,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7664,6 +7963,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 4
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7701,6 +8001,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7714,6 +8015,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7751,6 +8053,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7762,6 +8065,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7797,6 +8101,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7808,6 +8113,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7845,6 +8151,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7856,6 +8163,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 3
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7893,6 +8201,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7904,6 +8213,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 4
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7941,6 +8251,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -7952,6 +8263,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7989,6 +8301,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8000,6 +8313,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8035,6 +8349,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8044,6 +8359,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8081,6 +8397,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8089,6 +8406,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8126,6 +8444,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8135,6 +8454,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8171,6 +8491,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8178,6 +8499,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8214,6 +8536,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8223,6 +8546,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8259,6 +8583,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8268,6 +8593,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8304,6 +8630,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8314,6 +8641,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8350,6 +8678,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8360,6 +8689,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8396,6 +8726,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8411,6 +8742,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8447,6 +8779,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8462,6 +8795,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8498,6 +8832,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8513,6 +8848,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8549,6 +8885,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8564,6 +8901,7 @@ TEST 14: pgfmanual-en-library-shapes-15
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8691,7 +9029,9 @@ TEST 15: pgfmanual-en-library-shapes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8764,6 +9104,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x42.74866, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 S
 ...........\TU/lmr/m/n/24.88 t
@@ -8771,6 +9112,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmr/m/n/24.88 r
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8808,6 +9150,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8826,6 +9169,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8863,6 +9207,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8881,6 +9226,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8918,6 +9264,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8936,6 +9283,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 3
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8973,6 +9321,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -8991,6 +9340,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 4
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9028,6 +9378,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9046,6 +9397,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9083,6 +9435,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9101,6 +9454,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9138,6 +9492,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9156,6 +9511,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9191,6 +9547,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9209,6 +9566,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 3
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9246,6 +9604,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9264,6 +9623,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 4
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9301,6 +9661,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9319,6 +9680,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9356,6 +9718,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9367,6 +9730,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9402,6 +9766,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9411,6 +9776,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9448,6 +9814,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9456,6 +9823,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9493,6 +9861,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9502,6 +9871,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9538,6 +9908,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9545,6 +9916,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9581,6 +9953,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9590,6 +9963,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9626,6 +10000,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9635,6 +10010,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9671,6 +10047,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9681,6 +10058,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9717,6 +10095,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9727,6 +10106,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9763,6 +10143,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9778,6 +10159,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9814,6 +10196,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9829,6 +10212,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9865,6 +10249,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9880,6 +10265,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9916,6 +10302,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -9931,6 +10318,7 @@ TEST 16: pgfmanual-en-library-shapes-17
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9992,8 +10380,10 @@ TEST 17: pgfmanual-en-library-shapes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10035,6 +10425,7 @@ TEST 17: pgfmanual-en-library-shapes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.01, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 w
 ...........\TU/lmr/m/n/10 i
@@ -10042,6 +10433,7 @@ TEST 17: pgfmanual-en-library-shapes-18
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10083,6 +10475,7 @@ TEST 17: pgfmanual-en-library-shapes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x26.95, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
@@ -10092,6 +10485,7 @@ TEST 17: pgfmanual-en-library-shapes-18
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10199,6 +10593,8 @@ TEST 18: pgfmanual-en-library-shapes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10233,6 +10629,8 @@ TEST 18: pgfmanual-en-library-shapes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10268,6 +10666,8 @@ TEST 18: pgfmanual-en-library-shapes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10302,6 +10702,8 @@ TEST 18: pgfmanual-en-library-shapes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10337,6 +10739,8 @@ TEST 18: pgfmanual-en-library-shapes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10371,6 +10775,8 @@ TEST 18: pgfmanual-en-library-shapes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10477,6 +10883,8 @@ TEST 19: pgfmanual-en-library-shapes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10511,6 +10919,8 @@ TEST 19: pgfmanual-en-library-shapes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10546,6 +10956,8 @@ TEST 19: pgfmanual-en-library-shapes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10580,6 +10992,8 @@ TEST 19: pgfmanual-en-library-shapes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10615,6 +11029,8 @@ TEST 19: pgfmanual-en-library-shapes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10649,6 +11065,8 @@ TEST 19: pgfmanual-en-library-shapes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10715,6 +11133,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x172.99548, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 I
 ...........\TU/lmr/m/n/24.88 s
@@ -10743,6 +11162,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10780,6 +11200,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10789,6 +11210,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 x
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10826,6 +11248,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10842,6 +11265,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10879,6 +11303,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10896,6 +11321,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10933,6 +11359,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10947,6 +11374,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10984,6 +11412,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -10999,6 +11428,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11036,6 +11466,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11051,6 +11482,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11088,6 +11520,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11099,6 +11532,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11136,6 +11570,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11145,6 +11580,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11182,6 +11618,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11190,6 +11627,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11227,6 +11665,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11235,6 +11674,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11272,6 +11712,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11285,6 +11726,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11322,6 +11764,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11335,6 +11778,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11372,6 +11816,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11381,6 +11826,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11418,6 +11864,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11432,6 +11879,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11469,6 +11917,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11483,6 +11932,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11520,6 +11970,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11529,6 +11980,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11566,6 +12018,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11575,6 +12028,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11612,6 +12066,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11622,6 +12077,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11659,6 +12115,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11669,6 +12126,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11706,6 +12164,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11721,6 +12180,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11758,6 +12218,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11773,6 +12234,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11810,6 +12272,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11825,6 +12288,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11862,6 +12326,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -11877,6 +12342,7 @@ TEST 20: pgfmanual-en-library-shapes-21
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11935,7 +12401,9 @@ TEST 21: pgfmanual-en-library-shapes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11965,7 +12433,9 @@ TEST 21: pgfmanual-en-library-shapes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11995,7 +12465,9 @@ TEST 21: pgfmanual-en-library-shapes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12062,6 +12534,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.19904)x44.01753, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 K
 ...........\TU/lmr/m/n/24.88 i
@@ -12069,6 +12542,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12106,6 +12580,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12123,6 +12598,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 x
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12160,6 +12636,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12176,6 +12653,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 x
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12213,6 +12691,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12230,6 +12709,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 x
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12267,6 +12747,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12284,6 +12765,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 x
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12321,6 +12803,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12341,6 +12824,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12378,6 +12862,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12399,6 +12884,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12436,6 +12922,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12456,6 +12943,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12493,6 +12981,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12514,6 +13003,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12551,6 +13041,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12562,6 +13053,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12597,6 +13089,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12606,6 +13099,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12643,6 +13137,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12651,6 +13146,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12688,6 +13184,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12697,6 +13194,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12732,6 +13230,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12745,6 +13244,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12782,6 +13282,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12796,6 +13297,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12833,6 +13335,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12846,6 +13349,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12883,6 +13387,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12897,6 +13402,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12934,6 +13440,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12943,6 +13450,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12980,6 +13488,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -12989,6 +13498,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13026,6 +13536,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13036,6 +13547,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13073,6 +13585,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13083,6 +13596,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13118,6 +13632,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13133,6 +13648,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13170,6 +13686,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13185,6 +13702,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13222,6 +13740,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13237,6 +13756,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13274,6 +13794,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13289,6 +13810,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13326,6 +13848,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13334,6 +13857,7 @@ TEST 22: pgfmanual-en-library-shapes-23
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13397,12 +13921,14 @@ TEST 23: pgfmanual-en-library-shapes-24
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.94+0.11)x18.37, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13447,6 +13973,7 @@ TEST 23: pgfmanual-en-library-shapes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x38.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 p
@@ -13458,6 +13985,7 @@ TEST 23: pgfmanual-en-library-shapes-24
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13504,6 +14032,7 @@ TEST 23: pgfmanual-en-library-shapes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x40.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 i
@@ -13516,6 +14045,7 @@ TEST 23: pgfmanual-en-library-shapes-24
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13583,6 +14113,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.19904)x47.62514, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 D
 ...........\TU/lmr/m/n/24.88 a
@@ -13590,6 +14121,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmr/m/n/24.88 t
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13627,6 +14159,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13635,6 +14168,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13672,6 +14206,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13688,6 +14223,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13725,6 +14261,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13740,6 +14277,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 l
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13777,6 +14315,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13791,6 +14330,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 l
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13828,6 +14368,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13843,6 +14384,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 l
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13878,6 +14420,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13892,6 +14435,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13929,6 +14473,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.596)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13944,6 +14489,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13981,6 +14527,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -13992,6 +14539,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14027,6 +14575,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14036,6 +14585,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14073,6 +14623,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14081,6 +14632,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14118,6 +14670,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14127,6 +14680,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14162,6 +14716,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14175,6 +14730,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14212,6 +14768,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14226,6 +14783,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14263,6 +14821,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14276,6 +14835,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14313,6 +14873,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14327,6 +14888,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14364,6 +14926,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14373,6 +14936,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14410,6 +14974,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14419,6 +14984,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14456,6 +15022,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14466,6 +15033,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14503,6 +15071,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14513,6 +15082,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14548,6 +15118,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14563,6 +15134,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14600,6 +15172,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14615,6 +15188,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14652,6 +15226,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14667,6 +15242,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14704,6 +15280,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14719,6 +15296,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14756,6 +15334,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14764,6 +15343,7 @@ TEST 24: pgfmanual-en-library-shapes-25
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14821,7 +15401,9 @@ TEST 25: pgfmanual-en-library-shapes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14850,7 +15432,9 @@ TEST 25: pgfmanual-en-library-shapes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14916,6 +15500,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x151.37479, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 C
 ...........\TU/lmr/m/n/24.88 i
@@ -14940,6 +15525,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmr/m/n/24.88 r
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14977,6 +15563,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -14995,6 +15582,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15032,6 +15620,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15046,6 +15635,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15083,6 +15673,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15095,6 +15686,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15132,6 +15724,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15147,6 +15740,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15184,6 +15778,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15195,6 +15790,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15232,6 +15828,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15241,6 +15838,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15278,6 +15876,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15286,6 +15885,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15323,6 +15923,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15332,6 +15933,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15369,6 +15971,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15379,6 +15982,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15416,6 +16020,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15426,6 +16031,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15463,6 +16069,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15472,6 +16079,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15509,6 +16117,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15518,6 +16127,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15555,6 +16165,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15570,6 +16181,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15605,6 +16217,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15620,6 +16233,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15657,6 +16271,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15672,6 +16287,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15709,6 +16325,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15724,6 +16341,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15761,6 +16379,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -15768,6 +16387,7 @@ TEST 26: pgfmanual-en-library-shapes-27
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15836,9 +16456,11 @@ TEST 27: pgfmanual-en-library-shapes-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x21.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15912,6 +16534,7 @@ TEST 28: pgfmanual-en-library-shapes-29
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(7.05+2.05)x37.54, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 y
@@ -15924,6 +16547,7 @@ TEST 28: pgfmanual-en-library-shapes-29
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15971,6 +16595,7 @@ TEST 28: pgfmanual-en-library-shapes-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x26.95, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
@@ -15980,6 +16605,7 @@ TEST 28: pgfmanual-en-library-shapes-29
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16029,6 +16655,7 @@ TEST 28: pgfmanual-en-library-shapes-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.01, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 w
 ...........\TU/lmr/m/n/10 i
@@ -16036,6 +16663,7 @@ TEST 28: pgfmanual-en-library-shapes-29
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16108,7 +16736,9 @@ TEST 29: pgfmanual-en-library-shapes-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16149,7 +16779,9 @@ TEST 29: pgfmanual-en-library-shapes-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16219,7 +16851,9 @@ TEST 30: pgfmanual-en-library-shapes-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16260,7 +16894,9 @@ TEST 30: pgfmanual-en-library-shapes-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16301,7 +16937,9 @@ TEST 30: pgfmanual-en-library-shapes-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16377,6 +17015,7 @@ TEST 31: pgfmanual-en-library-shapes-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.05)x37.54, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 y
 ...........\TU/lmr/m/n/10 l
@@ -16387,6 +17026,7 @@ TEST 31: pgfmanual-en-library-shapes-32
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16464,6 +17104,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.05064)x86.46283, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 C
 ...........\TU/lmr/m/n/24.88 y
@@ -16477,6 +17118,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmr/m/n/24.88 r
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16514,6 +17156,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16529,6 +17172,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16566,6 +17210,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16574,6 +17219,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16611,6 +17257,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16625,6 +17272,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16662,6 +17310,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16680,6 +17329,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 m
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16717,6 +17367,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16728,6 +17379,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 m
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16765,6 +17417,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16782,6 +17435,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 m
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16819,6 +17473,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16827,6 +17482,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16864,6 +17520,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16877,6 +17534,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16912,6 +17570,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16925,6 +17584,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16962,6 +17622,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -16971,6 +17632,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17008,6 +17670,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17022,6 +17685,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17059,6 +17723,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17073,6 +17738,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17110,6 +17776,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17121,6 +17788,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17158,6 +17826,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17167,6 +17836,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17204,6 +17874,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17221,6 +17892,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17258,6 +17930,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17267,6 +17940,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17302,6 +17976,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17311,6 +17986,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17348,6 +18024,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17358,6 +18035,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17395,6 +18073,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17405,6 +18084,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17442,6 +18122,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17457,6 +18138,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17494,6 +18176,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17509,6 +18192,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17546,6 +18230,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17561,6 +18246,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17598,6 +18284,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17613,6 +18300,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17650,6 +18338,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -17658,6 +18347,7 @@ TEST 32: pgfmanual-en-library-shapes-33
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17725,6 +18415,7 @@ TEST 33: pgfmanual-en-library-shapes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x37.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 o
@@ -17734,6 +18425,7 @@ TEST 33: pgfmanual-en-library-shapes-34
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17814,6 +18506,7 @@ TEST 34: pgfmanual-en-library-shapes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x37.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 o
@@ -17823,6 +18516,7 @@ TEST 34: pgfmanual-en-library-shapes-35
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17899,11 +18593,13 @@ TEST 35: pgfmanual-en-library-shapes-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x20.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17995,9 +18691,11 @@ TEST 36: pgfmanual-en-library-shapes-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x21.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18050,7 +18748,9 @@ TEST 36: pgfmanual-en-library-shapes-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18133,10 +18833,12 @@ TEST 37: pgfmanual-en-library-shapes-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+0.11)x17.26, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18191,11 +18893,13 @@ TEST 37: pgfmanual-en-library-shapes-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x21.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 w
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18322,6 +19026,8 @@ TEST 38: pgfmanual-en-library-shapes-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18409,6 +19115,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x60.68713, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 C
 ...........\TU/lmr/m/n/24.88 l
@@ -18417,6 +19124,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmr/m/n/24.88 d
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18454,6 +19162,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18465,6 +19174,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18502,6 +19212,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18513,6 +19224,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18550,6 +19262,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18561,6 +19274,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 3
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18598,6 +19312,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18609,6 +19324,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 4
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18644,6 +19360,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18655,6 +19372,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18692,6 +19410,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18703,6 +19422,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 6
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18740,6 +19460,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18751,6 +19472,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 7
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18788,6 +19510,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18799,6 +19522,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 8
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18836,6 +19560,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18847,6 +19572,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 9
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18884,6 +19610,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18896,6 +19623,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18933,6 +19661,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18945,6 +19674,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18982,6 +19712,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -18989,6 +19720,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19026,6 +19758,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19037,6 +19770,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19074,6 +19808,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19083,6 +19818,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19120,6 +19856,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19128,6 +19865,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19163,6 +19901,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19172,6 +19911,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19209,6 +19949,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19219,6 +19960,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19256,6 +19998,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19266,6 +20009,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19303,6 +20047,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19312,6 +20057,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19349,6 +20095,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19358,6 +20105,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19393,6 +20141,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19408,6 +20157,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19445,6 +20195,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19460,6 +20211,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19497,6 +20249,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19512,6 +20265,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19549,6 +20303,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -19564,6 +20319,7 @@ TEST 39: pgfmanual-en-library-shapes-40
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19693,11 +20449,13 @@ TEST 40: pgfmanual-en-library-shapes-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x38.40999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/bx/n/10 B
 ...........\TU/lmr/bx/n/10 A
 ...........\TU/lmr/bx/n/10 N
 ...........\TU/lmr/bx/n/10 G
 ...........\TU/lmr/bx/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19855,11 +20613,13 @@ TEST 41: pgfmanual-en-library-shapes-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x39.87999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/bx/n/10 B
 ...........\TU/lmr/bx/n/10 O
 ...........\TU/lmr/bx/n/10 O
 ...........\TU/lmr/bx/n/10 M
 ...........\TU/lmr/bx/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19958,6 +20718,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x94.72299, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 S
 ...........\TU/lmr/m/n/24.88 t
@@ -19972,6 +20733,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmr/m/n/24.88 t
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20009,6 +20771,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20027,6 +20790,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20064,6 +20828,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20082,6 +20847,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20119,6 +20885,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20137,6 +20904,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 3
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20174,6 +20942,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20192,6 +20961,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 4
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20229,6 +20999,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20247,6 +21018,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20284,6 +21056,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20302,6 +21075,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 6
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20337,6 +21111,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20355,6 +21130,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 7
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20392,6 +21168,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20410,6 +21187,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 8
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20447,6 +21225,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20465,6 +21244,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 9
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20502,6 +21282,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20520,6 +21301,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20557,6 +21339,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20575,6 +21358,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20610,6 +21394,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20628,6 +21413,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 3
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20665,6 +21451,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20683,6 +21470,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 4
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20720,6 +21508,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20738,6 +21527,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20775,6 +21565,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20793,6 +21584,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 6
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20830,6 +21622,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20848,6 +21641,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 7
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20885,6 +21679,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20903,6 +21698,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 8
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20940,6 +21736,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -20958,6 +21755,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 9
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20995,6 +21793,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21006,6 +21805,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21041,6 +21841,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21050,6 +21851,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21087,6 +21889,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21095,6 +21898,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21132,6 +21936,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21141,6 +21946,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21178,6 +21984,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21185,6 +21992,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21222,6 +22030,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21232,6 +22041,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21269,6 +22079,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21279,6 +22090,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21314,6 +22126,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21323,6 +22136,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21360,6 +22174,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21369,6 +22184,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21406,6 +22222,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21421,6 +22238,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21458,6 +22276,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21473,6 +22292,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21510,6 +22330,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21525,6 +22346,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21562,6 +22384,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21577,6 +22400,7 @@ TEST 42: pgfmanual-en-library-shapes-43
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21643,6 +22467,7 @@ TEST 43: pgfmanual-en-library-shapes-44
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.8+0.11)x34.36, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 T
 ...........\kern-0.83 (font)
@@ -21653,6 +22478,7 @@ TEST 43: pgfmanual-en-library-shapes-44
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21691,6 +22517,7 @@ TEST 43: pgfmanual-en-library-shapes-44
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.8+0.11)x45.92, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.83 (font)
@@ -21703,6 +22530,7 @@ TEST 43: pgfmanual-en-library-shapes-44
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21774,6 +22602,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x61.70721, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 S
 ...........\TU/lmr/m/n/24.88 i
@@ -21785,6 +22614,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmr/m/n/24.88 l
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21820,6 +22650,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21829,6 +22660,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21866,6 +22698,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21877,6 +22710,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21914,6 +22748,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21921,6 +22756,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21958,6 +22794,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -21967,6 +22804,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22005,6 +22843,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22019,6 +22858,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22057,6 +22897,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22071,6 +22912,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22108,6 +22950,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22116,6 +22959,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22154,6 +22998,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22167,6 +23012,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22205,6 +23051,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22218,6 +23065,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22255,6 +23103,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22265,6 +23114,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22302,6 +23152,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22312,6 +23163,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22349,6 +23201,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22358,6 +23211,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22395,6 +23249,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22404,6 +23259,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22441,6 +23297,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22456,6 +23313,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22493,6 +23351,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22508,6 +23367,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22545,6 +23405,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22560,6 +23421,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22597,6 +23459,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -22612,6 +23475,7 @@ TEST 44: pgfmanual-en-library-shapes-45
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22674,10 +23538,12 @@ TEST 45: pgfmanual-en-library-shapes-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x29.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22710,11 +23576,13 @@ TEST 45: pgfmanual-en-library-shapes-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x28.41, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 E
 ...........\TU/lmr/m/n/10 F
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 G
 ...........\TU/lmr/m/n/10 H
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22782,6 +23650,7 @@ TEST 46: pgfmanual-en-library-shapes-47
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.77+1.94)x21.67, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 T
 ...........\kern-0.83 (font)
@@ -22790,6 +23659,7 @@ TEST 46: pgfmanual-en-library-shapes-47
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22832,6 +23702,7 @@ TEST 46: pgfmanual-en-library-shapes-47
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.56999, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
@@ -22844,6 +23715,7 @@ TEST 46: pgfmanual-en-library-shapes-47
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22889,6 +23761,7 @@ TEST 46: pgfmanual-en-library-shapes-47
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.56999, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
@@ -22901,6 +23774,7 @@ TEST 46: pgfmanual-en-library-shapes-47
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22966,6 +23840,7 @@ TEST 47: pgfmanual-en-library-shapes-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x33.23, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 P
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 a
@@ -22979,6 +23854,7 @@ TEST 47: pgfmanual-en-library-shapes-48
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23013,11 +23889,13 @@ TEST 47: pgfmanual-en-library-shapes-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.05)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 W
 ...........\TU/lmr/m/n/10 h
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
 ...........\TU/lmr/m/n/10 ?
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23120,8 +23998,10 @@ TEST 48: pgfmanual-en-library-shapes-49
 ..........\pdfliteral origin{1 0.5 0.5 RG }
 ..........\pdfliteral origin{1 0.5 0.5 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0.5 rg 1 0.5 0.5 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23180,6 +24060,7 @@ TEST 48: pgfmanual-en-library-shapes-49
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x74.18, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 a
@@ -23201,6 +24082,7 @@ TEST 48: pgfmanual-en-library-shapes-49
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23275,6 +24157,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+4.85161)x50.56097, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 T
 ...........\kern-1.94064 (font)
@@ -23284,6 +24167,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23319,6 +24203,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23328,6 +24213,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23365,6 +24251,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23376,6 +24263,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23413,6 +24301,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23420,6 +24309,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23457,6 +24347,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23466,6 +24357,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23503,6 +24395,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23517,6 +24410,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23554,6 +24448,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23568,6 +24463,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23605,6 +24501,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23613,6 +24510,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23648,6 +24546,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23661,6 +24560,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23698,6 +24598,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23711,6 +24612,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23748,6 +24650,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23758,6 +24661,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23795,6 +24699,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23805,6 +24710,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23842,6 +24748,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23851,6 +24758,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23888,6 +24796,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23897,6 +24806,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23934,6 +24844,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -23949,6 +24860,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23986,6 +24898,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24001,6 +24914,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24038,6 +24952,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24053,6 +24968,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24090,6 +25006,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24105,6 +25022,7 @@ TEST 49: pgfmanual-en-library-shapes-50
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24168,7 +25086,9 @@ TEST 50: pgfmanual-en-library-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24232,7 +25152,9 @@ TEST 51: pgfmanual-en-library-shapes-52
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24268,7 +25190,9 @@ TEST 51: pgfmanual-en-library-shapes-52
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24332,7 +25256,9 @@ TEST 52: pgfmanual-en-library-shapes-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24368,7 +25294,9 @@ TEST 52: pgfmanual-en-library-shapes-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24441,6 +25369,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x150.00638, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 M
 ...........\TU/lmr/m/n/24.88 a
@@ -24461,6 +25390,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24498,6 +25428,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24513,6 +25444,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24550,6 +25482,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24560,6 +25493,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24595,6 +25529,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24610,6 +25545,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24645,6 +25581,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24654,6 +25591,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24691,6 +25629,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24702,6 +25641,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24739,6 +25679,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24748,6 +25689,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24785,6 +25727,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24798,6 +25741,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24835,6 +25779,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24843,6 +25788,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24878,6 +25824,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24891,6 +25838,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24928,6 +25876,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24942,6 +25891,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24979,6 +25929,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -24988,6 +25939,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25025,6 +25977,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25039,6 +25992,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25074,6 +26028,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25089,6 +26044,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25126,6 +26082,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25136,6 +26093,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25171,6 +26129,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25186,6 +26145,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25221,6 +26181,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25230,6 +26191,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25268,6 +26230,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25275,6 +26238,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25313,6 +26277,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25321,6 +26286,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25358,6 +26324,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25372,6 +26339,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25409,6 +26377,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25429,6 +26398,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25466,6 +26436,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -25486,6 +26457,7 @@ TEST 53: pgfmanual-en-library-shapes-54
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25549,12 +26521,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x20.87, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 h
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25587,8 +26561,10 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.42+1.94)x11.12, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 p
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25621,12 +26597,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x14.59726, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\OT1/cmr/m/n/10 7
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25691,6 +26669,8 @@ TEST 55: pgfmanual-en-library-shapes-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25735,6 +26715,7 @@ TEST 55: pgfmanual-en-library-shapes-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.01, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 w
 ...........\TU/lmr/m/n/10 i
@@ -25742,6 +26723,7 @@ TEST 55: pgfmanual-en-library-shapes-56
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25789,6 +26771,7 @@ TEST 55: pgfmanual-en-library-shapes-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x26.95, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
@@ -25798,6 +26781,7 @@ TEST 55: pgfmanual-en-library-shapes-56
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25865,6 +26849,7 @@ TEST 56: pgfmanual-en-library-shapes-57
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(7.16+0.11)x27.28, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 r
@@ -25875,6 +26860,7 @@ TEST 56: pgfmanual-en-library-shapes-57
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 w
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -25930,6 +26916,7 @@ TEST 56: pgfmanual-en-library-shapes-57
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x53.06, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
@@ -25945,6 +26932,7 @@ TEST 56: pgfmanual-en-library-shapes-57
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26012,6 +27000,7 @@ TEST 57: pgfmanual-en-library-shapes-58
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x33.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\discretionary (penalty 50)
@@ -26022,6 +27011,7 @@ TEST 57: pgfmanual-en-library-shapes-58
 ...........\TU/lmr/m/n/10 w
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26058,6 +27048,7 @@ TEST 57: pgfmanual-en-library-shapes-58
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x33.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\discretionary (penalty 50)
@@ -26068,6 +27059,7 @@ TEST 57: pgfmanual-en-library-shapes-58
 ...........\TU/lmr/m/n/10 w
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26137,6 +27129,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x130.15211, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 S
 ...........\TU/lmr/m/n/24.88 i
@@ -26157,6 +27150,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmr/m/n/24.88 w
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26194,6 +27188,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26203,6 +27198,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26240,6 +27236,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26251,6 +27248,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26288,6 +27286,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26295,6 +27294,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26330,6 +27330,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26343,6 +27344,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26380,6 +27382,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26388,6 +27391,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26425,6 +27429,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26438,6 +27443,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26475,6 +27481,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26489,6 +27496,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26526,6 +27534,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26535,6 +27544,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26572,6 +27582,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26586,6 +27597,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26623,6 +27635,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26631,6 +27644,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26668,6 +27682,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26683,6 +27698,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26720,6 +27736,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26734,6 +27751,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26771,6 +27789,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26787,6 +27806,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26824,6 +27844,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26839,6 +27860,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26876,6 +27898,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26891,6 +27914,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 l
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26928,6 +27952,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26944,6 +27969,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 l
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26981,6 +28007,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -26990,6 +28017,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 l
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27027,6 +28055,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27037,6 +28066,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27074,6 +28104,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27084,6 +28115,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27121,6 +28153,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27130,6 +28163,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27167,6 +28201,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27176,6 +28211,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27213,6 +28249,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27228,6 +28265,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27265,6 +28303,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27280,6 +28319,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27317,6 +28357,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27332,6 +28373,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27369,6 +28411,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27384,6 +28427,7 @@ TEST 58: pgfmanual-en-library-shapes-59
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27448,6 +28492,7 @@ TEST 59: pgfmanual-en-library-shapes-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x57.53, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 L
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 f
@@ -27462,6 +28507,7 @@ TEST 59: pgfmanual-en-library-shapes-60
 ...........\TU/lmr/m/n/10 h
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27529,6 +28575,8 @@ TEST 60: pgfmanual-en-library-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27575,6 +28623,7 @@ TEST 60: pgfmanual-en-library-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.01, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 w
 ...........\TU/lmr/m/n/10 i
@@ -27582,6 +28631,7 @@ TEST 60: pgfmanual-en-library-shapes-61
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27631,6 +28681,7 @@ TEST 60: pgfmanual-en-library-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x26.95, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
@@ -27640,6 +28691,7 @@ TEST 60: pgfmanual-en-library-shapes-61
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27710,6 +28762,7 @@ TEST 61: pgfmanual-en-library-shapes-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x33.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\discretionary (penalty 50)
@@ -27720,6 +28773,7 @@ TEST 61: pgfmanual-en-library-shapes-62
 ...........\TU/lmr/m/n/10 w
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27759,6 +28813,7 @@ TEST 61: pgfmanual-en-library-shapes-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x33.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\discretionary (penalty 50)
@@ -27769,6 +28824,7 @@ TEST 61: pgfmanual-en-library-shapes-62
 ...........\TU/lmr/m/n/10 w
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27841,6 +28897,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.19904)x141.52228, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 D
 ...........\TU/lmr/m/n/24.88 o
@@ -27861,6 +28918,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmr/m/n/24.88 w
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27898,6 +28956,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27907,6 +28966,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27944,6 +29004,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27955,6 +29016,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27992,6 +29054,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -27999,6 +29062,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28034,6 +29098,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28047,6 +29112,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28084,6 +29150,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28092,6 +29159,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28129,6 +29197,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28142,6 +29211,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28179,6 +29249,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28193,6 +29264,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28230,6 +29302,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28239,6 +29312,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28276,6 +29350,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28290,6 +29365,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28327,6 +29403,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28345,6 +29422,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28382,6 +29460,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28399,6 +29478,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28436,6 +29516,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28446,6 +29527,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28483,6 +29565,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28499,6 +29582,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28536,6 +29620,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28553,6 +29638,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28590,6 +29676,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x63.18892, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28608,6 +29695,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28645,6 +29733,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28662,6 +29751,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28699,6 +29789,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28709,6 +29800,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28746,6 +29838,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28762,6 +29855,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28799,6 +29893,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x59.47192, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28816,6 +29911,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28853,6 +29949,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28863,6 +29960,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28900,6 +29998,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28910,6 +30009,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28947,6 +30047,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -28956,6 +30057,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28993,6 +30095,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29002,6 +30105,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29039,6 +30143,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29054,6 +30159,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29091,6 +30197,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29106,6 +30213,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29143,6 +30251,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29158,6 +30267,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29195,6 +30305,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29210,6 +30321,7 @@ TEST 62: pgfmanual-en-library-shapes-63
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29295,7 +30407,9 @@ TEST 63: pgfmanual-en-library-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29340,7 +30454,9 @@ TEST 63: pgfmanual-en-library-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29447,9 +30563,11 @@ TEST 64: pgfmanual-en-library-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 O
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29491,11 +30609,13 @@ TEST 64: pgfmanual-en-library-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.11)x18.33, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 T
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 w
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29591,6 +30711,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.19904)x109.87491, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 A
 ...........\TU/lmr/m/n/24.88 r
@@ -29607,6 +30728,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmr/m/n/24.88 x
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29644,6 +30766,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29655,6 +30778,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29692,6 +30816,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29701,6 +30826,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29738,6 +30864,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29746,6 +30873,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29783,6 +30911,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29792,6 +30921,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29829,6 +30959,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29836,6 +30967,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29873,6 +31005,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29886,6 +31019,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29921,6 +31055,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29934,6 +31069,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29971,6 +31107,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -29985,6 +31122,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30020,6 +31158,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30034,6 +31173,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30071,6 +31211,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30081,6 +31222,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30118,6 +31260,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30128,6 +31271,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30165,6 +31309,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30174,6 +31319,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30211,6 +31357,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30220,6 +31367,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30257,6 +31405,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30272,6 +31421,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30309,6 +31459,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30324,6 +31475,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30361,6 +31513,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30376,6 +31529,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30413,6 +31567,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30428,6 +31583,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30465,6 +31621,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30485,6 +31642,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30522,6 +31680,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30542,6 +31701,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30579,6 +31739,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x66.90591, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30598,6 +31759,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30635,6 +31797,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x66.90591, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30654,6 +31817,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30691,6 +31855,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x81.7739, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30714,6 +31879,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 w
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30749,6 +31915,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x100.35887, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30777,6 +31944,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30814,6 +31982,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x96.64188, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30841,6 +32010,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30876,6 +32046,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x92.92488, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30902,6 +32073,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30939,6 +32111,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x96.64188, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -30966,6 +32139,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31003,6 +32177,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x78.0569, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31025,6 +32200,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 w
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31062,6 +32238,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x81.7739, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31085,6 +32262,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 w
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31120,6 +32298,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x100.35887, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31148,6 +32327,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31185,6 +32365,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x96.64188, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31212,6 +32393,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31247,6 +32429,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x92.92488, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31273,6 +32456,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31310,6 +32494,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x96.64188, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31337,6 +32522,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31374,6 +32560,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x78.0569, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31396,6 +32583,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 w
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31433,6 +32621,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x78.0569, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31455,6 +32644,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 w
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31490,6 +32680,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x96.64188, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31517,6 +32708,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31554,6 +32746,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x92.92488, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31580,6 +32773,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31617,6 +32811,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x89.20789, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31642,6 +32837,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31679,6 +32875,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x92.92488, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31705,6 +32902,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31742,6 +32940,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31763,6 +32962,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 w
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31800,6 +33000,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x78.0569, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31822,6 +33023,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 w
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31857,6 +33059,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x96.64188, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31884,6 +33087,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31921,6 +33125,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x92.92488, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -31947,6 +33152,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31984,6 +33190,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x89.20789, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32009,6 +33216,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 p
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32046,6 +33254,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x92.92488, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32072,6 +33281,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32109,6 +33319,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32130,6 +33341,7 @@ TEST 65: pgfmanual-en-library-shapes-66
 ...........\TU/lmtt/m/n/7 w
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32215,11 +33427,13 @@ TEST 66: pgfmanual-en-library-shapes-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32233,12 +33447,14 @@ TEST 66: pgfmanual-en-library-shapes-67
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+0.0)x10.00003, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\mathon
 ..........\OT1/cmr/m/n/10 0
 ..........\OT1/cmr/m/n/10 0
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -32313,12 +33529,14 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(15.30121+0.19904)x39.78314, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 t
 ...........\TU/lmr/m/n/24.88 e
 ...........\TU/lmr/m/n/24.88 x
 ...........\TU/lmr/m/n/24.88 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32332,6 +33550,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(17.26672+0.19904)x51.87482, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\TU/lmr/m/n/24.88 l
@@ -32341,6 +33560,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\kern-0.64688 (font)
 ..........\TU/lmr/m/n/24.88 e
 ..........\TU/lmr/m/n/24.88 r
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -32378,6 +33598,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32393,6 +33614,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32430,6 +33652,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32440,6 +33663,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32476,6 +33700,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32491,6 +33716,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32526,6 +33752,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32535,6 +33762,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32572,6 +33800,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32583,6 +33812,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32620,6 +33850,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32629,6 +33860,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32666,6 +33898,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32679,6 +33912,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32716,6 +33950,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32724,6 +33959,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32759,6 +33995,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32772,6 +34009,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32807,6 +34045,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32821,6 +34060,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32858,6 +34098,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32867,6 +34108,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32904,6 +34146,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32918,6 +34161,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32954,6 +34198,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -32969,6 +34214,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33006,6 +34252,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33016,6 +34263,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33054,6 +34302,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33069,6 +34318,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33104,6 +34354,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33113,6 +34364,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33148,6 +34400,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33158,6 +34411,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33195,6 +34449,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33203,6 +34458,7 @@ TEST 67: pgfmanual-en-library-shapes-68
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33287,11 +34543,13 @@ TEST 68: pgfmanual-en-library-shapes-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33305,12 +34563,14 @@ TEST 68: pgfmanual-en-library-shapes-69
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+0.0)x10.00003, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\mathon
 ..........\OT1/cmr/m/n/10 0
 ..........\OT1/cmr/m/n/10 0
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -33384,12 +34644,14 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(15.30121+0.19904)x39.78314, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 t
 ...........\TU/lmr/m/n/24.88 e
 ...........\TU/lmr/m/n/24.88 x
 ...........\TU/lmr/m/n/24.88 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33403,6 +34665,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(17.26672+0.19904)x51.87482, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\TU/lmr/m/n/24.88 l
@@ -33412,6 +34675,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\kern-0.64688 (font)
 ..........\TU/lmr/m/n/24.88 e
 ..........\TU/lmr/m/n/24.88 r
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -33449,6 +34713,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33464,6 +34729,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33501,6 +34767,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33511,6 +34778,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33547,6 +34815,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33562,6 +34831,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33597,6 +34867,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33606,6 +34877,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33643,6 +34915,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33654,6 +34927,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33691,6 +34965,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33700,6 +34975,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33737,6 +35013,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33750,6 +35027,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33787,6 +35065,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33795,6 +35074,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33830,6 +35110,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33843,6 +35124,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33878,6 +35160,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33892,6 +35175,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33929,6 +35213,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33938,6 +35223,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33975,6 +35261,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -33989,6 +35276,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34025,6 +35313,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34040,6 +35329,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34077,6 +35367,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34087,6 +35378,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34125,6 +35417,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34140,6 +35433,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34175,6 +35469,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34184,6 +35479,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34219,6 +35515,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34229,6 +35526,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34266,6 +35564,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34274,6 +35573,7 @@ TEST 69: pgfmanual-en-library-shapes-70
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34345,12 +35645,14 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(15.30121+0.19904)x39.78314, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 t
 ...........\TU/lmr/m/n/24.88 e
 ...........\TU/lmr/m/n/24.88 x
 ...........\TU/lmr/m/n/24.88 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34364,6 +35666,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(17.26672+0.19904)x51.87482, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\TU/lmr/m/n/24.88 l
@@ -34373,6 +35676,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\kern-0.64688 (font)
 ..........\TU/lmr/m/n/24.88 e
 ..........\TU/lmr/m/n/24.88 r
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -34409,6 +35713,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34420,6 +35725,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34455,6 +35761,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34464,6 +35771,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34499,6 +35807,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34509,6 +35818,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34544,6 +35854,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34551,6 +35862,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34588,6 +35900,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34596,6 +35909,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34633,6 +35947,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34646,6 +35961,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34683,6 +35999,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34696,6 +36013,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34733,6 +36051,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34742,6 +36061,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34777,6 +36097,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34791,6 +36112,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34828,6 +36150,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34842,6 +36165,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34879,6 +36203,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34889,6 +36214,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34926,6 +36252,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34936,6 +36263,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34973,6 +36301,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -34982,6 +36311,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35019,6 +36349,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35028,6 +36359,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35065,6 +36397,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35080,6 +36413,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35117,6 +36451,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35132,6 +36467,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35169,6 +36505,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35184,6 +36521,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35221,6 +36559,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35236,6 +36575,7 @@ TEST 70: pgfmanual-en-library-shapes-71
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35309,12 +36649,14 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(15.30121+0.19904)x39.78314, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 t
 ...........\TU/lmr/m/n/24.88 e
 ...........\TU/lmr/m/n/24.88 x
 ...........\TU/lmr/m/n/24.88 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35328,6 +36670,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(17.26672+0.19904)x51.87482, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\TU/lmr/m/n/24.88 l
@@ -35337,6 +36680,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\kern-0.64688 (font)
 ..........\TU/lmr/m/n/24.88 e
 ..........\TU/lmr/m/n/24.88 r
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -35373,6 +36717,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35388,6 +36733,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35425,6 +36771,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35435,6 +36782,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35470,6 +36818,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35485,6 +36834,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35520,6 +36870,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35529,6 +36880,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35566,6 +36918,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35577,6 +36930,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35614,6 +36968,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35623,6 +36978,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35660,6 +37016,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35668,6 +37025,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35705,6 +37063,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35714,6 +37073,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35749,6 +37109,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35764,6 +37125,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35801,6 +37163,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35811,6 +37174,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35848,6 +37212,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35863,6 +37228,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35898,6 +37264,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35907,6 +37274,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35942,6 +37310,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35952,6 +37321,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -35989,6 +37359,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -35997,6 +37368,7 @@ TEST 71: pgfmanual-en-library-shapes-72
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36062,7 +37434,9 @@ TEST 72: pgfmanual-en-library-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36076,9 +37450,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.11)x5.56, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 b
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36091,9 +37467,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x4.44, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 c
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36106,9 +37484,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.11)x5.56, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 d
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36121,9 +37501,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x4.44, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 e
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36159,7 +37541,9 @@ TEST 72: pgfmanual-en-library-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36173,9 +37557,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.66+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 2
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36188,9 +37574,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.66+0.22)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 3
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36203,9 +37591,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.77+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 4
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36218,9 +37608,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.66+0.22)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 5
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36252,7 +37644,9 @@ TEST 72: pgfmanual-en-library-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36266,9 +37660,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.83+0.0)x7.08, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 B
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36281,9 +37677,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(7.05+0.22)x7.22, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 C
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36317,7 +37715,9 @@ TEST 72: pgfmanual-en-library-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36331,9 +37731,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.66+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 2
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36346,9 +37748,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.66+0.22)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 3
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36361,9 +37765,11 @@ TEST 72: pgfmanual-en-library-shapes-73
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.77+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 4
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36423,6 +37829,7 @@ TEST 73: pgfmanual-en-library-shapes-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x78.24507, direction TLT
+...........\begindir TLT
 ...........\vbox(7.05+0.22)x78.24507, direction TLT
 ............\hbox(7.05+0.22)x78.24507, glue set 1.10162, direction TLT
 .............\glue(\leftskip) 0.0 plus 20.0
@@ -36446,6 +37853,7 @@ TEST 73: pgfmanual-en-library-shapes-74
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36459,6 +37867,7 @@ TEST 73: pgfmanual-en-library-shapes-74
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+14.06)x78.24507, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\vbox(6.57+14.06)x78.24507, direction TLT
@@ -36506,6 +37915,7 @@ TEST 73: pgfmanual-en-library-shapes-74
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0 plus 20.0
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36518,6 +37928,7 @@ TEST 73: pgfmanual-en-library-shapes-74
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(7.5+14.5)x78.24507, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\vbox(7.5+14.5)x78.24507, direction TLT
@@ -36577,6 +37988,7 @@ TEST 73: pgfmanual-en-library-shapes-74
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0 plus 20.0
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36636,10 +38048,12 @@ TEST 74: pgfmanual-en-library-shapes-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x17.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 x
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36668,6 +38082,7 @@ TEST 74: pgfmanual-en-library-shapes-75
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.11)x21.70999, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 t
@@ -36675,6 +38090,7 @@ TEST 74: pgfmanual-en-library-shapes-75
 ..........\TU/lmr/m/n/10 i
 ..........\TU/lmr/m/n/10 r
 ..........\TU/lmr/m/n/10 d
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36704,10 +38120,12 @@ TEST 74: pgfmanual-en-library-shapes-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x17.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 x
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36721,8 +38139,10 @@ TEST 74: pgfmanual-en-library-shapes-75
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(0.0+0.0)x0.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36735,6 +38155,7 @@ TEST 74: pgfmanual-en-library-shapes-75
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.11)x21.70999, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 t
@@ -36742,6 +38163,7 @@ TEST 74: pgfmanual-en-library-shapes-75
 ..........\TU/lmr/m/n/10 i
 ..........\TU/lmr/m/n/10 r
 ..........\TU/lmr/m/n/10 d
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36804,9 +38226,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36820,9 +38244,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.66+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 2
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36835,6 +38261,7 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.11)x22.25, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 t
@@ -36842,6 +38269,7 @@ TEST 75: pgfmanual-en-library-shapes-76
 ..........\TU/lmr/m/n/10 r
 ..........\TU/lmr/m/n/10 e
 ..........\TU/lmr/m/n/10 e
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36854,9 +38282,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.77+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 4
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36890,9 +38320,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36906,9 +38338,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.66+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 2
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36921,6 +38355,7 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.11)x22.25, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 t
@@ -36928,6 +38363,7 @@ TEST 75: pgfmanual-en-library-shapes-76
 ..........\TU/lmr/m/n/10 r
 ..........\TU/lmr/m/n/10 e
 ..........\TU/lmr/m/n/10 e
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36940,9 +38376,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.77+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 4
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -36976,9 +38414,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -36992,9 +38432,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.66+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 2
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37007,6 +38449,7 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.11)x22.25, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 t
@@ -37014,6 +38457,7 @@ TEST 75: pgfmanual-en-library-shapes-76
 ..........\TU/lmr/m/n/10 r
 ..........\TU/lmr/m/n/10 e
 ..........\TU/lmr/m/n/10 e
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37026,9 +38470,11 @@ TEST 75: pgfmanual-en-library-shapes-76
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.77+0.0)x5.0, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 4
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37091,7 +38537,9 @@ TEST 76: pgfmanual-en-library-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.20639+0.144)x10.1808, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/14.4 w
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37105,9 +38553,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.31+0.0)x5.28, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 x
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37120,9 +38570,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(10.6984+5.05064)x12.0668, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/24.88 y
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37135,9 +38587,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(2.155+0.0)x3.055, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/5 z
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37171,7 +38625,9 @@ TEST 76: pgfmanual-en-library-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.20639+0.144)x10.1808, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/14.4 w
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37185,9 +38641,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.31+0.0)x5.28, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 x
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37200,9 +38658,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(10.6984+5.05064)x12.0668, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/24.88 y
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37215,9 +38675,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(2.155+0.0)x3.055, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/5 z
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37251,7 +38713,9 @@ TEST 76: pgfmanual-en-library-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.20639+0.144)x10.1808, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/14.4 w
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37265,9 +38729,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.31+0.0)x5.28, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 x
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37280,9 +38746,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(10.6984+5.05064)x12.0668, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/24.88 y
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37295,9 +38763,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(2.155+0.0)x3.055, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/5 z
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37331,7 +38801,9 @@ TEST 76: pgfmanual-en-library-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.20639+0.144)x10.1808, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/14.4 w
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37345,9 +38817,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.31+0.0)x5.28, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/10 x
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37360,9 +38834,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(10.6984+5.05064)x12.0668, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/24.88 y
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37375,9 +38851,11 @@ TEST 76: pgfmanual-en-library-shapes-77
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(2.155+0.0)x3.055, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/5 z
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37904,12 +39382,14 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(15.30121+0.19904)x39.78314, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0.7 G }
 ...........\pdfliteral origin{0.7 g }
 ...........\TU/lmr/m/n/24.88 t
 ...........\TU/lmr/m/n/24.88 e
 ...........\TU/lmr/m/n/24.88 x
 ...........\TU/lmr/m/n/24.88 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -37923,6 +39403,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(15.30121+0.19904)x35.55353, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\TU/lmr/m/n/24.88 t
@@ -37930,6 +39411,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\TU/lmr/m/n/24.88 w
 ..........\kern-0.64688 (font)
 ..........\TU/lmr/m/n/24.88 o
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37942,6 +39424,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(17.26672+0.19904)x50.53131, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\TU/lmr/m/n/24.88 t
@@ -37949,6 +39432,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\TU/lmr/m/n/24.88 r
 ..........\TU/lmr/m/n/24.88 e
 ..........\TU/lmr/m/n/24.88 e
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -37961,12 +39445,14 @@ TEST 78: pgfmanual-en-library-shapes-79
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(17.46576+0.19904)x39.80801, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\TU/lmr/m/n/24.88 f
 ..........\TU/lmr/m/n/24.88 o
 ..........\TU/lmr/m/n/24.88 u
 ..........\TU/lmr/m/n/24.88 r
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -38001,6 +39487,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38010,6 +39497,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38047,6 +39535,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38061,6 +39550,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38098,6 +39588,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38112,6 +39603,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38147,6 +39639,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38155,6 +39648,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 o
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38192,6 +39686,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38205,6 +39700,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38242,6 +39738,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38255,6 +39752,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38290,6 +39788,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38300,6 +39799,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38337,6 +39837,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38352,6 +39853,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38389,6 +39891,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38404,6 +39907,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38439,6 +39943,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38448,6 +39953,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38485,6 +39991,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38499,6 +40006,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38536,6 +40044,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38550,6 +40059,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38585,6 +40095,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38600,6 +40111,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38637,6 +40149,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38657,6 +40170,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38694,6 +40208,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x70.62291, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38714,6 +40229,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38749,6 +40265,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38763,6 +40280,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38800,6 +40318,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x66.90591, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38819,6 +40338,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38856,6 +40376,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x66.90591, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38875,6 +40396,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38910,6 +40432,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x55.75493, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38926,6 +40449,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -38963,6 +40487,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -38984,6 +40509,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39021,6 +40547,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39042,6 +40569,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39079,6 +40607,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39089,6 +40618,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39126,6 +40656,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39136,6 +40667,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39173,6 +40705,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39182,6 +40715,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39219,6 +40753,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39228,6 +40763,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39265,6 +40801,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39280,6 +40817,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39317,6 +40855,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39332,6 +40871,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39369,6 +40909,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39384,6 +40925,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39421,6 +40963,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39436,6 +40979,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39473,6 +41017,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39484,6 +41029,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39521,6 +41067,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39528,6 +41075,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39565,6 +41113,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39573,6 +41122,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39610,6 +41160,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39619,6 +41170,7 @@ TEST 78: pgfmanual-en-library-shapes-79
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39719,7 +41271,9 @@ TEST 79: pgfmanual-en-library-shapes-82
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39758,7 +41312,9 @@ TEST 79: pgfmanual-en-library-shapes-82
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39829,6 +41385,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x179.73798, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 R
 ...........\TU/lmr/m/n/24.88 e
@@ -39855,6 +41412,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmr/m/n/24.88 t
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39892,6 +41450,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39903,6 +41462,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39940,6 +41500,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39949,6 +41510,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -39986,6 +41548,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -39993,6 +41556,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40030,6 +41594,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40038,6 +41603,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40073,6 +41639,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40086,6 +41653,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40123,6 +41691,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40136,6 +41705,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40173,6 +41743,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40182,6 +41753,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40219,6 +41791,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40233,6 +41806,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40270,6 +41844,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40284,6 +41859,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40321,6 +41897,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40331,6 +41908,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40368,6 +41946,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40378,6 +41957,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40415,6 +41995,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40424,6 +42005,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40461,6 +42043,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40470,6 +42053,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40507,6 +42091,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40522,6 +42107,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40559,6 +42145,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40574,6 +42161,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40611,6 +42199,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40626,6 +42215,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40663,6 +42253,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40678,6 +42269,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40715,6 +42307,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40727,6 +42320,7 @@ TEST 80: pgfmanual-en-library-shapes-83
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40800,6 +42394,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+4.85161)x147.9662, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 E
 ...........\TU/lmr/m/n/24.88 l
@@ -40822,6 +42417,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmr/m/n/24.88 t
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40859,6 +42455,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40870,6 +42467,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40907,6 +42505,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40916,6 +42515,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40953,6 +42553,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -40960,6 +42561,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -40997,6 +42599,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41005,6 +42608,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41042,6 +42646,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41055,6 +42660,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41090,6 +42696,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41103,6 +42710,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41140,6 +42748,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41149,6 +42758,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41186,6 +42796,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41200,6 +42811,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41237,6 +42849,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41251,6 +42864,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41288,6 +42902,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41298,6 +42913,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41335,6 +42951,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41345,6 +42962,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41382,6 +43000,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41391,6 +43010,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41428,6 +43048,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41437,6 +43058,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41474,6 +43096,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41489,6 +43112,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41524,6 +43148,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41539,6 +43164,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41574,6 +43200,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41589,6 +43216,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41626,6 +43254,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41641,6 +43270,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41678,6 +43308,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41690,6 +43321,7 @@ TEST 81: pgfmanual-en-library-shapes-84
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41789,8 +43421,10 @@ TEST 82: pgfmanual-en-library-shapes-85
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -41806,6 +43440,7 @@ TEST 82: pgfmanual-en-library-shapes-85
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.86+2.01)x49.70001, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/bx/n/10 I
 ...........\TU/lmr/bx/n/10 m
@@ -41820,6 +43455,7 @@ TEST 82: pgfmanual-en-library-shapes-85
 ...........\TU/lmr/bx/n/10 .
 ...........\TU/lmr/bx/n/10 .
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41921,6 +43557,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.39809)x141.6218, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 C
 ...........\TU/lmr/m/n/24.88 l
@@ -41939,6 +43576,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmr/m/n/24.88 t
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -41976,6 +43614,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -41987,6 +43626,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42024,6 +43664,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42035,6 +43676,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 2
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42072,6 +43714,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42083,6 +43726,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 3
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42120,6 +43764,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42131,6 +43776,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 4
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42166,6 +43812,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42177,6 +43824,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 5
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42214,6 +43862,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42225,6 +43874,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 6
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42262,6 +43912,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42273,6 +43924,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 7
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42310,6 +43962,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42321,6 +43974,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 8
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42358,6 +44012,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42369,6 +44024,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 9
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42406,6 +44062,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42418,6 +44075,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42455,6 +44113,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42467,6 +44126,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 1
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42504,6 +44164,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42511,6 +44172,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42548,6 +44210,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42559,6 +44222,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42596,6 +44260,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42605,6 +44270,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42642,6 +44308,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42650,6 +44317,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42685,6 +44353,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42694,6 +44363,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42731,6 +44401,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42741,6 +44412,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42778,6 +44450,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42788,6 +44461,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42825,6 +44499,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42834,6 +44509,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42871,6 +44547,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42880,6 +44557,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42915,6 +44593,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42930,6 +44609,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -42967,6 +44647,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -42982,6 +44663,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43019,6 +44701,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43034,6 +44717,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43071,6 +44755,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43086,6 +44771,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43123,6 +44809,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+1.554)x40.88695, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43135,6 +44822,7 @@ TEST 83: pgfmanual-en-library-shapes-86
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43226,6 +44914,7 @@ TEST 84: pgfmanual-en-library-shapes-87
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x39.02, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
@@ -43235,6 +44924,7 @@ TEST 84: pgfmanual-en-library-shapes-87
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43306,8 +44996,10 @@ TEST 85: pgfmanual-en-library-shapes-88
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x12.77, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43381,6 +45073,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+0.19904)x89.64746, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 c
 ...........\TU/lmr/m/n/24.88 r
@@ -43393,6 +45086,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmr/m/n/24.88 t
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43450,6 +45144,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43465,6 +45160,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43503,6 +45199,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43513,6 +45210,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43548,6 +45246,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43563,6 +45262,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43599,6 +45299,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43608,6 +45309,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43646,6 +45348,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43657,6 +45360,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43694,6 +45398,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43703,6 +45408,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43740,6 +45446,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43753,6 +45460,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43791,6 +45499,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43799,6 +45508,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43834,6 +45544,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43847,6 +45558,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43882,6 +45594,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43896,6 +45609,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43934,6 +45648,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43943,6 +45658,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -43980,6 +45696,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -43994,6 +45711,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44029,6 +45747,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -44044,6 +45763,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44082,6 +45802,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -44092,6 +45813,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44130,6 +45852,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -44145,6 +45868,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44180,6 +45904,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -44189,6 +45914,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44226,6 +45952,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -44233,6 +45960,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44270,6 +45998,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -44278,6 +46007,7 @@ TEST 86: pgfmanual-en-library-shapes-89
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44336,8 +46066,10 @@ TEST 87: pgfmanual-en-library-shapes-90
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x12.77, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44415,11 +46147,13 @@ TEST 88: pgfmanual-en-library-shapes-91
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x23.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44503,9 +46237,11 @@ TEST 89: pgfmanual-en-library-shapes-92
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 8
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -44553,9 +46289,11 @@ TEST 89: pgfmanual-en-library-shapes-92
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -44601,8 +46339,10 @@ TEST 89: pgfmanual-en-library-shapes-92
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
 .....................\TU/lmr/m/n/10 0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -44700,6 +46440,7 @@ TEST 90: pgfmanual-en-library-shapes-93
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(7.05+0.22)x36.38, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 C
 .....................\TU/lmr/m/n/10 o
 .....................\TU/lmr/m/n/10 n
@@ -44711,6 +46452,7 @@ TEST 90: pgfmanual-en-library-shapes-93
 .....................\TU/lmr/m/n/10 v
 .....................\kern-0.28 (font)
 .....................\TU/lmr/m/n/10 e
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -44758,6 +46500,7 @@ TEST 90: pgfmanual-en-library-shapes-93
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(7.05+0.22)x32.22, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 C
 .....................\TU/lmr/m/n/10 o
 .....................\TU/lmr/m/n/10 n
@@ -44768,6 +46511,7 @@ TEST 90: pgfmanual-en-library-shapes-93
 .....................\kern-0.28 (font)
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 x
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -44814,10 +46558,12 @@ TEST 90: pgfmanual-en-library-shapes-93
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.11)x22.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 N
 .....................\TU/lmr/m/n/10 o
 .....................\TU/lmr/m/n/10 n
 .....................\TU/lmr/m/n/10 e
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -44900,6 +46646,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x195.61142, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 R
 ...........\TU/lmr/m/n/24.88 o
@@ -44924,6 +46671,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -44961,6 +46709,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -44972,6 +46721,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45009,6 +46759,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45018,6 +46769,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45054,6 +46806,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45061,6 +46814,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45098,6 +46852,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45106,6 +46861,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45142,6 +46898,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45155,6 +46912,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45189,6 +46947,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45202,6 +46961,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45239,6 +46999,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45248,6 +47009,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45284,6 +47046,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45298,6 +47061,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45334,6 +47098,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45348,6 +47113,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45384,6 +47150,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45394,6 +47161,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45430,6 +47198,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45440,6 +47209,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45476,6 +47246,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45485,6 +47256,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45521,6 +47293,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45530,6 +47303,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45566,6 +47340,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45581,6 +47356,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45615,6 +47391,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45630,6 +47407,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45664,6 +47442,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45679,6 +47458,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45715,6 +47495,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -45730,6 +47511,7 @@ TEST 91: pgfmanual-en-library-shapes-94
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45825,6 +47607,7 @@ TEST 92: pgfmanual-en-library-shapes-95
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.11)x34.39, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/bx/n/10 S
 ...........\TU/lmr/bx/n/10 T
@@ -45832,6 +47615,7 @@ TEST 92: pgfmanual-en-library-shapes-95
 ...........\TU/lmr/bx/n/10 P
 ...........\TU/lmr/bx/n/10 !
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45898,10 +47682,12 @@ TEST 93: pgfmanual-en-library-shapes-96
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -45939,9 +47725,11 @@ TEST 93: pgfmanual-en-library-shapes-96
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46007,9 +47795,11 @@ TEST 94: pgfmanual-en-library-shapes-97
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x13.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46047,9 +47837,11 @@ TEST 94: pgfmanual-en-library-shapes-97
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.22)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46115,9 +47907,11 @@ TEST 95: pgfmanual-en-library-shapes-98
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x13.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46155,9 +47949,11 @@ TEST 95: pgfmanual-en-library-shapes-98
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46232,6 +48028,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0.7 G }
 ..........\pdfliteral origin{0.7 g }
 ..........\hbox(56.9055+5.07552)x214.86856, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 g 0.7 G}
 ...........\TU/lmr/m/n/24.88 C
 ...........\TU/lmr/m/n/24.88 h
@@ -46260,6 +48057,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmr/m/n/24.88 e
 ...........\rule(56.9055+*)x1.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46297,6 +48095,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46306,6 +48105,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46343,6 +48143,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x37.16995, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46354,6 +48155,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 r
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46391,6 +48193,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x22.30197, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46398,6 +48201,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 0
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46435,6 +48239,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46444,6 +48249,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 e
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46479,6 +48285,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46493,6 +48300,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46530,6 +48338,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x48.32094, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46544,6 +48353,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46581,6 +48391,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x26.01897, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46589,6 +48400,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 d
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46626,6 +48438,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46639,6 +48452,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46676,6 +48490,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x44.60394, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46689,6 +48504,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46726,6 +48542,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46736,6 +48553,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46773,6 +48591,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x33.45296, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46783,6 +48602,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 h
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46820,6 +48640,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46829,6 +48650,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46866,6 +48688,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x29.73596, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46875,6 +48698,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46912,6 +48736,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x78.0569, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46934,6 +48759,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -46971,6 +48797,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -46986,6 +48813,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47023,6 +48851,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47044,6 +48873,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47081,6 +48911,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x78.0569, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47103,6 +48934,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47140,6 +48972,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47155,6 +48988,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47192,6 +49026,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47213,6 +49048,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47250,6 +49086,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x78.0569, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47272,6 +49109,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47309,6 +49147,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47324,6 +49163,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47361,6 +49201,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47382,6 +49223,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47419,6 +49261,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x78.0569, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47441,6 +49284,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47478,6 +49322,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x52.03793, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47493,6 +49338,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47530,6 +49376,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.858+0.581)x74.3399, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/7 (
 ...........\TU/lmtt/m/n/7 s
 ...........\TU/lmtt/m/n/7 .
@@ -47551,6 +49398,7 @@ TEST 96: pgfmanual-en-library-shapes-99
 ...........\TU/lmtt/m/n/7 t
 ...........\TU/lmtt/m/n/7 )
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-spy.tlg
+++ b/testfiles-examples/pgfmanual-en-library-spy.tlg
@@ -1823,8 +1823,10 @@ TEST 1: pgfmanual-en-library-spy-1
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1885,6 +1887,7 @@ TEST 1: pgfmanual-en-library-spy-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -3672,6 +3675,7 @@ TEST 1: pgfmanual-en-library-spy-1
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3704,8 +3708,10 @@ TEST 1: pgfmanual-en-library-spy-1
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3757,8 +3763,10 @@ TEST 1: pgfmanual-en-library-spy-1
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3819,6 +3827,7 @@ TEST 1: pgfmanual-en-library-spy-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -5606,6 +5615,7 @@ TEST 1: pgfmanual-en-library-spy-1
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5638,8 +5648,10 @@ TEST 1: pgfmanual-en-library-spy-1
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6511,10 +6523,12 @@ TEST 2: pgfmanual-en-library-spy-2
 ..........\pdfliteral origin{0 1 0 RG }
 ..........\pdfliteral origin{0 1 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6579,6 +6593,7 @@ TEST 2: pgfmanual-en-library-spy-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfliteral origin{/pgf@ca1 gs }
 .............\pdfliteral origin{/pgf@CA1 gs }
 .............\pdfcolorstack 0 push {0 g 0 G}
@@ -7381,6 +7396,7 @@ TEST 2: pgfmanual-en-library-spy-2
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7405,10 +7421,12 @@ TEST 2: pgfmanual-en-library-spy-2
 ..........\pdfliteral origin{0 1 0 RG }
 ..........\pdfliteral origin{0 1 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7455,10 +7473,12 @@ TEST 2: pgfmanual-en-library-spy-2
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7523,6 +7543,7 @@ TEST 2: pgfmanual-en-library-spy-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfliteral origin{/pgf@ca1 gs }
 .............\pdfliteral origin{/pgf@CA1 gs }
 .............\pdfcolorstack 0 push {0 g 0 G}
@@ -8325,6 +8346,7 @@ TEST 2: pgfmanual-en-library-spy-2
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8349,10 +8371,12 @@ TEST 2: pgfmanual-en-library-spy-2
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8399,10 +8423,12 @@ TEST 2: pgfmanual-en-library-spy-2
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8467,6 +8493,7 @@ TEST 2: pgfmanual-en-library-spy-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfliteral origin{/pgf@ca1 gs }
 .............\pdfliteral origin{/pgf@CA1 gs }
 .............\pdfcolorstack 0 push {0 g 0 G}
@@ -9269,6 +9296,7 @@ TEST 2: pgfmanual-en-library-spy-2
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9293,10 +9321,12 @@ TEST 2: pgfmanual-en-library-spy-2
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9776,8 +9806,10 @@ TEST 3: pgfmanual-en-library-spy-3
 ...........\pdfliteral origin{0 0 1 RG }
 ...........\pdfliteral origin{0 0 1 rg }
 ...........\hbox(0.0+0.0)x0.0, direction TLT
+............\begindir TLT
 ............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ............\pdfcolorstack 0 pop
+............\enddir TLT
 ...........\glue(\spaceskip) 0.0
 .........\pdfliteral origin{Q }
 .........\glue(\spaceskip) 0.0
@@ -9838,6 +9870,7 @@ TEST 3: pgfmanual-en-library-spy-3
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(0.0+0.0)x0.0, direction TLT
+..............\begindir TLT
 ..............\pdfcolorstack 0 push {0 g 0 G}
 ..............\hbox(0.0+0.0)x0.0, direction TLT
 ...............\glue 0.0
@@ -10247,6 +10280,7 @@ TEST 3: pgfmanual-en-library-spy-3
 ................\pdfliteral origin{Q }
 ................\glue 0.0 plus 1.0fil minus 1.0fil
 ..............\pdfcolorstack 0 pop
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0
@@ -10279,8 +10313,10 @@ TEST 3: pgfmanual-en-library-spy-3
 ...........\pdfliteral origin{0 0 1 RG }
 ...........\pdfliteral origin{0 0 1 rg }
 ...........\hbox(0.0+0.0)x0.0, direction TLT
+............\begindir TLT
 ............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ............\pdfcolorstack 0 pop
+............\enddir TLT
 ...........\glue(\spaceskip) 0.0
 .........\pdfliteral origin{Q }
 .........\glue(\spaceskip) 0.0
@@ -10342,8 +10378,10 @@ TEST 3: pgfmanual-en-library-spy-3
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10407,6 +10445,7 @@ TEST 3: pgfmanual-en-library-spy-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -10854,8 +10893,10 @@ TEST 3: pgfmanual-en-library-spy-3
 .......................\pdfliteral origin{0 0 1 RG }
 .......................\pdfliteral origin{0 0 1 rg }
 .......................\hbox(0.0+0.0)x0.0, direction TLT
+........................\begindir TLT
 ........................\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ........................\pdfcolorstack 0 pop
+........................\enddir TLT
 .......................\glue(\spaceskip) 0.0
 .....................\pdfliteral origin{Q }
 .....................\glue(\spaceskip) 0.0
@@ -10916,6 +10957,7 @@ TEST 3: pgfmanual-en-library-spy-3
 .........................\pdfliteral origin{0 G }
 .........................\pdfliteral origin{0 g }
 .........................\hbox(0.0+0.0)x0.0, direction TLT
+..........................\begindir TLT
 ..........................\pdfcolorstack 0 push {0 g 0 G}
 ..........................\hbox(0.0+0.0)x0.0, direction TLT
 ...........................\glue 0.0
@@ -11325,6 +11367,7 @@ TEST 3: pgfmanual-en-library-spy-3
 ............................\pdfliteral origin{Q }
 ............................\glue 0.0 plus 1.0fil minus 1.0fil
 ..........................\pdfcolorstack 0 pop
+..........................\enddir TLT
 .........................\glue(\spaceskip) 0.0
 .......................\pdfliteral origin{Q }
 .......................\glue(\spaceskip) 0.0
@@ -11357,8 +11400,10 @@ TEST 3: pgfmanual-en-library-spy-3
 .......................\pdfliteral origin{0 0 1 RG }
 .......................\pdfliteral origin{0 0 1 rg }
 .......................\hbox(0.0+0.0)x0.0, direction TLT
+........................\begindir TLT
 ........................\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ........................\pdfcolorstack 0 pop
+........................\enddir TLT
 .......................\glue(\spaceskip) 0.0
 .....................\pdfliteral origin{Q }
 .....................\glue(\spaceskip) 0.0
@@ -11389,6 +11434,7 @@ TEST 3: pgfmanual-en-library-spy-3
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11415,8 +11461,10 @@ TEST 3: pgfmanual-en-library-spy-3
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11862,8 +11910,10 @@ TEST 4: pgfmanual-en-library-spy-4
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11924,6 +11974,7 @@ TEST 4: pgfmanual-en-library-spy-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -12297,6 +12348,7 @@ TEST 4: pgfmanual-en-library-spy-4
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12329,8 +12381,10 @@ TEST 4: pgfmanual-en-library-spy-4
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12374,8 +12428,10 @@ TEST 4: pgfmanual-en-library-spy-4
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12436,6 +12492,7 @@ TEST 4: pgfmanual-en-library-spy-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -12809,6 +12866,7 @@ TEST 4: pgfmanual-en-library-spy-4
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12841,8 +12899,10 @@ TEST 4: pgfmanual-en-library-spy-4
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13277,8 +13337,10 @@ TEST 5: pgfmanual-en-library-spy-5
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13339,6 +13401,7 @@ TEST 5: pgfmanual-en-library-spy-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -13712,6 +13775,7 @@ TEST 5: pgfmanual-en-library-spy-5
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13744,8 +13808,10 @@ TEST 5: pgfmanual-en-library-spy-5
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13797,8 +13863,10 @@ TEST 5: pgfmanual-en-library-spy-5
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13859,6 +13927,7 @@ TEST 5: pgfmanual-en-library-spy-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -14232,6 +14301,7 @@ TEST 5: pgfmanual-en-library-spy-5
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14264,8 +14334,10 @@ TEST 5: pgfmanual-en-library-spy-5
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14722,8 +14794,10 @@ TEST 6: pgfmanual-en-library-spy-7
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14786,6 +14860,7 @@ TEST 6: pgfmanual-en-library-spy-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -15157,6 +15232,7 @@ TEST 6: pgfmanual-en-library-spy-7
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15183,8 +15259,10 @@ TEST 6: pgfmanual-en-library-spy-7
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15628,8 +15706,10 @@ TEST 7: pgfmanual-en-library-spy-8
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15690,6 +15770,7 @@ TEST 7: pgfmanual-en-library-spy-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -16061,6 +16142,7 @@ TEST 7: pgfmanual-en-library-spy-8
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16093,8 +16175,10 @@ TEST 7: pgfmanual-en-library-spy-8
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16534,10 +16618,12 @@ TEST 8: pgfmanual-en-library-spy-9
 ..........\pdfliteral origin{0 1 0 RG }
 ..........\pdfliteral origin{0 1 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16606,6 +16692,7 @@ TEST 8: pgfmanual-en-library-spy-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfliteral origin{/pgf@ca1 gs }
 .............\pdfliteral origin{/pgf@CA1 gs }
 .............\pdfcolorstack 0 push {0 g 0 G}
@@ -16979,6 +17066,7 @@ TEST 8: pgfmanual-en-library-spy-9
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17003,10 +17091,12 @@ TEST 8: pgfmanual-en-library-spy-9
 ..........\pdfliteral origin{0 1 0 RG }
 ..........\pdfliteral origin{0 1 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18348,10 +18438,12 @@ TEST 9: pgfmanual-en-library-spy-10
 ..........\pdfliteral origin{0 1 0 RG }
 ..........\pdfliteral origin{0 1 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18420,6 +18512,7 @@ TEST 9: pgfmanual-en-library-spy-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfliteral origin{/pgf@ca1 gs }
 .............\pdfliteral origin{/pgf@CA1 gs }
 .............\pdfcolorstack 0 push {0 g 0 G}
@@ -19695,6 +19788,7 @@ TEST 9: pgfmanual-en-library-spy-10
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19719,10 +19813,12 @@ TEST 9: pgfmanual-en-library-spy-10
 ..........\pdfliteral origin{0 1 0 RG }
 ..........\pdfliteral origin{0 1 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19766,10 +19862,12 @@ TEST 9: pgfmanual-en-library-spy-10
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19838,6 +19936,7 @@ TEST 9: pgfmanual-en-library-spy-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfliteral origin{/pgf@ca1 gs }
 .............\pdfliteral origin{/pgf@CA1 gs }
 .............\pdfcolorstack 0 push {0 g 0 G}
@@ -21113,6 +21212,7 @@ TEST 9: pgfmanual-en-library-spy-10
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21137,10 +21237,12 @@ TEST 9: pgfmanual-en-library-spy-10
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22481,10 +22583,12 @@ TEST 10: pgfmanual-en-library-spy-11
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22578,6 +22682,7 @@ TEST 10: pgfmanual-en-library-spy-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -23849,6 +23954,7 @@ TEST 10: pgfmanual-en-library-spy-11
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23897,8 +24003,10 @@ TEST 10: pgfmanual-en-library-spy-11
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23971,6 +24079,7 @@ TEST 10: pgfmanual-en-library-spy-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -25242,6 +25351,7 @@ TEST 10: pgfmanual-en-library-spy-11
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26591,8 +26701,10 @@ TEST 11: pgfmanual-en-library-spy-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -26684,6 +26796,7 @@ TEST 11: pgfmanual-en-library-spy-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -27955,6 +28068,7 @@ TEST 11: pgfmanual-en-library-spy-12
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28003,8 +28117,10 @@ TEST 11: pgfmanual-en-library-spy-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28077,6 +28193,7 @@ TEST 11: pgfmanual-en-library-spy-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\hbox(0.0+0.0)x0.0, direction TLT
 ..............\glue 0.0
@@ -29348,6 +29465,7 @@ TEST 11: pgfmanual-en-library-spy-12
 ...............\pdfliteral origin{Q }
 ...............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-through.tlg
+++ b/testfiles-examples/pgfmanual-en-library-through.tlg
@@ -74,9 +74,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.28589, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 a
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -111,9 +113,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.32756, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-trees.tlg
+++ b/testfiles-examples/pgfmanual-en-library-trees.tlg
@@ -39,9 +39,11 @@ TEST 1: pgfmanual-en-library-trees-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -88,11 +90,13 @@ TEST 1: pgfmanual-en-library-trees-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x15.55, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 w
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -157,11 +161,13 @@ TEST 1: pgfmanual-en-library-trees-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -244,10 +250,12 @@ TEST 1: pgfmanual-en-library-trees-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x17.54, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -379,9 +387,11 @@ TEST 2: pgfmanual-en-library-trees-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -428,11 +438,13 @@ TEST 2: pgfmanual-en-library-trees-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x15.55, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 w
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -497,11 +509,13 @@ TEST 2: pgfmanual-en-library-trees-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -584,10 +598,12 @@ TEST 2: pgfmanual-en-library-trees-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x17.54, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -719,9 +735,11 @@ TEST 3: pgfmanual-en-library-trees-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -768,11 +786,13 @@ TEST 3: pgfmanual-en-library-trees-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x15.55, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 w
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -837,11 +857,13 @@ TEST 3: pgfmanual-en-library-trees-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -924,10 +946,12 @@ TEST 3: pgfmanual-en-library-trees-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x17.54, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1727,11 +1751,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1762,10 +1788,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.0)x10.00003, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OT1/cmr/m/n/10 3
 .............\OT1/cmr/m/n/10 0
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1808,9 +1836,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.0)x5.00002, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OT1/cmr/m/n/10 0
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1853,11 +1883,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.83333)x17.77783, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OMS/cmsy/m/n/10 ^^@
 .............\OT1/cmr/m/n/10 3
 .............\OT1/cmr/m/n/10 0
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1900,11 +1932,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.83333)x17.77783, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OMS/cmsy/m/n/10 ^^@
 .............\OT1/cmr/m/n/10 6
 .............\OT1/cmr/m/n/10 0
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1972,11 +2006,13 @@ TEST 6: pgfmanual-en-library-trees-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2007,10 +2043,12 @@ TEST 6: pgfmanual-en-library-trees-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2055,12 +2093,14 @@ TEST 6: pgfmanual-en-library-trees-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2105,12 +2145,14 @@ TEST 6: pgfmanual-en-library-trees-6
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2153,12 +2195,14 @@ TEST 6: pgfmanual-en-library-trees-6
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2230,11 +2274,13 @@ TEST 7: pgfmanual-en-library-trees-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2265,10 +2311,12 @@ TEST 7: pgfmanual-en-library-trees-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2313,12 +2361,14 @@ TEST 7: pgfmanual-en-library-trees-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2363,12 +2413,14 @@ TEST 7: pgfmanual-en-library-trees-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2413,12 +2465,14 @@ TEST 7: pgfmanual-en-library-trees-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-library-views.tlg
+++ b/testfiles-examples/pgfmanual-en-library-views.tlg
@@ -83,8 +83,10 @@ TEST 1: pgfmanual-en-library-views-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -193,8 +195,10 @@ TEST 2: pgfmanual-en-library-views-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -317,8 +321,10 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -441,8 +447,10 @@ TEST 4: pgfmanual-en-library-views-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-main-body.tlg
+++ b/testfiles-examples/pgfmanual-en-main-body.tlg
@@ -128,6 +128,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x9.30177, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -135,6 +136,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OML/cmm/m/it/7 a
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -184,11 +186,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -245,6 +249,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x8.48079, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -252,6 +257,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OML/cmm/m/it/7 b
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -306,6 +312,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x9.127, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -313,6 +320,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OML/cmm/m/it/7 d
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -367,6 +375,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x8.53787, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -374,6 +383,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OML/cmm/m/it/7 c
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -428,6 +438,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.30554+1.94444)x8.75824, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
@@ -435,6 +446,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OML/cmm/m/it/7 e
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -473,11 +485,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x21.81, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 L
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -516,11 +530,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x22.92, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -561,11 +577,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x21.81, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 L
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -602,11 +620,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x21.81, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 L
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -645,11 +665,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x21.81, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 L
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -691,11 +713,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x22.92, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 0
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -736,11 +760,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x22.92, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -777,11 +803,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x22.92, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -821,11 +849,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+1.93)x22.92, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 0
 .............\TU/lmr/m/n/10 ,
 .............\TU/lmr/m/n/10 R
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -855,6 +885,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+61.94)x227.62204, direction TLT
+...........\begindir TLT
 ...........\vbox(7.05+61.94)x227.62204, direction TLT
 ............\hbox(7.05+2.05)x227.62204, glue set 0.42542, direction TLT
 .............\localpar
@@ -1211,6 +1242,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1271,11 +1303,13 @@ TEST 3: pgfmanual-en-main-body-3
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1309,12 +1343,14 @@ TEST 3: pgfmanual-en-main-body-3
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1346,12 +1382,14 @@ TEST 3: pgfmanual-en-main-body-3
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1385,12 +1423,14 @@ TEST 3: pgfmanual-en-main-body-3
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1419,10 +1459,12 @@ TEST 3: pgfmanual-en-main-body-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.95831, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 E
 ...........\kern0.57637 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1450,10 +1492,12 @@ TEST 3: pgfmanual-en-main-body-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.81946, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 F
 ...........\kern1.3889 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1686,10 +1730,12 @@ TEST 3: pgfmanual-en-main-body-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x6.43404, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^K
 .............\kern0.03702 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1733,10 +1779,12 @@ TEST 3: pgfmanual-en-main-body-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94444+1.94444)x6.18402, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^L
 .............\kern0.52777 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1782,10 +1830,12 @@ TEST 3: pgfmanual-en-main-body-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x5.73285, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 
 .............\kern0.55554 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1829,10 +1879,12 @@ TEST 3: pgfmanual-en-main-body-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94444+0.0)x4.8229, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^N
 .............\kern0.37846 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1882,6 +1934,7 @@ TEST 3: pgfmanual-en-main-body-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+25.94444)x170.71652, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+25.94444)x170.71652, direction TLT
 ............\hbox(6.94+0.22)x170.71652, glue set 0.79112, direction TLT
 .............\localpar
@@ -2020,6 +2073,7 @@ TEST 3: pgfmanual-en-main-body-3
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5402,6 +5456,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x42.6, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 5
 .................\TU/lmr/m/n/8 t
 .................\TU/lmr/m/n/8 h
@@ -5415,6 +5470,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 i
 .................\TU/lmr/m/n/8 o
 .................\TU/lmr/m/n/8 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5477,6 +5533,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x42.6, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 6
 .................\TU/lmr/m/n/8 t
 .................\TU/lmr/m/n/8 h
@@ -5490,6 +5547,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 i
 .................\TU/lmr/m/n/8 o
 .................\TU/lmr/m/n/8 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5552,6 +5610,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x34.216, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 P
 .................\TU/lmr/m/n/8 W
 .................\TU/lmr/m/n/8 B
@@ -5559,6 +5618,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 1
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5621,9 +5681,11 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x16.4, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 L
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 X
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5686,11 +5748,13 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x24.30402, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 1
 .................\glue(\spaceskip) 2.832 plus 1.416 minus 0.944
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5753,6 +5817,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x37.992, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 M
 .................\TU/lmr/m/n/8 i
 .................\TU/lmr/m/n/8 n
@@ -5762,6 +5827,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 n
 .................\TU/lmr/m/n/8 i
 .................\TU/lmr/m/n/8 x
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5824,6 +5890,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x43.416, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 W
 .................\kern-0.712 (font)
 .................\TU/lmr/m/n/8 o
@@ -5839,6 +5906,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 o
 .................\TU/lmr/m/n/8 n
 .................\TU/lmr/m/n/8 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5901,6 +5969,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x34.456, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 I
 .................\TU/lmr/m/n/8 n
 .................\discretionary (penalty 50)
@@ -5915,6 +5984,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 a
 .................\TU/lmr/m/n/8 t
 .................\TU/lmr/m/n/8 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5977,6 +6047,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x46.72801, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 n
 .................\TU/lmr/m/n/8 i
@@ -5988,6 +6059,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 3
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6050,6 +6122,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x34.216, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 P
 .................\TU/lmr/m/n/8 W
 .................\TU/lmr/m/n/8 B
@@ -6057,6 +6130,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 2
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6119,6 +6193,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x42.6, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 7
 .................\TU/lmr/m/n/8 t
 .................\TU/lmr/m/n/8 h
@@ -6132,6 +6207,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 i
 .................\TU/lmr/m/n/8 o
 .................\TU/lmr/m/n/8 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6194,6 +6270,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x42.6, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 8
 .................\TU/lmr/m/n/8 t
 .................\TU/lmr/m/n/8 h
@@ -6207,6 +6284,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 i
 .................\TU/lmr/m/n/8 o
 .................\TU/lmr/m/n/8 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6269,9 +6347,11 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x14.864, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 3
 .................\TU/lmr/m/n/8 2
 .................\TU/lmr/m/n/8 V
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6334,9 +6414,11 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x18.4, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 V
 .................\TU/lmr/m/n/8 7
 .................\TU/lmr/m/n/8 M
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6399,6 +6481,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x33.52, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 l
 .................\TU/lmr/m/n/8 t
@@ -6410,6 +6493,7 @@ TEST 4: pgfmanual-en-main-body-4
 ..................= \TU/lmr/m/n/8 -
 .................\TU/lmr/m/n/8 1
 .................\TU/lmr/m/n/8 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6472,11 +6556,13 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x21.712, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 X
 .................\TU/lmr/m/n/8 e
 .................\TU/lmr/m/n/8 n
 .................\TU/lmr/m/n/8 i
 .................\TU/lmr/m/n/8 x
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6539,6 +6625,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x36.272, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 n
 .................\TU/lmr/m/n/8 i
@@ -6549,6 +6636,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 u
 .................\TU/lmr/m/n/8 s
 .................\TU/lmr/m/n/8 +
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6611,6 +6699,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x42.6, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 9
 .................\TU/lmr/m/n/8 t
 .................\TU/lmr/m/n/8 h
@@ -6624,6 +6713,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 i
 .................\TU/lmr/m/n/8 o
 .................\TU/lmr/m/n/8 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6686,11 +6776,13 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x24.30402, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 2
 .................\glue(\spaceskip) 2.832 plus 1.416 minus 0.944
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6753,6 +6845,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x30.91202, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 2
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 8
@@ -6760,6 +6853,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6822,6 +6916,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x30.91202, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 2
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 9
@@ -6829,6 +6924,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6891,11 +6987,13 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x24.30402, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 3
 .................\glue(\spaceskip) 2.832 plus 1.416 minus 0.944
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6958,11 +7056,13 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x24.30402, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 4
 .................\glue(\spaceskip) 2.832 plus 1.416 minus 0.944
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7025,6 +7125,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x30.91202, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 4
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 1
@@ -7032,6 +7133,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7094,6 +7196,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x30.91202, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 4
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 2
@@ -7101,6 +7204,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7163,6 +7267,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x30.91202, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 4
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 3
@@ -7170,6 +7275,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 B
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 D
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7232,6 +7338,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x33.52, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 l
 .................\TU/lmr/m/n/8 t
@@ -7243,6 +7350,7 @@ TEST 4: pgfmanual-en-main-body-4
 ..................= \TU/lmr/m/n/8 -
 .................\TU/lmr/m/n/8 3
 .................\TU/lmr/m/n/8 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7305,6 +7413,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x34.216, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 P
 .................\TU/lmr/m/n/8 W
 .................\TU/lmr/m/n/8 B
@@ -7312,6 +7421,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 1
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7374,6 +7484,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x31.448, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 G
@@ -7381,6 +7492,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 1
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7443,6 +7555,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x40.00002, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 C
 .................\TU/lmr/m/n/8 B
 .................\glue(\spaceskip) 2.832 plus 1.41458 minus 0.94493
@@ -7452,6 +7565,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 x
 .................\glue(\spaceskip) 2.832 plus 1.416 minus 0.944
 .................\TU/lmr/m/n/8 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7514,6 +7628,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x31.448, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 G
@@ -7521,6 +7636,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 2
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7583,6 +7699,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x40.00002, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 C
 .................\TU/lmr/m/n/8 B
 .................\glue(\spaceskip) 2.832 plus 1.41458 minus 0.94493
@@ -7592,6 +7709,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 x
 .................\glue(\spaceskip) 2.832 plus 1.416 minus 0.944
 .................\TU/lmr/m/n/8 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7654,6 +7772,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x40.00002, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 C
 .................\TU/lmr/m/n/8 B
 .................\glue(\spaceskip) 2.832 plus 1.41458 minus 0.94493
@@ -7663,6 +7782,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 x
 .................\glue(\spaceskip) 2.832 plus 1.416 minus 0.944
 .................\TU/lmr/m/n/8 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7725,6 +7845,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x46.25601, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 n
 .................\TU/lmr/m/n/8 i
@@ -7734,6 +7855,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 +
 .................\TU/lmr/m/n/8 +
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7796,6 +7918,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x53.97601, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 P
 .................\TU/lmr/m/n/8 D
 .................\TU/lmr/m/n/8 P
@@ -7810,6 +7933,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 s
 .................\glue(\spaceskip) 2.832 plus 1.416 minus 0.944
 .................\TU/lmr/m/n/8 V
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7872,6 +7996,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x31.448, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 G
@@ -7879,6 +8004,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 3
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7941,6 +8067,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x46.72801, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 U
 .................\TU/lmr/m/n/8 n
 .................\TU/lmr/m/n/8 i
@@ -7952,6 +8079,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 1
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8014,12 +8142,14 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x24.544, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 T
 .................\TU/lmr/m/n/8 S
 .................\glue(\spaceskip) 2.832 plus 1.41458 minus 0.94493
 .................\TU/lmr/m/n/8 4
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8082,6 +8212,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x42.52802, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 y
 .................\TU/lmr/m/n/8 s
@@ -8094,6 +8225,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 V
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8156,6 +8288,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x42.52802, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 y
 .................\TU/lmr/m/n/8 s
@@ -8168,6 +8301,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 V
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8230,6 +8364,7 @@ TEST 4: pgfmanual-en-main-body-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.99997+1.99997)x42.52802, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/8 S
 .................\TU/lmr/m/n/8 y
 .................\TU/lmr/m/n/8 s
@@ -8242,6 +8377,7 @@ TEST 4: pgfmanual-en-main-body-4
 .................\TU/lmr/m/n/8 V
 .................\TU/lmr/m/n/8 .
 .................\TU/lmr/m/n/8 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9857,6 +9993,7 @@ TEST 5: pgfmanual-en-main-body-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.739+0.154)x44.541, direction TLT
+.............\begindir TLT
 .............\vbox(20.739+0.154)x44.541, direction TLT
 ..............\hbox(12.739+0.154)x44.541, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -9928,6 +10065,7 @@ TEST 5: pgfmanual-en-main-body-5
 ................\TU/lmr/m/sc/7 e
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11504,6 +11642,7 @@ TEST 5: pgfmanual-en-main-body-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.739+0.154)x44.541, direction TLT
+.............\begindir TLT
 .............\vbox(20.739+0.154)x44.541, direction TLT
 ..............\hbox(12.739+0.154)x44.541, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -11575,6 +11714,7 @@ TEST 5: pgfmanual-en-main-body-5
 ................\TU/lmr/m/sc/7 e
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13150,6 +13290,7 @@ TEST 5: pgfmanual-en-main-body-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.739+0.154)x44.541, direction TLT
+.............\begindir TLT
 .............\vbox(20.739+0.154)x44.541, direction TLT
 ..............\hbox(12.739+0.154)x44.541, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -13221,6 +13362,7 @@ TEST 5: pgfmanual-en-main-body-5
 ................\TU/lmr/m/sc/7 e
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14669,6 +14811,7 @@ TEST 5: pgfmanual-en-main-body-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.739+0.154)x44.541, direction TLT
+.............\begindir TLT
 .............\vbox(20.739+0.154)x44.541, direction TLT
 ..............\hbox(12.739+0.154)x44.541, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -14740,6 +14883,7 @@ TEST 5: pgfmanual-en-main-body-5
 ................\TU/lmr/m/sc/7 e
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19207,6 +19351,7 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(9.56331+0.0)x18.66837, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/9 e
 ...........\hbox(5.74002+0.83331)x14.36804, shifted -3.82329, direction TLT
@@ -19215,6 +19360,7 @@ TEST 6: pgfmanual-en-main-body-6
 ............\hbox(3.22221+0.0)x3.90283, shifted -2.5178, direction TLT
 .............\OT1/cmr/m/n/5 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19470,10 +19616,12 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19593,12 +19741,14 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.83337)x17.47247, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/8 ^^@
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19718,9 +19868,11 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19840,11 +19992,13 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 2
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19964,9 +20118,11 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20099,9 +20255,11 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20219,11 +20377,13 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20341,11 +20501,13 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20463,11 +20625,13 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20585,11 +20749,13 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x10.86127, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 0
 ...........\OML/cmm/m/it/8 :
 ...........\OT1/cmr/m/n/8 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20707,9 +20873,11 @@ TEST 6: pgfmanual-en-main-body-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.15556+0.0)x4.25006, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/8 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20843,6 +21011,7 @@ TEST 6: pgfmanual-en-main-body-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(8.1445+2.75005)x120.34589, direction TLT
+.....................\begindir TLT
 .....................\hbox(6.75+0.0)x0.0, direction TLT
 ......................\rule(6.75+*)x0.0
 .....................\mathon
@@ -20889,6 +21058,7 @@ TEST 6: pgfmanual-en-main-body-6
 .....................\mathoff
 .....................\hbox(0.0+2.25)x0.0, direction TLT
 ......................\rule(*+2.25)x0.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -21008,8 +21178,10 @@ TEST 7: pgfmanual-en-main-body-7
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -21035,6 +21207,7 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(16.38902+9.11122)x42.37512, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(0.0+22.22246)x5.55557, shifted -13.61122, direction TLT
 ............\OMX/cmex/m/n/10 Z
@@ -21055,6 +21228,7 @@ TEST 7: pgfmanual-en-main-body-7
 ...........\OT1/cmr/m/n/10 d
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21174,9 +21348,11 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21212,6 +21388,7 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x19.46533, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
 ...........\kern1.0764 (italic)
@@ -21219,6 +21396,7 @@ TEST 7: pgfmanual-en-main-body-7
 ...........\OML/cmm/m/it/10 x
 ...........\OT1/cmr/m/n/10 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21250,9 +21428,11 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21284,6 +21464,7 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.44843+3.44841)x11.38614, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\hbox(8.44843+3.44841)x6.38612, direction TLT
@@ -21299,6 +21480,7 @@ TEST 7: pgfmanual-en-main-body-7
 ...............\OT1/cmr/m/n/7 2
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21330,9 +21512,11 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21364,9 +21548,11 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21397,9 +21583,11 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21429,9 +21617,11 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21461,6 +21651,7 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.44843+3.44841)x11.38614, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\hbox(8.44843+3.44841)x6.38612, direction TLT
@@ -21476,6 +21667,7 @@ TEST 7: pgfmanual-en-main-body-7
 ...............\OT1/cmr/m/n/7 4
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21505,9 +21697,11 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21540,11 +21734,13 @@ TEST 7: pgfmanual-en-main-body-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.14003+0.0)x10.2014, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\hbox(4.51111+0.0)x4.48613, shifted -3.62892, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32421,12 +32617,14 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x17.10419, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\OT1/cmr/m/n/10 (
 ...........\OML/cmm/m/it/10 t
 ...........\OT1/cmr/m/n/10 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32462,6 +32660,7 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x16.65051, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 y
 ...........\kern0.35878 (italic)
@@ -32469,6 +32668,7 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ...........\OML/cmm/m/it/10 t
 ...........\OT1/cmr/m/n/10 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32500,10 +32700,12 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32535,9 +32737,11 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32568,10 +32772,12 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32601,9 +32807,11 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32633,9 +32841,11 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32665,9 +32875,11 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -32909,6 +33121,7 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.50005+3.50006)x125.24895, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(8.50005+3.50006)x4.58336, direction TLT
 ............\mathon
@@ -32989,6 +33202,7 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\OT1/cmr/m/n/10 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33034,6 +33248,7 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(8.44843+3.44841)x24.5497, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 (
@@ -33057,6 +33272,7 @@ runsystem(gnuplot pgfmanual-en-main-body.asymptotic-example.gnuplot)...executed.
 ...........\OT1/cmr/m/n/10 )
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33124,9 +33340,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.6875, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33162,9 +33380,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33200,9 +33420,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33238,9 +33460,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33276,10 +33500,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33315,10 +33541,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33354,10 +33582,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 7
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33393,10 +33623,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33432,10 +33664,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 9
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33471,9 +33705,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15079+0.0)x3.61111, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 t
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33508,9 +33744,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33545,9 +33783,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 6
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33582,9 +33822,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 7
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33619,9 +33861,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 8
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33656,9 +33900,11 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 9
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33693,10 +33939,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33731,10 +33979,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33769,10 +34019,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33807,10 +34059,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -33845,10 +34099,12 @@ TEST 10: pgfmanual-en-main-body-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x10.00003, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 4
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34346,9 +34602,11 @@ TEST 11: pgfmanual-en-main-body-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.6875, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -34376,9 +34634,11 @@ TEST 11: pgfmanual-en-main-body-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15079+0.0)x3.61111, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 t
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-math-parsing.tlg
+++ b/testfiles-examples/pgfmanual-en-math-parsing.tlg
@@ -205,9 +205,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -240,10 +242,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -276,10 +280,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -323,10 +329,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -457,7 +465,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -485,7 +495,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -513,7 +525,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -541,7 +555,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -569,7 +585,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -597,7 +615,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -625,7 +645,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -653,7 +675,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -681,7 +705,9 @@ TEST 11: pgfmanual-en-math-parsing-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-pgfcalendar.tlg
+++ b/testfiles-examples/pgfmanual-en-pgfcalendar.tlg
@@ -930,8 +930,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -968,8 +970,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1005,8 +1009,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1043,8 +1049,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1081,8 +1089,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1119,8 +1129,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1157,8 +1169,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1195,8 +1209,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1233,8 +1249,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1270,8 +1288,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1308,8 +1328,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1346,8 +1368,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1384,8 +1408,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1422,8 +1448,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1460,8 +1488,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1498,8 +1528,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1535,8 +1567,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1573,8 +1607,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1611,8 +1647,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1649,8 +1687,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1687,8 +1727,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1725,8 +1767,10 @@ TEST 5: pgfmanual-en-pgfcalendar-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-pgffor.tlg
+++ b/testfiles-examples/pgfmanual-en-pgffor.tlg
@@ -674,9 +674,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -706,9 +708,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -738,9 +742,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -770,9 +776,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -802,9 +810,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.65627, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 e
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -868,7 +878,9 @@ TEST 9: pgfmanual-en-pgffor-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -902,7 +914,9 @@ TEST 9: pgfmanual-en-pgffor-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -936,7 +950,9 @@ TEST 9: pgfmanual-en-pgffor-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -970,7 +986,9 @@ TEST 9: pgfmanual-en-pgffor-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1155,8 +1173,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 3
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1195,8 +1215,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 2
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1235,8 +1257,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 1
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1275,9 +1299,11 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 1
 ...........\TU/lmss/m/n/10 2
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1316,9 +1342,11 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.0)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 1
 ...........\TU/lmss/m/n/10 1
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1357,9 +1385,11 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 1
 ...........\TU/lmss/m/n/10 0
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1398,8 +1428,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 9
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1438,8 +1470,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 8
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1478,8 +1512,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.56+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 7
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1518,8 +1554,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.78+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 6
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1558,8 +1596,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.56+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 5
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1598,8 +1638,10 @@ TEST 11: pgfmanual-en-pgffor-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.56+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmss/m/n/10 4
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1698,8 +1740,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1724,8 +1768,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1750,8 +1796,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1776,8 +1824,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1802,8 +1852,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1828,8 +1880,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1854,8 +1908,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1880,8 +1936,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1906,8 +1964,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1932,8 +1992,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1958,8 +2020,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1984,8 +2048,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2010,8 +2076,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2036,8 +2104,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2062,8 +2132,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2088,8 +2160,10 @@ TEST 12: pgfmanual-en-pgffor-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2364,7 +2438,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2398,7 +2474,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2432,7 +2510,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2466,7 +2546,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2500,7 +2582,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2534,7 +2618,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2568,7 +2654,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2602,7 +2690,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2636,7 +2726,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2670,7 +2762,9 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2704,8 +2798,10 @@ TEST 15: pgfmanual-en-pgffor-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3092,8 +3188,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3111,11 +3209,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x10.57178, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 a
 ...........\OML/cmm/m/it/10 a
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3144,8 +3244,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3163,11 +3265,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x9.57755, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 a
 ...........\OML/cmm/m/it/10 b
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3196,8 +3300,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3215,11 +3321,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x9.61345, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 a
 ...........\OML/cmm/m/it/10 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3248,8 +3356,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3267,11 +3377,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x10.49075, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 a
 ...........\OML/cmm/m/it/10 d
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3300,8 +3412,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3319,11 +3433,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x9.94215, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 a
 ...........\OML/cmm/m/it/10 e
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3352,8 +3468,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3371,11 +3489,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x8.58331, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 b
 ...........\OML/cmm/m/it/10 b
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3404,8 +3524,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3423,11 +3545,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x8.61922, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 b
 ...........\OML/cmm/m/it/10 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3456,8 +3580,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3475,11 +3601,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x9.49652, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 b
 ...........\OML/cmm/m/it/10 d
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3508,8 +3636,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3527,11 +3657,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x8.94792, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 b
 ...........\OML/cmm/m/it/10 e
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3560,8 +3692,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3579,11 +3713,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x8.65512, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 c
 ...........\OML/cmm/m/it/10 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3612,8 +3748,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3631,11 +3769,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x9.53242, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 c
 ...........\OML/cmm/m/it/10 d
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3664,8 +3804,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3683,11 +3825,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x8.98383, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 c
 ...........\OML/cmm/m/it/10 e
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3716,8 +3860,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3735,11 +3881,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x10.40973, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 d
 ...........\OML/cmm/m/it/10 d
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3768,8 +3916,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3787,11 +3937,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x9.86113, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 d
 ...........\OML/cmm/m/it/10 e
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3820,8 +3972,10 @@ TEST 17: pgfmanual-en-pgffor-17
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3839,11 +3993,13 @@ TEST 17: pgfmanual-en-pgffor-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x9.31253, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(7.5+2.5)x0.0, direction TLT
 ...........\OML/cmm/m/it/10 e
 ...........\OML/cmm/m/it/10 e
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-pgfkeys.tlg
+++ b/testfiles-examples/pgfmanual-en-pgfkeys.tlg
@@ -341,7 +341,9 @@ TEST 11: pgfmanual-en-pgfkeys-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -383,7 +385,9 @@ TEST 11: pgfmanual-en-pgfkeys-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -452,9 +456,11 @@ TEST 11: pgfmanual-en-pgfkeys-17
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 1
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -495,7 +501,9 @@ TEST 11: pgfmanual-en-pgfkeys-17
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -561,7 +569,9 @@ TEST 11: pgfmanual-en-pgfkeys-17
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -637,7 +647,9 @@ TEST 12: pgfmanual-en-pgfkeys-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -679,7 +691,9 @@ TEST 12: pgfmanual-en-pgfkeys-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -746,9 +760,11 @@ TEST 12: pgfmanual-en-pgfkeys-18
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 1
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -789,7 +805,9 @@ TEST 12: pgfmanual-en-pgfkeys-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -855,7 +873,9 @@ TEST 12: pgfmanual-en-pgfkeys-18
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1006,9 +1026,11 @@ TEST 15: pgfmanual-en-pgfkeys-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x14.48, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1034,12 +1056,14 @@ TEST 15: pgfmanual-en-pgfkeys-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x18.9, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ’
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 ’
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1112,7 +1136,9 @@ TEST 16: pgfmanual-en-pgfkeys-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1166,7 +1192,9 @@ TEST 16: pgfmanual-en-pgfkeys-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1220,7 +1248,9 @@ TEST 16: pgfmanual-en-pgfkeys-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1271,7 +1301,9 @@ TEST 16: pgfmanual-en-pgfkeys-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1739,6 +1771,7 @@ TEST 25: pgfmanual-en-pgfkeys-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x33.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
@@ -1748,6 +1781,7 @@ TEST 25: pgfmanual-en-pgfkeys-41
 ...........\TU/lmr/m/n/10 o
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1783,6 +1817,7 @@ TEST 25: pgfmanual-en-pgfkeys-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x37.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 u
@@ -1793,6 +1828,7 @@ TEST 25: pgfmanual-en-pgfkeys-41
 ...........\TU/lmr/m/n/10 o
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-pgfsys-animations.tlg
+++ b/testfiles-examples/pgfmanual-en-pgfsys-animations.tlg
@@ -54,6 +54,7 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -80,6 +81,7 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -161,8 +163,10 @@ TEST 2: pgfmanual-en-pgfsys-animations-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -234,8 +238,10 @@ TEST 2: pgfmanual-en-pgfsys-animations-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -307,8 +313,10 @@ TEST 2: pgfmanual-en-pgfsys-animations-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -380,8 +388,10 @@ TEST 2: pgfmanual-en-pgfsys-animations-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x10.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -457,6 +467,7 @@ TEST 3: pgfmanual-en-pgfsys-animations-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -483,6 +494,7 @@ TEST 3: pgfmanual-en-pgfsys-animations-6
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -556,6 +568,7 @@ TEST 4: pgfmanual-en-pgfsys-animations-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -582,6 +595,7 @@ TEST 4: pgfmanual-en-pgfsys-animations-7
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -655,6 +669,7 @@ TEST 5: pgfmanual-en-pgfsys-animations-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -681,6 +696,7 @@ TEST 5: pgfmanual-en-pgfsys-animations-8
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -754,6 +770,7 @@ TEST 6: pgfmanual-en-pgfsys-animations-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -780,6 +797,7 @@ TEST 6: pgfmanual-en-pgfsys-animations-9
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -853,6 +871,7 @@ TEST 7: pgfmanual-en-pgfsys-animations-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -879,6 +898,7 @@ TEST 7: pgfmanual-en-pgfsys-animations-10
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -952,6 +972,7 @@ TEST 8: pgfmanual-en-pgfsys-animations-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -978,6 +999,7 @@ TEST 8: pgfmanual-en-pgfsys-animations-11
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1063,6 +1085,7 @@ TEST 9: pgfmanual-en-pgfsys-animations-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1089,6 +1112,7 @@ TEST 9: pgfmanual-en-pgfsys-animations-12
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1171,6 +1195,7 @@ TEST 10: pgfmanual-en-pgfsys-animations-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1197,6 +1222,7 @@ TEST 10: pgfmanual-en-pgfsys-animations-13
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1270,6 +1296,7 @@ TEST 11: pgfmanual-en-pgfsys-animations-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1296,6 +1323,7 @@ TEST 11: pgfmanual-en-pgfsys-animations-14
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1369,6 +1397,7 @@ TEST 12: pgfmanual-en-pgfsys-animations-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1395,6 +1424,7 @@ TEST 12: pgfmanual-en-pgfsys-animations-15
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1468,6 +1498,7 @@ TEST 13: pgfmanual-en-pgfsys-animations-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1494,6 +1525,7 @@ TEST 13: pgfmanual-en-pgfsys-animations-16
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1567,6 +1599,7 @@ TEST 14: pgfmanual-en-pgfsys-animations-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1593,6 +1626,7 @@ TEST 14: pgfmanual-en-pgfsys-animations-17
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1670,8 +1704,10 @@ TEST 15: pgfmanual-en-pgfsys-animations-19
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1700,6 +1736,7 @@ TEST 15: pgfmanual-en-pgfsys-animations-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1726,6 +1763,7 @@ TEST 15: pgfmanual-en-pgfsys-animations-19
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1792,8 +1830,10 @@ TEST 15: pgfmanual-en-pgfsys-animations-19
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1822,6 +1862,7 @@ TEST 15: pgfmanual-en-pgfsys-animations-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1848,6 +1889,7 @@ TEST 15: pgfmanual-en-pgfsys-animations-19
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1926,8 +1968,10 @@ TEST 16: pgfmanual-en-pgfsys-animations-20
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1956,6 +2000,7 @@ TEST 16: pgfmanual-en-pgfsys-animations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -1982,6 +2027,7 @@ TEST 16: pgfmanual-en-pgfsys-animations-20
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2048,8 +2094,10 @@ TEST 16: pgfmanual-en-pgfsys-animations-20
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2078,6 +2126,7 @@ TEST 16: pgfmanual-en-pgfsys-animations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -2104,6 +2153,7 @@ TEST 16: pgfmanual-en-pgfsys-animations-20
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2182,8 +2232,10 @@ TEST 17: pgfmanual-en-pgfsys-animations-21
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2212,6 +2264,7 @@ TEST 17: pgfmanual-en-pgfsys-animations-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -2238,6 +2291,7 @@ TEST 17: pgfmanual-en-pgfsys-animations-21
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2304,8 +2358,10 @@ TEST 17: pgfmanual-en-pgfsys-animations-21
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2334,6 +2390,7 @@ TEST 17: pgfmanual-en-pgfsys-animations-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -2360,6 +2417,7 @@ TEST 17: pgfmanual-en-pgfsys-animations-21
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2438,8 +2496,10 @@ TEST 18: pgfmanual-en-pgfsys-animations-22
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2468,6 +2528,7 @@ TEST 18: pgfmanual-en-pgfsys-animations-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -2494,6 +2555,7 @@ TEST 18: pgfmanual-en-pgfsys-animations-22
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2560,8 +2622,10 @@ TEST 18: pgfmanual-en-pgfsys-animations-22
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -2590,6 +2654,7 @@ TEST 18: pgfmanual-en-pgfsys-animations-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -2616,6 +2681,7 @@ TEST 18: pgfmanual-en-pgfsys-animations-22
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2689,6 +2755,7 @@ TEST 19: pgfmanual-en-pgfsys-animations-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -2715,6 +2782,7 @@ TEST 19: pgfmanual-en-pgfsys-animations-23
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2787,6 +2855,7 @@ TEST 20: pgfmanual-en-pgfsys-animations-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -2813,6 +2882,7 @@ TEST 20: pgfmanual-en-pgfsys-animations-24
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2885,6 +2955,7 @@ TEST 21: pgfmanual-en-pgfsys-animations-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -2911,6 +2982,7 @@ TEST 21: pgfmanual-en-pgfsys-animations-25
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2983,6 +3055,7 @@ TEST 22: pgfmanual-en-pgfsys-animations-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3009,6 +3082,7 @@ TEST 22: pgfmanual-en-pgfsys-animations-26
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3083,6 +3157,7 @@ TEST 23: pgfmanual-en-pgfsys-animations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3109,6 +3184,7 @@ TEST 23: pgfmanual-en-pgfsys-animations-27
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3183,6 +3259,7 @@ TEST 24: pgfmanual-en-pgfsys-animations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3209,6 +3286,7 @@ TEST 24: pgfmanual-en-pgfsys-animations-28
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3286,6 +3364,7 @@ TEST 25: pgfmanual-en-pgfsys-animations-29
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(20.858+0.07)x26.27101, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\vbox(20.858+0.07)x26.27101, direction TLT
 ............\hbox(12.858+0.07)x26.27101, direction TLT
@@ -3336,6 +3415,7 @@ TEST 25: pgfmanual-en-pgfsys-animations-29
 ..............\TU/lmr/m/n/7 x
 .............\glue(\tabskip) 0.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3377,6 +3457,7 @@ TEST 25: pgfmanual-en-pgfsys-animations-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(20.305+0.07)x20.88799, direction TLT
+...........\begindir TLT
 ...........\vbox(20.305+0.07)x20.88799, direction TLT
 ............\hbox(12.305+0.07)x20.88799, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3421,6 +3502,7 @@ TEST 25: pgfmanual-en-pgfsys-animations-29
 ..............\kern-0.217 (font)
 ..............\TU/lmr/m/n/7 x
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3472,6 +3554,7 @@ TEST 25: pgfmanual-en-pgfsys-animations-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3498,6 +3581,7 @@ TEST 25: pgfmanual-en-pgfsys-animations-29
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3572,6 +3656,7 @@ TEST 26: pgfmanual-en-pgfsys-animations-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3598,6 +3683,7 @@ TEST 26: pgfmanual-en-pgfsys-animations-31
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3671,6 +3757,7 @@ TEST 27: pgfmanual-en-pgfsys-animations-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3697,6 +3784,7 @@ TEST 27: pgfmanual-en-pgfsys-animations-32
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3771,6 +3859,7 @@ TEST 28: pgfmanual-en-pgfsys-animations-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3797,6 +3886,7 @@ TEST 28: pgfmanual-en-pgfsys-animations-33
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3872,6 +3962,7 @@ TEST 29: pgfmanual-en-pgfsys-animations-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3898,6 +3989,7 @@ TEST 29: pgfmanual-en-pgfsys-animations-34
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3972,6 +4064,7 @@ TEST 30: pgfmanual-en-pgfsys-animations-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -3998,6 +4091,7 @@ TEST 30: pgfmanual-en-pgfsys-animations-35
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4072,6 +4166,7 @@ TEST 31: pgfmanual-en-pgfsys-animations-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4098,6 +4193,7 @@ TEST 31: pgfmanual-en-pgfsys-animations-36
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4172,6 +4268,7 @@ TEST 32: pgfmanual-en-pgfsys-animations-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4198,6 +4295,7 @@ TEST 32: pgfmanual-en-pgfsys-animations-37
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4272,6 +4370,7 @@ TEST 33: pgfmanual-en-pgfsys-animations-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4298,6 +4397,7 @@ TEST 33: pgfmanual-en-pgfsys-animations-38
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4372,6 +4472,7 @@ TEST 34: pgfmanual-en-pgfsys-animations-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4398,6 +4499,7 @@ TEST 34: pgfmanual-en-pgfsys-animations-39
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4474,6 +4576,7 @@ TEST 35: pgfmanual-en-pgfsys-animations-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4500,6 +4603,7 @@ TEST 35: pgfmanual-en-pgfsys-animations-40
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4561,6 +4665,7 @@ TEST 35: pgfmanual-en-pgfsys-animations-40
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x25.59, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 O
 ...........\TU/lmr/m/n/10 t
@@ -4568,6 +4673,7 @@ TEST 35: pgfmanual-en-pgfsys-animations-40
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4642,6 +4748,7 @@ TEST 36: pgfmanual-en-pgfsys-animations-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4668,6 +4775,7 @@ TEST 36: pgfmanual-en-pgfsys-animations-41
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4741,6 +4849,7 @@ TEST 37: pgfmanual-en-pgfsys-animations-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4767,6 +4876,7 @@ TEST 37: pgfmanual-en-pgfsys-animations-42
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4840,6 +4950,7 @@ TEST 38: pgfmanual-en-pgfsys-animations-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4866,6 +4977,7 @@ TEST 38: pgfmanual-en-pgfsys-animations-43
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4939,6 +5051,7 @@ TEST 39: pgfmanual-en-pgfsys-animations-44
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4965,6 +5078,7 @@ TEST 39: pgfmanual-en-pgfsys-animations-44
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5038,6 +5152,7 @@ TEST 40: pgfmanual-en-pgfsys-animations-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -5064,6 +5179,7 @@ TEST 40: pgfmanual-en-pgfsys-animations-45
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5137,6 +5253,7 @@ TEST 41: pgfmanual-en-pgfsys-animations-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -5163,6 +5280,7 @@ TEST 41: pgfmanual-en-pgfsys-animations-46
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5237,6 +5355,7 @@ TEST 42: pgfmanual-en-pgfsys-animations-47
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -5263,6 +5382,7 @@ TEST 42: pgfmanual-en-pgfsys-animations-47
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5337,6 +5457,7 @@ TEST 43: pgfmanual-en-pgfsys-animations-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(15.132+0.08)x18.88, direction TLT
+...........\begindir TLT
 ...........\vbox(15.132+0.08)x18.88, direction TLT
 ............\hbox(5.632+0.168)x18.88, direction TLT
 .............\glue(\tabskip) 0.0
@@ -5363,6 +5484,7 @@ TEST 43: pgfmanual-en-pgfsys-animations-48
 ..............\TU/lmr/m/n/8 e
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-actions.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-actions.tlg
@@ -2505,6 +2505,7 @@ TEST 47: pgfmanual-en-tikz-actions-49
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+2.06)x94.07321, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
@@ -2530,6 +2531,7 @@ TEST 47: pgfmanual-en-tikz-actions-49
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2608,6 +2610,7 @@ TEST 47: pgfmanual-en-tikz-actions-49
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+2.06)x86.29541, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
@@ -2632,6 +2635,7 @@ TEST 47: pgfmanual-en-tikz-actions-49
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2718,6 +2722,7 @@ TEST 48: pgfmanual-en-tikz-actions-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+2.06)x86.29541, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
@@ -2742,6 +2747,7 @@ TEST 48: pgfmanual-en-tikz-actions-50
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2864,6 +2870,7 @@ TEST 49: pgfmanual-en-tikz-actions-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x83.16, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 T
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
@@ -2884,6 +2891,7 @@ TEST 49: pgfmanual-en-tikz-actions-51
 ...........\TU/lmr/m/n/10 x
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3046,8 +3054,10 @@ TEST 50: pgfmanual-en-tikz-actions-52
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3196,6 +3206,7 @@ Package luatex.def Info: brave-gnu-world-logo.jpg  used on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(85.35826+0.0)x75.43332, direction TLT
+...........\begindir TLT
 ...........\hbox(85.35826+0.0)x75.43332, direction TLT
 ............\hbox(85.35898+0.0)x75.43352, direction TLT
 .............\hbox(85.35898+0.0)x75.43352, direction TLT
@@ -3209,6 +3220,7 @@ Package luatex.def Info: brave-gnu-world-logo.jpg  used on input line ....
 ...............\pdfrestore
 ..............\kern75.43352
 ..............\glue 0.0 plus 1.0fil minus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3263,6 +3275,7 @@ Package luatex.def Info: brave-gnu-world-logo.jpg  used on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(85.35826+0.0)x75.43332, direction TLT
+...........\begindir TLT
 ...........\hbox(85.35826+0.0)x75.43332, direction TLT
 ............\hbox(85.35898+0.0)x75.43352, direction TLT
 .............\hbox(85.35898+0.0)x75.43352, direction TLT
@@ -3276,6 +3289,7 @@ Package luatex.def Info: brave-gnu-world-logo.jpg  used on input line ....
 ...............\pdfrestore
 ..............\kern75.43352
 ..............\glue 0.0 plus 1.0fil minus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3356,8 +3370,10 @@ TEST 52: pgfmanual-en-tikz-actions-54
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3409,8 +3425,10 @@ TEST 53: pgfmanual-en-tikz-actions-55
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3471,8 +3489,10 @@ TEST 54: pgfmanual-en-tikz-actions-56
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3521,8 +3541,10 @@ TEST 54: pgfmanual-en-tikz-actions-56
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3571,8 +3593,10 @@ TEST 54: pgfmanual-en-tikz-actions-56
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3633,8 +3657,10 @@ TEST 55: pgfmanual-en-tikz-actions-57
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3694,8 +3720,10 @@ TEST 56: pgfmanual-en-tikz-actions-58
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -4154,10 +4182,12 @@ TEST 61: pgfmanual-en-tikz-actions-63
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.83333)x12.77782, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OMS/cmsy/m/n/10 ^^@
 .............\OT1/cmr/m/n/10 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4230,9 +4260,11 @@ TEST 61: pgfmanual-en-tikz-actions-63
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.0)x5.00002, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OT1/cmr/m/n/10 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4307,10 +4339,12 @@ TEST 61: pgfmanual-en-tikz-actions-63
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.83333)x12.77782, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OMS/cmsy/m/n/10 ^^@
 .............\OT1/cmr/m/n/10 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4385,9 +4419,11 @@ TEST 61: pgfmanual-en-tikz-actions-63
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.0)x5.00002, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OT1/cmr/m/n/10 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5046,8 +5082,10 @@ TEST 68: pgfmanual-en-tikz-actions-70
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -5217,8 +5255,10 @@ TEST 69: pgfmanual-en-tikz-actions-71
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -5251,8 +5291,10 @@ TEST 69: pgfmanual-en-tikz-actions-71
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -5271,9 +5313,11 @@ TEST 69: pgfmanual-en-tikz-actions-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(16.99304+5.07552)x33.91145, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/24.88 B
 ...........\TU/lmr/m/n/24.88 i
 ...........\TU/lmr/m/n/24.88 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5348,8 +5392,10 @@ TEST 69: pgfmanual-en-tikz-actions-71
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -5380,8 +5426,10 @@ TEST 69: pgfmanual-en-tikz-actions-71
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -5400,6 +5448,7 @@ TEST 69: pgfmanual-en-tikz-actions-71
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x24.45, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 m
@@ -5407,6 +5456,7 @@ TEST 69: pgfmanual-en-tikz-actions-71
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5608,8 +5658,10 @@ TEST 71: pgfmanual-en-tikz-actions-73
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -6039,12 +6091,14 @@ TEST 73: pgfmanual-en-tikz-actions-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x25.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-animations.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-animations.tlg
@@ -55,9 +55,11 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x16.68, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -97,11 +99,13 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.18, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 E
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -139,11 +143,13 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.11)x25.01, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 M
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -263,6 +269,7 @@ TEST 3: pgfmanual-en-tikz-animations-3
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -274,6 +281,7 @@ TEST 3: pgfmanual-en-tikz-animations-3
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -339,6 +347,7 @@ TEST 4: pgfmanual-en-tikz-animations-4
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -350,6 +359,7 @@ TEST 4: pgfmanual-en-tikz-animations-4
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -441,12 +451,14 @@ TEST 5: pgfmanual-en-tikz-animations-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x25.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 k
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -527,11 +539,13 @@ TEST 5: pgfmanual-en-tikz-animations-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x35.15, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 K
 ...........\TU/lmr/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -599,6 +613,7 @@ TEST 6: pgfmanual-en-tikz-animations-6
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -610,6 +625,7 @@ TEST 6: pgfmanual-en-tikz-animations-6
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -676,6 +692,7 @@ TEST 7: pgfmanual-en-tikz-animations-7
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -687,6 +704,7 @@ TEST 7: pgfmanual-en-tikz-animations-7
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -758,6 +776,7 @@ TEST 8: pgfmanual-en-tikz-animations-8
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.94+0.11)x31.11, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 N
 ...........\TU/lmr/m/n/10 o
@@ -767,6 +786,7 @@ TEST 8: pgfmanual-en-tikz-animations-8
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -805,6 +825,7 @@ TEST 8: pgfmanual-en-tikz-animations-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x31.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 N
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
@@ -812,6 +833,7 @@ TEST 8: pgfmanual-en-tikz-animations-8
 ...........\TU/lmr/m/n/10 e
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -876,9 +898,11 @@ TEST 9: pgfmanual-en-tikz-animations-9
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 a
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -910,9 +934,11 @@ TEST 9: pgfmanual-en-tikz-animations-9
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 b
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -942,9 +968,11 @@ TEST 9: pgfmanual-en-tikz-animations-9
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 c
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1097,6 +1125,7 @@ TEST 11: pgfmanual-en-tikz-animations-11
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.94+0.11)x41.39, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 T
 ...........\TU/lmr/m/n/10 h
@@ -1108,6 +1137,7 @@ TEST 11: pgfmanual-en-tikz-animations-11
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1190,6 +1220,7 @@ TEST 12: pgfmanual-en-tikz-animations-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x41.39, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 T
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 e
@@ -1199,6 +1230,7 @@ TEST 12: pgfmanual-en-tikz-animations-12
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1285,6 +1317,7 @@ TEST 13: pgfmanual-en-tikz-animations-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -1294,6 +1327,7 @@ TEST 13: pgfmanual-en-tikz-animations-13
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1382,6 +1416,7 @@ TEST 14: pgfmanual-en-tikz-animations-15
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -1393,6 +1428,7 @@ TEST 14: pgfmanual-en-tikz-animations-15
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1478,6 +1514,7 @@ TEST 15: pgfmanual-en-tikz-animations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -1487,6 +1524,7 @@ TEST 15: pgfmanual-en-tikz-animations-20
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1562,11 +1600,13 @@ TEST 16: pgfmanual-en-tikz-animations-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1651,11 +1691,13 @@ TEST 17: pgfmanual-en-tikz-animations-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1740,11 +1782,13 @@ TEST 18: pgfmanual-en-tikz-animations-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1828,11 +1872,13 @@ TEST 19: pgfmanual-en-tikz-animations-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1900,9 +1946,11 @@ TEST 20: pgfmanual-en-tikz-animations-37
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 A
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1932,9 +1980,11 @@ TEST 20: pgfmanual-en-tikz-animations-37
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 B
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1968,9 +2018,11 @@ TEST 20: pgfmanual-en-tikz-animations-37
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2038,9 +2090,11 @@ TEST 21: pgfmanual-en-tikz-animations-38
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 A
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2079,9 +2133,11 @@ TEST 21: pgfmanual-en-tikz-animations-38
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 B
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2149,9 +2205,11 @@ TEST 22: pgfmanual-en-tikz-animations-39
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 A
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2181,9 +2239,11 @@ TEST 22: pgfmanual-en-tikz-animations-39
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 B
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2259,6 +2319,7 @@ TEST 23: pgfmanual-en-tikz-animations-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2269,6 +2330,7 @@ TEST 23: pgfmanual-en-tikz-animations-40
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2344,6 +2406,7 @@ TEST 24: pgfmanual-en-tikz-animations-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2354,6 +2417,7 @@ TEST 24: pgfmanual-en-tikz-animations-41
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2431,6 +2495,7 @@ TEST 25: pgfmanual-en-tikz-animations-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2441,6 +2506,7 @@ TEST 25: pgfmanual-en-tikz-animations-42
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2517,6 +2583,7 @@ TEST 26: pgfmanual-en-tikz-animations-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2527,6 +2594,7 @@ TEST 26: pgfmanual-en-tikz-animations-43
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2564,6 +2632,7 @@ TEST 26: pgfmanual-en-tikz-animations-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x25.41, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 E
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 f
@@ -2573,6 +2642,7 @@ TEST 26: pgfmanual-en-tikz-animations-43
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2648,6 +2718,7 @@ TEST 27: pgfmanual-en-tikz-animations-44
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2658,6 +2729,7 @@ TEST 27: pgfmanual-en-tikz-animations-44
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2733,6 +2805,7 @@ TEST 28: pgfmanual-en-tikz-animations-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2743,6 +2816,7 @@ TEST 28: pgfmanual-en-tikz-animations-45
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2818,6 +2892,7 @@ TEST 29: pgfmanual-en-tikz-animations-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2828,6 +2903,7 @@ TEST 29: pgfmanual-en-tikz-animations-46
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2905,6 +2981,7 @@ TEST 30: pgfmanual-en-tikz-animations-47
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -2915,6 +2992,7 @@ TEST 30: pgfmanual-en-tikz-animations-47
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2990,6 +3068,7 @@ TEST 31: pgfmanual-en-tikz-animations-48
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3000,6 +3079,7 @@ TEST 31: pgfmanual-en-tikz-animations-48
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3075,6 +3155,7 @@ TEST 32: pgfmanual-en-tikz-animations-49
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3085,6 +3166,7 @@ TEST 32: pgfmanual-en-tikz-animations-49
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3153,6 +3235,7 @@ TEST 33: pgfmanual-en-tikz-animations-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3163,6 +3246,7 @@ TEST 33: pgfmanual-en-tikz-animations-53
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3242,6 +3326,7 @@ TEST 34: pgfmanual-en-tikz-animations-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3252,6 +3337,7 @@ TEST 34: pgfmanual-en-tikz-animations-54
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3327,6 +3413,7 @@ TEST 35: pgfmanual-en-tikz-animations-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3337,6 +3424,7 @@ TEST 35: pgfmanual-en-tikz-animations-55
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3412,6 +3500,7 @@ TEST 36: pgfmanual-en-tikz-animations-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3422,6 +3511,7 @@ TEST 36: pgfmanual-en-tikz-animations-56
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3497,6 +3587,7 @@ TEST 37: pgfmanual-en-tikz-animations-57
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3507,6 +3598,7 @@ TEST 37: pgfmanual-en-tikz-animations-57
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3583,6 +3675,7 @@ TEST 38: pgfmanual-en-tikz-animations-58
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3593,6 +3686,7 @@ TEST 38: pgfmanual-en-tikz-animations-58
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3670,6 +3764,7 @@ TEST 39: pgfmanual-en-tikz-animations-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3680,6 +3775,7 @@ TEST 39: pgfmanual-en-tikz-animations-59
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3757,6 +3853,7 @@ TEST 40: pgfmanual-en-tikz-animations-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -3767,6 +3864,7 @@ TEST 40: pgfmanual-en-tikz-animations-60
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3890,12 +3988,14 @@ TEST 41: pgfmanual-en-tikz-animations-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x22.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 c
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 k
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4019,12 +4119,14 @@ TEST 42: pgfmanual-en-tikz-animations-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x22.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 c
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 k
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4134,6 +4236,7 @@ TEST 43: pgfmanual-en-tikz-animations-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4143,6 +4246,7 @@ TEST 43: pgfmanual-en-tikz-animations-63
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4252,6 +4356,7 @@ TEST 44: pgfmanual-en-tikz-animations-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4261,6 +4366,7 @@ TEST 44: pgfmanual-en-tikz-animations-64
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4373,6 +4479,7 @@ TEST 45: pgfmanual-en-tikz-animations-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4382,6 +4489,7 @@ TEST 45: pgfmanual-en-tikz-animations-65
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4492,6 +4600,7 @@ TEST 46: pgfmanual-en-tikz-animations-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4501,6 +4610,7 @@ TEST 46: pgfmanual-en-tikz-animations-66
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4612,6 +4722,7 @@ TEST 47: pgfmanual-en-tikz-animations-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -4621,6 +4732,7 @@ TEST 47: pgfmanual-en-tikz-animations-67
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4751,12 +4863,14 @@ TEST 48: pgfmanual-en-tikz-animations-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x22.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 c
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 k
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4887,12 +5001,14 @@ TEST 49: pgfmanual-en-tikz-animations-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x22.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 c
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 k
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5023,12 +5139,14 @@ TEST 50: pgfmanual-en-tikz-animations-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x22.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 c
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 k
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5098,6 +5216,7 @@ TEST 51: pgfmanual-en-tikz-animations-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -5108,6 +5227,7 @@ TEST 51: pgfmanual-en-tikz-animations-72
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5187,11 +5307,13 @@ TEST 51: pgfmanual-en-tikz-animations-72
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(3.47+0.055)x9.515, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/5 r
 ...........\TU/lmr/m/n/5 e
 ...........\TU/lmr/m/n/5 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5267,6 +5389,7 @@ TEST 52: pgfmanual-en-tikz-animations-73
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -5278,6 +5401,7 @@ TEST 52: pgfmanual-en-tikz-animations-73
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5349,6 +5473,7 @@ TEST 53: pgfmanual-en-tikz-animations-74
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -5360,6 +5485,7 @@ TEST 53: pgfmanual-en-tikz-animations-74
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5431,6 +5557,7 @@ TEST 54: pgfmanual-en-tikz-animations-75
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -5442,6 +5569,7 @@ TEST 54: pgfmanual-en-tikz-animations-75
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5512,6 +5640,7 @@ TEST 55: pgfmanual-en-tikz-animations-76
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -5523,6 +5652,7 @@ TEST 55: pgfmanual-en-tikz-animations-76
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5592,6 +5722,7 @@ TEST 56: pgfmanual-en-tikz-animations-77
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -5603,6 +5734,7 @@ TEST 56: pgfmanual-en-tikz-animations-77
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5673,6 +5805,7 @@ TEST 57: pgfmanual-en-tikz-animations-78
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(7.05+0.22)x38.32, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
@@ -5684,6 +5817,7 @@ TEST 57: pgfmanual-en-tikz-animations-78
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5750,7 +5884,9 @@ TEST 58: pgfmanual-en-tikz-animations-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5788,7 +5924,9 @@ TEST 58: pgfmanual-en-tikz-animations-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5833,10 +5971,12 @@ TEST 58: pgfmanual-en-tikz-animations-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x24.17, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5874,7 +6014,9 @@ TEST 58: pgfmanual-en-tikz-animations-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5912,7 +6054,9 @@ TEST 58: pgfmanual-en-tikz-animations-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5979,7 +6123,9 @@ TEST 59: pgfmanual-en-tikz-animations-80
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6017,7 +6163,9 @@ TEST 59: pgfmanual-en-tikz-animations-80
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6062,10 +6210,12 @@ TEST 59: pgfmanual-en-tikz-animations-80
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x24.17, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6103,7 +6253,9 @@ TEST 59: pgfmanual-en-tikz-animations-80
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6141,7 +6293,9 @@ TEST 59: pgfmanual-en-tikz-animations-80
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6217,11 +6371,13 @@ TEST 60: pgfmanual-en-tikz-animations-81
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6297,11 +6453,13 @@ TEST 61: pgfmanual-en-tikz-animations-82
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6377,11 +6535,13 @@ TEST 62: pgfmanual-en-tikz-animations-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6457,11 +6617,13 @@ TEST 63: pgfmanual-en-tikz-animations-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6537,11 +6699,13 @@ TEST 64: pgfmanual-en-tikz-animations-85
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6617,11 +6781,13 @@ TEST 65: pgfmanual-en-tikz-animations-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6707,11 +6873,13 @@ TEST 66: pgfmanual-en-tikz-animations-87
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6798,11 +6966,13 @@ TEST 67: pgfmanual-en-tikz-animations-88
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6891,11 +7061,13 @@ TEST 68: pgfmanual-en-tikz-animations-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6973,11 +7145,13 @@ TEST 69: pgfmanual-en-tikz-animations-90
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7054,11 +7228,13 @@ TEST 70: pgfmanual-en-tikz-animations-91
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x23.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7135,6 +7311,7 @@ TEST 71: pgfmanual-en-tikz-animations-92
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -7145,6 +7322,7 @@ TEST 71: pgfmanual-en-tikz-animations-92
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7221,6 +7399,7 @@ TEST 72: pgfmanual-en-tikz-animations-93
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -7231,6 +7410,7 @@ TEST 72: pgfmanual-en-tikz-animations-93
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7307,6 +7487,7 @@ TEST 73: pgfmanual-en-tikz-animations-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -7317,6 +7498,7 @@ TEST 73: pgfmanual-en-tikz-animations-94
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7393,6 +7575,7 @@ TEST 74: pgfmanual-en-tikz-animations-95
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -7403,6 +7586,7 @@ TEST 74: pgfmanual-en-tikz-animations-95
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7479,6 +7663,7 @@ TEST 75: pgfmanual-en-tikz-animations-96
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -7489,6 +7674,7 @@ TEST 75: pgfmanual-en-tikz-animations-96
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7619,6 +7805,7 @@ TEST 76: pgfmanual-en-tikz-animations-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -7629,6 +7816,7 @@ TEST 76: pgfmanual-en-tikz-animations-99
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7760,6 +7948,7 @@ TEST 77: pgfmanual-en-tikz-animations-100
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -7770,6 +7959,7 @@ TEST 77: pgfmanual-en-tikz-animations-100
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7902,6 +8092,7 @@ TEST 78: pgfmanual-en-tikz-animations-101
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -7912,6 +8103,7 @@ TEST 78: pgfmanual-en-tikz-animations-101
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8039,6 +8231,7 @@ TEST 79: pgfmanual-en-tikz-animations-102
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -8049,6 +8242,7 @@ TEST 79: pgfmanual-en-tikz-animations-102
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8180,6 +8374,7 @@ TEST 80: pgfmanual-en-tikz-animations-103
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -8190,6 +8385,7 @@ TEST 80: pgfmanual-en-tikz-animations-103
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8321,6 +8517,7 @@ TEST 81: pgfmanual-en-tikz-animations-104
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -8331,6 +8528,7 @@ TEST 81: pgfmanual-en-tikz-animations-104
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-arrows.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-arrows.tlg
@@ -39,7 +39,9 @@ TEST 1: pgfmanual-en-tikz-arrows-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -71,7 +73,9 @@ TEST 1: pgfmanual-en-tikz-arrows-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -898,9 +902,11 @@ TEST 12: pgfmanual-en-tikz-arrows-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x21.66, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -997,9 +1003,11 @@ TEST 13: pgfmanual-en-tikz-arrows-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x21.66, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1090,9 +1098,11 @@ TEST 14: pgfmanual-en-tikz-arrows-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x21.66, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1375,10 +1385,12 @@ TEST 18: pgfmanual-en-tikz-arrows-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x26.66, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1481,10 +1493,12 @@ TEST 19: pgfmanual-en-tikz-arrows-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x26.66, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2462,9 +2476,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83331+0.0)x7.50002, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 A
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2506,10 +2522,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83331+0.0)x8.0868, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 B
 .............\kern0.50172 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2588,10 +2606,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83331+0.0)x7.86249, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 C
 .............\kern0.71527 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6366,7 +6386,9 @@ TEST 86: pgfmanual-en-tikz-arrows-88
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6397,7 +6419,9 @@ TEST 86: pgfmanual-en-tikz-arrows-88
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7398,8 +7422,10 @@ TEST 102: pgfmanual-en-tikz-arrows-105
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -7527,10 +7553,12 @@ TEST 103: pgfmanual-en-tikz-arrows-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x6.43404, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^K
 .............\kern0.03702 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7575,10 +7603,12 @@ TEST 103: pgfmanual-en-tikz-arrows-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94444+1.94444)x6.18402, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^L
 .............\kern0.52777 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7623,10 +7653,12 @@ TEST 103: pgfmanual-en-tikz-arrows-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x5.73285, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 
 .............\kern0.55554 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-coordinates.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-coordinates.tlg
@@ -784,6 +784,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x70.86, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 n
@@ -807,6 +808,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -832,6 +834,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x78.2, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 r
@@ -855,6 +858,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -882,6 +886,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x58.95, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 r
@@ -898,6 +903,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -939,6 +945,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.345+1.746)x42.08405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 P
 ...........\kern-0.261 (font)
 ...........\TU/lmr/m/n/9 o
@@ -950,6 +957,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\TU/lmr/m/n/9 i
 ...........\TU/lmr/m/n/9 p
 ...........\TU/lmr/m/n/9 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -977,10 +985,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.147+0.198)x17.082, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 D
 ...........\kern-0.261 (font)
 ...........\TU/lmr/m/n/9 V
 ...........\TU/lmr/m/n/9 I
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1008,9 +1018,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.147+0.0)x19.395, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 P
 ...........\TU/lmr/m/n/9 D
 ...........\TU/lmr/m/n/9 F
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1038,9 +1050,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.345+0.198)x16.95601, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 C
 ...........\TU/lmr/m/n/9 S
 ...........\TU/lmr/m/n/9 S
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1068,9 +1082,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.147+0.0)x21.19499, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 X
 ...........\TU/lmr/m/n/9 M
 ...........\TU/lmr/m/n/9 L
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1098,10 +1114,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.147+0.0)x27.87299, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 H
 ...........\TU/lmr/m/n/9 T
 ...........\TU/lmr/m/n/9 M
 ...........\TU/lmr/m/n/9 L
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1129,12 +1147,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.147+1.9395)x17.28267, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 T
 ...........\kern-1.50032
 ...........\hbox(6.12+0.0)x6.291, shifted 1.9395, direction TLT
 ............\TU/lmr/m/n/9 E
 ...........\kern-1.125
 ...........\TU/lmr/m/n/9 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1162,6 +1182,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.147+1.9395)x23.84673, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 L
 ...........\kern-3.24
 ...........\vbox(6.093+0.0)x5.376, glue set 1.809fil, direction TLT
@@ -1175,6 +1196,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\TU/lmr/m/n/9 E
 ...........\kern-1.125
 ...........\TU/lmr/m/n/9 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1202,11 +1224,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.246+0.198)x22.113, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 W
 ...........\kern-0.774 (font)
 ...........\TU/lmr/m/n/9 o
 ...........\TU/lmr/m/n/9 r
 ...........\TU/lmr/m/n/9 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1234,12 +1258,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.444+0.198)x25.695, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 A
 ...........\TU/lmr/m/n/9 S
 ...........\TU/lmr/m/n/9 C
 ...........\TU/lmr/m/n/9 I
 ...........\kern0.261 (font)
 ...........\TU/lmr/m/n/9 I
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1297,6 +1323,7 @@ TEST 13: pgfmanual-en-tikz-coordinates-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.22+2.22)x57.75, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 c
 ...........\TU/lmtt/m/n/10 l
 ...........\TU/lmtt/m/n/10 a
@@ -1308,6 +1335,7 @@ TEST 13: pgfmanual-en-tikz-coordinates-13
 ...........\TU/lmtt/m/n/10 a
 ...........\TU/lmtt/m/n/10 p
 ...........\TU/lmtt/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1337,6 +1365,7 @@ TEST 13: pgfmanual-en-tikz-coordinates-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+2.29)x78.75, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 c
 ...........\TU/lmtt/m/n/10 l
 ...........\TU/lmtt/m/n/10 a
@@ -1352,6 +1381,7 @@ TEST 13: pgfmanual-en-tikz-coordinates-13
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 l
 ...........\TU/lmtt/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1381,6 +1411,7 @@ TEST 13: pgfmanual-en-tikz-coordinates-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.22+0.11)x63.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 c
 ...........\TU/lmtt/m/n/10 l
 ...........\TU/lmtt/m/n/10 a
@@ -1393,6 +1424,7 @@ TEST 13: pgfmanual-en-tikz-coordinates-13
 ...........\TU/lmtt/m/n/10 c
 ...........\TU/lmtt/m/n/10 l
 ...........\TU/lmtt/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1422,6 +1454,7 @@ TEST 13: pgfmanual-en-tikz-coordinates-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+2.22)x68.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 c
 ...........\TU/lmtt/m/n/10 l
 ...........\TU/lmtt/m/n/10 a
@@ -1435,6 +1468,7 @@ TEST 13: pgfmanual-en-tikz-coordinates-13
 ...........\TU/lmtt/m/n/10 p
 ...........\TU/lmtt/m/n/10 s
 ...........\TU/lmtt/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1541,11 +1575,13 @@ TEST 14: pgfmanual-en-tikz-coordinates-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x20.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1682,6 +1718,7 @@ TEST 15: pgfmanual-en-tikz-coordinates-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+1.94)x43.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 n
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
@@ -1694,6 +1731,7 @@ TEST 15: pgfmanual-en-tikz-coordinates-15
 ...........\TU/lmr/m/n/10 p
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1723,6 +1761,7 @@ TEST 15: pgfmanual-en-tikz-coordinates-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x33.63, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\glue(\spaceskip) 3.33 plus 1.66331 minus 1.1111
 ...........\TU/lmr/m/n/10 c
@@ -1733,6 +1772,7 @@ TEST 15: pgfmanual-en-tikz-coordinates-15
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1811,11 +1851,13 @@ TEST 16: pgfmanual-en-tikz-coordinates-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.11)x20.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 T
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 x
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1881,7 +1923,9 @@ TEST 17: pgfmanual-en-tikz-coordinates-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1907,7 +1951,9 @@ TEST 17: pgfmanual-en-tikz-coordinates-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2035,6 +2081,7 @@ TEST 18: pgfmanual-en-tikz-coordinates-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+1.94)x43.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 n
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
@@ -2047,6 +2094,7 @@ TEST 18: pgfmanual-en-tikz-coordinates-18
 ...........\TU/lmr/m/n/10 p
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2076,6 +2124,7 @@ TEST 18: pgfmanual-en-tikz-coordinates-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.11)x33.63, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\glue(\spaceskip) 3.33 plus 1.66331 minus 1.1111
 ...........\TU/lmr/m/n/10 c
@@ -2086,6 +2135,7 @@ TEST 18: pgfmanual-en-tikz-coordinates-18
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2118,6 +2168,7 @@ TEST 18: pgfmanual-en-tikz-coordinates-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+2.06)x50.3, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\glue(\spaceskip) 3.33 plus 1.66331 minus 1.1111
 ...........\TU/lmr/m/n/10 r
@@ -2133,6 +2184,7 @@ TEST 18: pgfmanual-en-tikz-coordinates-18
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2165,6 +2217,7 @@ TEST 18: pgfmanual-en-tikz-coordinates-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+2.06)x78.67, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 n
 ...........\discretionary (penalty 50)
@@ -2188,6 +2241,7 @@ TEST 18: pgfmanual-en-tikz-coordinates-18
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2360,9 +2414,11 @@ TEST 19: pgfmanual-en-tikz-coordinates-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.32756, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2870,11 +2926,13 @@ TEST 21: pgfmanual-en-tikz-coordinates-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2900,11 +2958,13 @@ TEST 21: pgfmanual-en-tikz-coordinates-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.51738, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 p
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2936,11 +2996,13 @@ TEST 21: pgfmanual-en-tikz-coordinates-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2972,11 +3034,13 @@ TEST 21: pgfmanual-en-tikz-coordinates-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3083,7 +3147,9 @@ TEST 22: pgfmanual-en-tikz-coordinates-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3111,7 +3177,9 @@ TEST 22: pgfmanual-en-tikz-coordinates-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3139,7 +3207,9 @@ TEST 22: pgfmanual-en-tikz-coordinates-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3167,7 +3237,9 @@ TEST 22: pgfmanual-en-tikz-coordinates-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3203,7 +3275,9 @@ TEST 22: pgfmanual-en-tikz-coordinates-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3239,7 +3313,9 @@ TEST 22: pgfmanual-en-tikz-coordinates-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3271,7 +3347,9 @@ TEST 22: pgfmanual-en-tikz-coordinates-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3439,9 +3517,11 @@ TEST 23: pgfmanual-en-tikz-coordinates-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3477,9 +3557,11 @@ TEST 23: pgfmanual-en-tikz-coordinates-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/10 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3707,9 +3789,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3745,9 +3829,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3783,9 +3869,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3821,9 +3909,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.4+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3859,9 +3949,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3897,9 +3989,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3935,9 +4029,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.408+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 7
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3973,9 +4069,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4011,9 +4109,11 @@ TEST 24: pgfmanual-en-tikz-coordinates-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4303,7 +4403,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4337,7 +4439,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4371,7 +4475,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4405,7 +4511,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4439,7 +4547,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4473,7 +4583,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4507,7 +4619,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4541,7 +4655,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4575,7 +4691,9 @@ TEST 26: pgfmanual-en-tikz-coordinates-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4719,9 +4837,11 @@ TEST 27: pgfmanual-en-tikz-coordinates-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4755,9 +4875,11 @@ TEST 27: pgfmanual-en-tikz-coordinates-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4791,9 +4913,11 @@ TEST 27: pgfmanual-en-tikz-coordinates-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4900,9 +5024,11 @@ TEST 27: pgfmanual-en-tikz-coordinates-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4936,9 +5062,11 @@ TEST 27: pgfmanual-en-tikz-coordinates-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.0)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4972,9 +5100,11 @@ TEST 27: pgfmanual-en-tikz-coordinates-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.32+0.168)x4.248, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 g 0 G}
 ...........\TU/lmr/m/n/8 3
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5542,7 +5672,9 @@ TEST 38: pgfmanual-en-tikz-coordinates-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5776,7 +5908,9 @@ TEST 40: pgfmanual-en-tikz-coordinates-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5804,9 +5938,11 @@ TEST 40: pgfmanual-en-tikz-coordinates-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5834,9 +5970,11 @@ TEST 40: pgfmanual-en-tikz-coordinates-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5864,9 +6002,11 @@ TEST 40: pgfmanual-en-tikz-coordinates-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5894,7 +6034,9 @@ TEST 40: pgfmanual-en-tikz-coordinates-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6453,9 +6595,11 @@ TEST 44: pgfmanual-en-tikz-coordinates-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x17.77, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6483,9 +6627,11 @@ TEST 44: pgfmanual-en-tikz-coordinates-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6513,10 +6659,12 @@ TEST 44: pgfmanual-en-tikz-coordinates-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x26.66, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6651,9 +6799,11 @@ TEST 45: pgfmanual-en-tikz-coordinates-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-decorations.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-decorations.tlg
@@ -654,12 +654,14 @@ TEST 2: pgfmanual-en-tikz-decorations-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+2.05)x31.53, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 p
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1409,6 +1411,7 @@ TEST 4: pgfmanual-en-tikz-decorations-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x74.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 a
 ...........\kern-0.28 (font)
@@ -1427,6 +1430,7 @@ TEST 4: pgfmanual-en-tikz-decorations-4
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1877,9 +1881,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.77+0.0)x7.22, direction TLT
 ........\hbox(6.77+0.0)x7.22, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 T
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1893,9 +1899,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x5.56, direction TLT
 ........\hbox(6.94+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 h
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1909,9 +1917,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1925,9 +1935,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x3.94, direction TLT
 ........\hbox(4.48+0.11)x3.94, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 s
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1941,9 +1953,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1957,9 +1971,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.57+0.0)x2.78, direction TLT
 ........\hbox(6.57+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 i
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1973,9 +1989,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x3.94, direction TLT
 ........\hbox(4.48+0.11)x3.94, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 s
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -1989,9 +2007,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2005,9 +2025,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2021,9 +2043,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2037,9 +2061,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2053,9 +2079,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2069,9 +2097,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+0.0)x5.28, direction TLT
 ........\hbox(4.31+0.0)x5.28, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 x
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2085,9 +2115,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2101,9 +2133,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2117,9 +2151,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2133,9 +2169,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x2.78, direction TLT
 ........\hbox(6.94+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 l
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2149,9 +2187,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2165,9 +2205,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2181,9 +2223,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2197,9 +2241,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2213,9 +2259,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2229,9 +2277,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2245,9 +2295,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+1.94)x5.56, direction TLT
 ........\hbox(4.42+1.94)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 p
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2261,9 +2313,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2277,9 +2331,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2293,9 +2349,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x5.56, direction TLT
 ........\hbox(6.94+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 h
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2309,9 +2367,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(1.06+0.0)x2.78, direction TLT
 ........\hbox(1.06+0.0)x2.78, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 .
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2325,9 +2385,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2341,9 +2403,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.83+0.0)x7.5, direction TLT
 ........\hbox(6.83+0.0)x7.5, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 N
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2357,9 +2421,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2373,9 +2439,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.15+0.11)x3.89, direction TLT
 ........\hbox(6.15+0.11)x3.89, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 t
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2389,9 +2457,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2405,9 +2475,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2421,9 +2493,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.0)x5.56, direction TLT
 ........\hbox(6.94+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 h
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2437,9 +2511,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -2453,9 +2529,11 @@ TEST 9: pgfmanual-en-tikz-decorations-9
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+0.11)x7.22, direction TLT
 ........\hbox(4.31+0.11)x7.22, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 w
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3578,9 +3656,11 @@ TEST 14: pgfmanual-en-tikz-decorations-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x13.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4067,9 +4147,11 @@ TEST 18: pgfmanual-en-tikz-decorations-18
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4083,9 +4165,11 @@ TEST 18: pgfmanual-en-tikz-decorations-18
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 r
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4099,9 +4183,11 @@ TEST 18: pgfmanual-en-tikz-decorations-18
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4115,9 +4201,11 @@ TEST 18: pgfmanual-en-tikz-decorations-18
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4131,9 +4219,11 @@ TEST 18: pgfmanual-en-tikz-decorations-18
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4147,9 +4237,11 @@ TEST 18: pgfmanual-en-tikz-decorations-18
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4568,6 +4660,7 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x29.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 E
 ...........\TU/lmr/m/n/10 l
 ...........\discretionary (penalty 50)
@@ -4577,6 +4670,7 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ...........\TU/lmr/m/n/10 p
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4598,9 +4692,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.77+0.0)x7.22, direction TLT
 ..........\hbox(6.77+0.0)x7.22, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 T
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4614,9 +4710,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.0)x5.56, direction TLT
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 h
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4630,9 +4728,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+0.0)x2.78, direction TLT
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4646,9 +4746,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x3.94, direction TLT
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4662,9 +4764,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(0.0+0.0)x3.33, direction TLT
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4678,9 +4782,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+0.0)x2.78, direction TLT
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4694,9 +4800,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x3.94, direction TLT
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4710,9 +4818,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(0.0+0.0)x3.33, direction TLT
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4726,9 +4836,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.53+2.06)x5.0, direction TLT
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4742,9 +4854,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x4.44, direction TLT
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4758,9 +4872,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.15+0.11)x3.89, direction TLT
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4774,9 +4890,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.15+0.11)x3.89, direction TLT
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4790,9 +4908,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+0.0)x2.78, direction TLT
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4806,9 +4926,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.42+0.0)x5.56, direction TLT
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4822,9 +4944,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.53+2.06)x5.0, direction TLT
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4838,9 +4962,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(0.0+0.0)x3.33, direction TLT
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4854,9 +4980,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x3.94, direction TLT
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4870,9 +4998,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+0.0)x2.78, direction TLT
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4886,9 +5016,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.0)x2.78, direction TLT
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 l
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4902,9 +5034,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.0)x2.78, direction TLT
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 l
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4918,9 +5052,11 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.31+2.05)x5.28, direction TLT
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4944,6 +5080,7 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x29.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 E
 ...........\TU/lmr/m/n/10 l
 ...........\discretionary (penalty 50)
@@ -4953,6 +5090,7 @@ TEST 20: pgfmanual-en-tikz-decorations-20
 ...........\TU/lmr/m/n/10 p
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5014,9 +5152,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.77+0.0)x7.22, direction TLT
 ..........\hbox(6.77+0.0)x7.22, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 T
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5030,9 +5170,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.0)x5.56, direction TLT
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 h
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5046,9 +5188,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+0.0)x2.78, direction TLT
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5062,9 +5206,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x3.94, direction TLT
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5078,9 +5224,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(0.0+0.0)x3.33, direction TLT
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5094,9 +5242,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+0.0)x2.78, direction TLT
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5110,9 +5260,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x3.94, direction TLT
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5126,9 +5278,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(0.0+0.0)x3.33, direction TLT
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5142,9 +5296,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.53+2.06)x5.0, direction TLT
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5158,9 +5314,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x4.44, direction TLT
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5174,9 +5332,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.15+0.11)x3.89, direction TLT
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5190,9 +5350,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.15+0.11)x3.89, direction TLT
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5206,9 +5368,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+0.0)x2.78, direction TLT
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5222,9 +5386,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.42+0.0)x5.56, direction TLT
 ..........\hbox(4.42+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5238,9 +5404,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.53+2.06)x5.0, direction TLT
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5254,9 +5422,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(0.0+0.0)x3.33, direction TLT
 ..........\hbox(0.0+0.0)x3.33, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5270,9 +5440,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.48+0.11)x3.94, direction TLT
 ..........\hbox(4.48+0.11)x3.94, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5286,9 +5458,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.57+0.0)x2.78, direction TLT
 ..........\hbox(6.57+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 i
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5302,9 +5476,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.0)x2.78, direction TLT
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 l
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5318,9 +5494,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.94+0.0)x2.78, direction TLT
 ..........\hbox(6.94+0.0)x2.78, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 l
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5334,9 +5512,11 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.31+2.05)x5.28, direction TLT
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{0 G }
 ...........\pdfliteral origin{0 g }
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5358,6 +5538,7 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x29.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 E
 ...........\TU/lmr/m/n/10 l
 ...........\discretionary (penalty 50)
@@ -5367,6 +5548,7 @@ TEST 21: pgfmanual-en-tikz-decorations-21
 ...........\TU/lmr/m/n/10 p
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5462,9 +5644,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5478,9 +5662,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 r
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5494,9 +5680,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5510,9 +5698,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5526,9 +5716,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5542,9 +5734,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5558,9 +5752,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5574,9 +5770,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5590,9 +5788,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5606,9 +5806,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5622,9 +5824,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5638,9 +5842,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5654,9 +5860,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 r
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5670,9 +5878,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5686,9 +5896,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5702,9 +5914,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5718,9 +5932,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5734,9 +5950,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5750,9 +5968,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5766,9 +5986,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5782,9 +6004,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5798,9 +6022,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5814,9 +6040,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5830,9 +6058,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 r
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5846,9 +6076,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5862,9 +6094,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5878,9 +6112,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5894,9 +6130,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5910,9 +6148,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5926,9 +6166,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5942,9 +6184,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5958,9 +6202,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5974,9 +6220,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -5990,9 +6238,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 a
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6006,9 +6256,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x3.92, direction TLT
 ........\hbox(4.42+0.0)x3.92, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 r
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6022,9 +6274,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6038,9 +6292,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.11)x5.56, direction TLT
 ........\hbox(4.42+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 u
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6054,9 +6310,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.42+0.0)x5.56, direction TLT
 ........\hbox(4.42+0.0)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 n
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6070,9 +6328,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(6.94+0.11)x5.56, direction TLT
 ........\hbox(6.94+0.11)x5.56, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 d
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6086,9 +6346,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6102,9 +6364,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.31+0.11)x7.22, direction TLT
 ........\hbox(4.31+0.11)x7.22, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 w
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6118,9 +6382,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x4.44, direction TLT
 ........\hbox(4.48+0.11)x4.44, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 e
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6134,9 +6400,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(0.0+0.0)x3.33, direction TLT
 ........\hbox(0.0+0.0)x3.33, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6150,9 +6418,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.53+2.06)x5.0, direction TLT
 ........\hbox(4.53+2.06)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 g
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6166,9 +6436,11 @@ TEST 22: pgfmanual-en-tikz-decorations-22
 ......\hbox(0.0+0.0)x0.0, direction TLT
 .......\hbox(4.48+0.11)x5.0, direction TLT
 ........\hbox(4.48+0.11)x5.0, direction TLT
+.........\begindir TLT
 .........\pdfliteral origin{0 G }
 .........\pdfliteral origin{0 g }
 .........\TU/lmr/m/n/10 o
+.........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -6483,7 +6755,9 @@ TEST 24: pgfmanual-en-tikz-decorations-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6511,7 +6785,9 @@ TEST 24: pgfmanual-en-tikz-decorations-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-design.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-design.tlg
@@ -79,10 +79,12 @@ TEST 2: pgfmanual-en-tikz-design-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x17.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 x
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -138,11 +140,13 @@ TEST 3: pgfmanual-en-tikz-design-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -173,10 +177,12 @@ TEST 3: pgfmanual-en-tikz-design-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -219,12 +225,14 @@ TEST 3: pgfmanual-en-tikz-design-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -267,12 +275,14 @@ TEST 3: pgfmanual-en-tikz-design-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -315,12 +325,14 @@ TEST 3: pgfmanual-en-tikz-design-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -407,11 +419,13 @@ TEST 4: pgfmanual-en-tikz-design-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -458,10 +472,12 @@ TEST 4: pgfmanual-en-tikz-design-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -543,12 +559,14 @@ TEST 4: pgfmanual-en-tikz-design-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -616,12 +634,14 @@ TEST 4: pgfmanual-en-tikz-design-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -691,12 +711,14 @@ TEST 4: pgfmanual-en-tikz-design-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -782,8 +804,10 @@ TEST 5: pgfmanual-en-tikz-design-6
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -799,6 +823,7 @@ TEST 5: pgfmanual-en-tikz-design-6
 ..........\pdfliteral origin{1 G }
 ..........\pdfliteral origin{1 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 g 1 G}
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
@@ -806,6 +831,7 @@ TEST 5: pgfmanual-en-tikz-design-6
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -839,8 +865,10 @@ TEST 5: pgfmanual-en-tikz-design-6
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -856,12 +884,14 @@ TEST 5: pgfmanual-en-tikz-design-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -909,8 +939,10 @@ TEST 5: pgfmanual-en-tikz-design-6
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -926,6 +958,7 @@ TEST 5: pgfmanual-en-tikz-design-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
@@ -934,6 +967,7 @@ TEST 5: pgfmanual-en-tikz-design-6
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -978,8 +1012,10 @@ TEST 5: pgfmanual-en-tikz-design-6
 ............\glue -50.1875
 ............\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .............\hbox(100.375+0.0)x100.375, direction TLT
+..............\begindir TLT
 ..............\hbox(100.375+0.0)x100.375, direction TLT
 ...............\box(100.375+0.0)x100.375
+..............\enddir TLT
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
@@ -995,6 +1031,7 @@ TEST 5: pgfmanual-en-tikz-design-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 g 1 G}
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
@@ -1003,6 +1040,7 @@ TEST 5: pgfmanual-en-tikz-design-6
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1050,8 +1088,10 @@ TEST 5: pgfmanual-en-tikz-design-6
 ............\glue -50.1875
 ............\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .............\hbox(100.375+0.0)x100.375, direction TLT
+..............\begindir TLT
 ..............\hbox(100.375+0.0)x100.375, direction TLT
 ...............\box(100.375+0.0)x100.375
+..............\enddir TLT
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
@@ -1067,6 +1107,7 @@ TEST 5: pgfmanual-en-tikz-design-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 g 1 G}
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
@@ -1075,6 +1116,7 @@ TEST 5: pgfmanual-en-tikz-design-6
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1162,11 +1204,13 @@ TEST 6: pgfmanual-en-tikz-design-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x18.09, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 o
 .............\kern0.28 (font)
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1210,10 +1254,12 @@ TEST 6: pgfmanual-en-tikz-design-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1255,12 +1301,14 @@ TEST 6: pgfmanual-en-tikz-design-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1304,12 +1352,14 @@ TEST 6: pgfmanual-en-tikz-design-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x20.84, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 h
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-graphs.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-graphs.tlg
@@ -47,7 +47,9 @@ TEST 1: pgfmanual-en-tikz-graphs-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91,7 +93,9 @@ TEST 1: pgfmanual-en-tikz-graphs-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -133,7 +137,9 @@ TEST 1: pgfmanual-en-tikz-graphs-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -243,7 +249,9 @@ TEST 1: pgfmanual-en-tikz-graphs-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -397,7 +405,9 @@ TEST 2: pgfmanual-en-tikz-graphs-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -450,7 +460,9 @@ TEST 2: pgfmanual-en-tikz-graphs-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -503,7 +515,9 @@ TEST 2: pgfmanual-en-tikz-graphs-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -570,7 +584,9 @@ TEST 2: pgfmanual-en-tikz-graphs-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -623,7 +639,9 @@ TEST 2: pgfmanual-en-tikz-graphs-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -676,7 +694,9 @@ TEST 2: pgfmanual-en-tikz-graphs-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -729,7 +749,9 @@ TEST 2: pgfmanual-en-tikz-graphs-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1217,6 +1239,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1273,6 +1297,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1329,6 +1355,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1385,6 +1413,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1441,6 +1471,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1511,6 +1543,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1567,6 +1601,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1623,6 +1659,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1679,6 +1717,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1735,6 +1775,8 @@ TEST 3: pgfmanual-en-tikz-graphs-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2298,6 +2340,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2354,6 +2398,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2410,6 +2456,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2466,6 +2514,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2522,6 +2572,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2578,6 +2630,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2634,6 +2688,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2690,6 +2746,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2891,6 +2949,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2947,6 +3007,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3003,6 +3065,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3059,6 +3123,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3115,6 +3181,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3171,6 +3239,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3227,6 +3297,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3283,6 +3355,8 @@ TEST 4: pgfmanual-en-tikz-graphs-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3754,6 +3828,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3801,6 +3877,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3846,6 +3924,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3913,6 +3993,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3958,6 +4040,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4003,6 +4087,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4064,6 +4150,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4133,6 +4221,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4250,6 +4340,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4295,6 +4387,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4356,6 +4450,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4425,6 +4521,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4498,6 +4596,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4543,6 +4643,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4594,6 +4696,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4639,6 +4743,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4684,6 +4790,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4745,6 +4853,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4814,6 +4924,8 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5164,7 +5276,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5213,9 +5327,11 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(7.05+0.0)x3.06, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 f
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5264,7 +5380,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5311,7 +5429,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.42+0.0)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5358,7 +5478,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.42+0.0)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5405,7 +5527,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5452,7 +5576,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.0)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5499,7 +5625,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5546,7 +5674,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.42+0.0)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5593,7 +5723,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5642,9 +5774,11 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 a
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5695,9 +5829,11 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.42+0.0)x5.56, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 n
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5746,7 +5882,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5793,7 +5931,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5840,7 +5980,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.0)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5887,7 +6029,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5934,7 +6078,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.42+0.0)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5981,7 +6127,9 @@ TEST 5: pgfmanual-en-tikz-graphs-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6056,10 +6204,12 @@ TEST 6: pgfmanual-en-tikz-graphs-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 o
 .............\kern0.28 (font)
 .............\TU/lmr/m/n/10 o
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6103,9 +6253,11 @@ TEST 6: pgfmanual-en-tikz-graphs-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x14.48, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6182,10 +6334,12 @@ TEST 6: pgfmanual-en-tikz-graphs-6
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x19.45999, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 u
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6302,7 +6456,9 @@ TEST 7: pgfmanual-en-tikz-graphs-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6344,7 +6500,9 @@ TEST 7: pgfmanual-en-tikz-graphs-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6419,7 +6577,9 @@ TEST 7: pgfmanual-en-tikz-graphs-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6498,7 +6658,9 @@ TEST 7: pgfmanual-en-tikz-graphs-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6540,7 +6702,9 @@ TEST 7: pgfmanual-en-tikz-graphs-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6615,7 +6779,9 @@ TEST 7: pgfmanual-en-tikz-graphs-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6694,7 +6860,9 @@ TEST 7: pgfmanual-en-tikz-graphs-7
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6824,11 +6992,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x10.2014, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 x
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6875,6 +7045,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(4.30554+1.49998)x10.2014, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\mathon
 .............\OML/cmm/m/it/10 x
@@ -6882,6 +7053,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6958,6 +7130,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x24.84721, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 x
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -6968,6 +7141,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 4
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7149,11 +7323,13 @@ TEST 9: pgfmanual-en-tikz-graphs-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x10.2014, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 x
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7203,6 +7379,7 @@ TEST 9: pgfmanual-en-tikz-graphs-9
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(4.30554+1.49998)x10.2014, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\mathon
 .............\OML/cmm/m/it/10 x
@@ -7210,6 +7387,7 @@ TEST 9: pgfmanual-en-tikz-graphs-9
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7288,6 +7466,7 @@ TEST 9: pgfmanual-en-tikz-graphs-9
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x24.84721, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 x
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
@@ -7298,6 +7477,7 @@ TEST 9: pgfmanual-en-tikz-graphs-9
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 4
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7482,7 +7662,9 @@ TEST 10: pgfmanual-en-tikz-graphs-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7526,7 +7708,9 @@ TEST 10: pgfmanual-en-tikz-graphs-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7568,7 +7752,9 @@ TEST 10: pgfmanual-en-tikz-graphs-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7643,7 +7829,9 @@ TEST 10: pgfmanual-en-tikz-graphs-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7685,7 +7873,9 @@ TEST 10: pgfmanual-en-tikz-graphs-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7834,7 +8024,9 @@ TEST 10: pgfmanual-en-tikz-graphs-10
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7988,11 +8180,13 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x18.09, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 o
 .............\kern0.28 (font)
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8036,6 +8230,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x29.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 h
@@ -8044,6 +8239,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 .............\TU/lmr/m/n/10 d
 .............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8085,6 +8281,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x29.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 h
@@ -8093,6 +8290,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 .............\TU/lmr/m/n/10 d
 .............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8136,6 +8334,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x57.54, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 a
@@ -8150,6 +8349,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 .............\TU/lmr/m/n/10 d
 .............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8191,6 +8391,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x57.54, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 a
@@ -8205,6 +8406,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 .............\TU/lmr/m/n/10 d
 .............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8312,6 +8514,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.22)x29.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 h
@@ -8320,6 +8523,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 .............\TU/lmr/m/n/10 d
 .............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8363,6 +8567,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x57.54, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 a
@@ -8377,6 +8582,7 @@ TEST 11: pgfmanual-en-tikz-graphs-11
 .............\TU/lmr/m/n/10 d
 .............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8600,7 +8806,9 @@ TEST 12: pgfmanual-en-tikz-graphs-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8642,7 +8850,9 @@ TEST 12: pgfmanual-en-tikz-graphs-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8725,7 +8935,9 @@ TEST 12: pgfmanual-en-tikz-graphs-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8767,7 +8979,9 @@ TEST 12: pgfmanual-en-tikz-graphs-12
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8924,7 +9138,9 @@ TEST 13: pgfmanual-en-tikz-graphs-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8966,7 +9182,9 @@ TEST 13: pgfmanual-en-tikz-graphs-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9032,12 +9250,14 @@ TEST 13: pgfmanual-en-tikz-graphs-13
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(7.05+0.11)x13.34, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 f
 ...............\TU/lmr/m/n/10 o
 ...............\kern0.28 (font)
 ...............\TU/lmr/m/n/10 o
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9081,7 +9301,9 @@ TEST 13: pgfmanual-en-tikz-graphs-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9123,7 +9345,9 @@ TEST 13: pgfmanual-en-tikz-graphs-13
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9200,9 +9424,11 @@ TEST 13: pgfmanual-en-tikz-graphs-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x14.48, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
 ...............\TU/lmr/m/n/10 a
 ...............\TU/lmr/m/n/10 r
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9249,9 +9475,11 @@ TEST 13: pgfmanual-en-tikz-graphs-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x14.48, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
 ...............\TU/lmr/m/n/10 a
 ...............\TU/lmr/m/n/10 r
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9336,7 +9564,9 @@ TEST 14: pgfmanual-en-tikz-graphs-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9378,7 +9608,9 @@ TEST 14: pgfmanual-en-tikz-graphs-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9455,7 +9687,9 @@ TEST 14: pgfmanual-en-tikz-graphs-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9497,7 +9731,9 @@ TEST 14: pgfmanual-en-tikz-graphs-14
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9571,10 +9807,12 @@ TEST 14: pgfmanual-en-tikz-graphs-14
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.11)x13.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
 ...............\TU/lmr/m/n/10 o
 ...............\kern0.28 (font)
 ...............\TU/lmr/m/n/10 o
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9619,9 +9857,11 @@ TEST 14: pgfmanual-en-tikz-graphs-14
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x14.48, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
 ...............\TU/lmr/m/n/10 a
 ...............\TU/lmr/m/n/10 r
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9705,7 +9945,9 @@ TEST 15: pgfmanual-en-tikz-graphs-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9747,7 +9989,9 @@ TEST 15: pgfmanual-en-tikz-graphs-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9829,7 +10073,9 @@ TEST 15: pgfmanual-en-tikz-graphs-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9871,7 +10117,9 @@ TEST 15: pgfmanual-en-tikz-graphs-15
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9967,9 +10215,11 @@ TEST 15: pgfmanual-en-tikz-graphs-15
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x14.48, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
 ...............\TU/lmr/m/n/10 a
 ...............\TU/lmr/m/n/10 r
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10064,6 +10314,8 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10109,7 +10361,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10173,7 +10427,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 9
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10219,7 +10475,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10267,7 +10525,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10313,7 +10573,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10387,7 +10649,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 2
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10438,7 +10702,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10483,7 +10749,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+2.05)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10567,7 +10835,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.77+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 4
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10620,7 +10890,9 @@ TEST 16: pgfmanual-en-tikz-graphs-16
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.76+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 7
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10687,7 +10959,9 @@ TEST 17: pgfmanual-en-tikz-graphs-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10715,7 +10989,9 @@ TEST 17: pgfmanual-en-tikz-graphs-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10743,7 +11019,9 @@ TEST 17: pgfmanual-en-tikz-graphs-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10905,7 +11183,9 @@ TEST 18: pgfmanual-en-tikz-graphs-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10935,7 +11215,9 @@ TEST 18: pgfmanual-en-tikz-graphs-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10966,7 +11248,9 @@ TEST 18: pgfmanual-en-tikz-graphs-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11002,7 +11286,9 @@ TEST 18: pgfmanual-en-tikz-graphs-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11043,7 +11329,9 @@ TEST 18: pgfmanual-en-tikz-graphs-18
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+0.0)x7.5, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 X
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11301,7 +11589,9 @@ TEST 19: pgfmanual-en-tikz-graphs-19
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11354,7 +11644,9 @@ TEST 19: pgfmanual-en-tikz-graphs-19
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11407,7 +11699,9 @@ TEST 19: pgfmanual-en-tikz-graphs-19
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11460,7 +11754,9 @@ TEST 19: pgfmanual-en-tikz-graphs-19
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11513,7 +11809,9 @@ TEST 19: pgfmanual-en-tikz-graphs-19
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11566,7 +11864,9 @@ TEST 19: pgfmanual-en-tikz-graphs-19
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11966,7 +12266,9 @@ TEST 20: pgfmanual-en-tikz-graphs-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12019,7 +12321,9 @@ TEST 20: pgfmanual-en-tikz-graphs-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12072,7 +12376,9 @@ TEST 20: pgfmanual-en-tikz-graphs-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12125,7 +12431,9 @@ TEST 20: pgfmanual-en-tikz-graphs-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12178,7 +12486,9 @@ TEST 20: pgfmanual-en-tikz-graphs-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12344,9 +12654,11 @@ TEST 20: pgfmanual-en-tikz-graphs-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x16.67, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12575,6 +12887,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12635,6 +12949,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12695,6 +13011,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12755,6 +13073,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12815,6 +13135,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12875,6 +13197,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12935,6 +13259,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12995,6 +13321,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13069,6 +13397,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13129,6 +13459,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13189,6 +13521,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13249,6 +13583,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13309,6 +13645,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13369,6 +13707,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13429,6 +13769,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13489,6 +13831,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13904,6 +14248,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13964,6 +14310,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14024,6 +14372,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14084,6 +14434,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14144,6 +14496,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14204,6 +14558,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14264,6 +14620,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14324,6 +14682,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14803,6 +15163,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14863,6 +15225,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14923,6 +15287,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14983,6 +15349,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15043,6 +15411,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15103,6 +15473,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15163,6 +15535,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15223,6 +15597,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15766,6 +16142,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15826,6 +16204,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15886,6 +16266,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -15946,6 +16328,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16006,6 +16390,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16066,6 +16452,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16126,6 +16514,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16186,6 +16576,8 @@ TEST 21: pgfmanual-en-tikz-graphs-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16555,9 +16947,11 @@ TEST 22: pgfmanual-en-tikz-graphs-22
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 a
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16605,9 +16999,11 @@ TEST 22: pgfmanual-en-tikz-graphs-22
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 b
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16688,9 +17084,11 @@ TEST 22: pgfmanual-en-tikz-graphs-22
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 c
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16808,7 +17206,9 @@ TEST 23: pgfmanual-en-tikz-graphs-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16850,7 +17250,9 @@ TEST 23: pgfmanual-en-tikz-graphs-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16934,7 +17336,9 @@ TEST 23: pgfmanual-en-tikz-graphs-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17056,7 +17460,9 @@ TEST 24: pgfmanual-en-tikz-graphs-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17098,7 +17504,9 @@ TEST 24: pgfmanual-en-tikz-graphs-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17165,9 +17573,11 @@ TEST 24: pgfmanual-en-tikz-graphs-24
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 X
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17208,7 +17618,9 @@ TEST 24: pgfmanual-en-tikz-graphs-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17279,9 +17691,11 @@ TEST 24: pgfmanual-en-tikz-graphs-24
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 X
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17360,7 +17774,9 @@ TEST 25: pgfmanual-en-tikz-graphs-25
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17402,7 +17818,9 @@ TEST 25: pgfmanual-en-tikz-graphs-25
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17464,7 +17882,9 @@ TEST 25: pgfmanual-en-tikz-graphs-25
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 X
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17490,7 +17910,9 @@ TEST 25: pgfmanual-en-tikz-graphs-25
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 Y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17530,7 +17952,9 @@ TEST 25: pgfmanual-en-tikz-graphs-25
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17596,7 +18020,9 @@ TEST 25: pgfmanual-en-tikz-graphs-25
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 X
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17622,7 +18048,9 @@ TEST 25: pgfmanual-en-tikz-graphs-25
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 Y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17700,7 +18128,9 @@ TEST 26: pgfmanual-en-tikz-graphs-26
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17742,7 +18172,9 @@ TEST 26: pgfmanual-en-tikz-graphs-26
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17804,7 +18236,9 @@ TEST 26: pgfmanual-en-tikz-graphs-26
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 x
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17846,7 +18280,9 @@ TEST 26: pgfmanual-en-tikz-graphs-26
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17888,7 +18324,9 @@ TEST 26: pgfmanual-en-tikz-graphs-26
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -17964,7 +18402,9 @@ TEST 26: pgfmanual-en-tikz-graphs-26
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 x
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18011,7 +18451,9 @@ TEST 26: pgfmanual-en-tikz-graphs-26
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 x
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18104,7 +18546,9 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18157,7 +18601,9 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18210,7 +18656,9 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18263,7 +18711,9 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18316,7 +18766,9 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18388,9 +18840,11 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.15+0.11)x14.45, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 u
 ...............\TU/lmr/m/n/10 t
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18414,8 +18868,10 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+0.0)x8.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18461,9 +18917,11 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.15+0.11)x14.45, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 u
 ...............\TU/lmr/m/n/10 t
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18489,8 +18947,10 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+0.0)x8.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18536,9 +18996,11 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.15+0.11)x14.45, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 u
 ...............\TU/lmr/m/n/10 t
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18564,8 +19026,10 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+0.0)x8.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18609,9 +19073,11 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.15+0.11)x14.45, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 u
 ...............\TU/lmr/m/n/10 t
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18635,8 +19101,10 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+0.0)x8.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18681,9 +19149,11 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.15+0.11)x14.45, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 u
 ...............\TU/lmr/m/n/10 t
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18709,8 +19179,10 @@ TEST 27: pgfmanual-en-tikz-graphs-27
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+0.0)x8.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18792,7 +19264,9 @@ TEST 28: pgfmanual-en-tikz-graphs-28
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18834,7 +19308,9 @@ TEST 28: pgfmanual-en-tikz-graphs-28
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18909,7 +19385,9 @@ TEST 28: pgfmanual-en-tikz-graphs-28
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18951,7 +19429,9 @@ TEST 28: pgfmanual-en-tikz-graphs-28
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18993,7 +19473,9 @@ TEST 28: pgfmanual-en-tikz-graphs-28
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19068,7 +19550,9 @@ TEST 28: pgfmanual-en-tikz-graphs-28
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19192,9 +19676,11 @@ TEST 29: pgfmanual-en-tikz-graphs-29
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 a
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19244,9 +19730,11 @@ TEST 29: pgfmanual-en-tikz-graphs-29
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\TU/lmr/m/n/10 b
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19331,9 +19819,11 @@ TEST 29: pgfmanual-en-tikz-graphs-29
 ............\pdfliteral origin{0.75 0.5 0.25 RG }
 ............\pdfliteral origin{0.75 0.5 0.25 rg }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.75 0.5 0.25 rg 0.75 0.5 0.25 RG}
 .............\TU/lmr/m/n/10 c
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19414,7 +19904,9 @@ TEST 30: pgfmanual-en-tikz-graphs-30
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19463,9 +19955,11 @@ TEST 30: pgfmanual-en-tikz-graphs-30
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 b
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19513,9 +20007,11 @@ TEST 30: pgfmanual-en-tikz-graphs-30
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 c
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19624,7 +20120,9 @@ TEST 30: pgfmanual-en-tikz-graphs-30
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19768,9 +20266,11 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x5.28589, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 a
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19818,11 +20318,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x9.77202, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 a
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19866,11 +20368,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x10.2014, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 x
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -19912,11 +20416,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.38895, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 y
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20035,11 +20541,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x9.77202, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 a
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20083,11 +20591,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x10.2014, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 x
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20129,11 +20639,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.38895, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 y
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20252,11 +20764,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x9.77202, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 a
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20300,11 +20814,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x10.2014, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 x
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20346,11 +20862,13 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.38895, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 y
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20468,9 +20986,11 @@ TEST 31: pgfmanual-en-tikz-graphs-31
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94444+0.0)x4.29166, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 b
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20691,7 +21211,9 @@ TEST 32: pgfmanual-en-tikz-graphs-32
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20733,7 +21255,9 @@ TEST 32: pgfmanual-en-tikz-graphs-32
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20808,7 +21332,9 @@ TEST 32: pgfmanual-en-tikz-graphs-32
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20887,7 +21413,9 @@ TEST 32: pgfmanual-en-tikz-graphs-32
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20929,7 +21457,9 @@ TEST 32: pgfmanual-en-tikz-graphs-32
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21053,7 +21583,9 @@ TEST 33: pgfmanual-en-tikz-graphs-33
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21095,7 +21627,9 @@ TEST 33: pgfmanual-en-tikz-graphs-33
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21170,7 +21704,9 @@ TEST 33: pgfmanual-en-tikz-graphs-33
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21249,7 +21785,9 @@ TEST 33: pgfmanual-en-tikz-graphs-33
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21374,7 +21912,9 @@ TEST 34: pgfmanual-en-tikz-graphs-34
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21416,7 +21956,9 @@ TEST 34: pgfmanual-en-tikz-graphs-34
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21458,7 +22000,9 @@ TEST 34: pgfmanual-en-tikz-graphs-34
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21518,7 +22062,9 @@ TEST 34: pgfmanual-en-tikz-graphs-34
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21560,7 +22106,9 @@ TEST 34: pgfmanual-en-tikz-graphs-34
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21602,7 +22150,9 @@ TEST 34: pgfmanual-en-tikz-graphs-34
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21934,7 +22484,9 @@ TEST 35: pgfmanual-en-tikz-graphs-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21976,7 +22528,9 @@ TEST 35: pgfmanual-en-tikz-graphs-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22018,7 +22572,9 @@ TEST 35: pgfmanual-en-tikz-graphs-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22078,7 +22634,9 @@ TEST 35: pgfmanual-en-tikz-graphs-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22120,7 +22678,9 @@ TEST 35: pgfmanual-en-tikz-graphs-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22162,7 +22722,9 @@ TEST 35: pgfmanual-en-tikz-graphs-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22429,7 +22991,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22471,7 +23035,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22546,7 +23112,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22588,7 +23156,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22660,7 +23230,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22702,7 +23274,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22777,7 +23351,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22819,7 +23395,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22899,7 +23477,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+0.0)x2.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 i
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22941,7 +23521,9 @@ TEST 36: pgfmanual-en-tikz-graphs-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+2.05)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23040,7 +23622,9 @@ TEST 37: pgfmanual-en-tikz-graphs-37
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23082,7 +23666,9 @@ TEST 37: pgfmanual-en-tikz-graphs-37
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23157,7 +23743,9 @@ TEST 37: pgfmanual-en-tikz-graphs-37
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23288,7 +23876,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23332,7 +23922,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23376,7 +23968,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23418,7 +24012,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23526,7 +24122,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23570,7 +24168,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23612,7 +24212,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23720,7 +24322,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23764,7 +24368,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23806,7 +24412,9 @@ TEST 38: pgfmanual-en-tikz-graphs-38
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24132,7 +24740,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24176,7 +24786,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24220,7 +24832,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24262,7 +24876,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24370,7 +24986,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24414,7 +25032,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24456,7 +25076,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24564,7 +25186,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24608,7 +25232,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24650,7 +25276,9 @@ TEST 39: pgfmanual-en-tikz-graphs-39
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24976,7 +25604,9 @@ TEST 40: pgfmanual-en-tikz-graphs-40
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25018,7 +25648,9 @@ TEST 40: pgfmanual-en-tikz-graphs-40
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25060,7 +25692,9 @@ TEST 40: pgfmanual-en-tikz-graphs-40
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25120,7 +25754,9 @@ TEST 40: pgfmanual-en-tikz-graphs-40
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25162,7 +25798,9 @@ TEST 40: pgfmanual-en-tikz-graphs-40
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25204,7 +25842,9 @@ TEST 40: pgfmanual-en-tikz-graphs-40
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25395,7 +26035,9 @@ TEST 41: pgfmanual-en-tikz-graphs-41
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25437,7 +26079,9 @@ TEST 41: pgfmanual-en-tikz-graphs-41
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25479,7 +26123,9 @@ TEST 41: pgfmanual-en-tikz-graphs-41
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25539,7 +26185,9 @@ TEST 41: pgfmanual-en-tikz-graphs-41
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25581,7 +26229,9 @@ TEST 41: pgfmanual-en-tikz-graphs-41
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25623,7 +26273,9 @@ TEST 41: pgfmanual-en-tikz-graphs-41
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25814,7 +26466,9 @@ TEST 42: pgfmanual-en-tikz-graphs-42
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25856,7 +26510,9 @@ TEST 42: pgfmanual-en-tikz-graphs-42
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25898,7 +26554,9 @@ TEST 42: pgfmanual-en-tikz-graphs-42
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25958,7 +26616,9 @@ TEST 42: pgfmanual-en-tikz-graphs-42
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26000,7 +26660,9 @@ TEST 42: pgfmanual-en-tikz-graphs-42
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26042,7 +26704,9 @@ TEST 42: pgfmanual-en-tikz-graphs-42
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26229,9 +26893,11 @@ TEST 43: pgfmanual-en-tikz-graphs-43
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x5.71527, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 x
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26273,11 +26939,13 @@ TEST 43: pgfmanual-en-tikz-graphs-43
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.38895, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 y
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 5
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26354,6 +27022,7 @@ TEST 43: pgfmanual-en-tikz-graphs-43
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(6.94+0.11)x15.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 a
 .............\discretionary (penalty 50)
@@ -26361,6 +27030,7 @@ TEST 43: pgfmanual-en-tikz-graphs-43
 ..............= \TU/lmr/m/n/10 –
 .............\TU/lmr/m/n/10 b
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26478,9 +27148,11 @@ TEST 44: pgfmanual-en-tikz-graphs-44
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.5+2.5)x12.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 (
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 )
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26522,9 +27194,11 @@ TEST 44: pgfmanual-en-tikz-graphs-44
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.5+2.5)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 (
 .............\TU/lmr/m/n/10 b
 .............\TU/lmr/m/n/10 )
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26599,9 +27273,11 @@ TEST 44: pgfmanual-en-tikz-graphs-44
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.5+2.5)x12.22, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 (
 .............\TU/lmr/m/n/10 c
 .............\TU/lmr/m/n/10 )
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26722,6 +27398,7 @@ TEST 45: pgfmanual-en-tikz-graphs-45
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+2.86108)x26.59035, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 a
 .............\hbox(4.51111+1.3611)x21.30446, shifted 1.49998, direction TLT
@@ -26734,6 +27411,7 @@ TEST 45: pgfmanual-en-tikz-graphs-45
 ..............\OML/cmm/m/it/7 ;
 ..............\OML/cmm/m/it/7 n
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26775,6 +27453,7 @@ TEST 45: pgfmanual-en-tikz-graphs-45
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94444+2.86108)x27.7489, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 b
 .............\hbox(4.51111+1.3611)x23.45724, shifted 1.49998, direction TLT
@@ -26787,6 +27466,7 @@ TEST 45: pgfmanual-en-tikz-graphs-45
 ..............\OML/cmm/m/it/7 ;
 ..............\OML/cmm/m/it/7 m
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26861,6 +27541,7 @@ TEST 45: pgfmanual-en-tikz-graphs-45
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+2.86108)x32.72813, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 c
 .............\hbox(4.51111+1.3611)x28.40057, shifted 1.49998, direction TLT
@@ -26874,6 +27555,7 @@ TEST 45: pgfmanual-en-tikz-graphs-45
 ..............\OML/cmm/m/it/7 n
 ..............\OML/cmm/m/it/7 m
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26994,6 +27676,8 @@ TEST 46: pgfmanual-en-tikz-graphs-46
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27041,6 +27725,8 @@ TEST 46: pgfmanual-en-tikz-graphs-46
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27086,6 +27772,8 @@ TEST 46: pgfmanual-en-tikz-graphs-46
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27225,11 +27913,13 @@ TEST 47: pgfmanual-en-tikz-graphs-47
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x9.77202, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 a
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27277,11 +27967,13 @@ TEST 47: pgfmanual-en-tikz-graphs-47
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(8.14003+0.0)x8.77779, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 b
 .............\hbox(4.51111+0.0)x4.48613, shifted -3.62892, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27327,6 +28019,7 @@ TEST 47: pgfmanual-en-tikz-graphs-47
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.6428+2.4821)x9.77089, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 c
 .............\vbox(9.12491+0.0)x5.44333, shifted 2.4821, direction TLT
@@ -27336,6 +28029,7 @@ TEST 47: pgfmanual-en-tikz-graphs-47
 ..............\hbox(4.51111+0.0)x4.48613, direction TLT
 ...............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27476,6 +28170,7 @@ TEST 48: pgfmanual-en-tikz-graphs-48
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.16+1.93)x45.87999, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 H
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 ,
@@ -27487,6 +28182,7 @@ TEST 48: pgfmanual-en-tikz-graphs-48
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 d
 .............\TU/lmr/m/n/10 !
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27536,6 +28232,7 @@ TEST 48: pgfmanual-en-tikz-graphs-48
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(7.16+1.94)x63.49002, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 I
 .............\TU/lmr/m/n/10 t
@@ -27559,6 +28256,7 @@ TEST 48: pgfmanual-en-tikz-graphs-48
 .............\kern0.61 (italic)
 .............\TU/lmr/m/n/10 !
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27637,6 +28335,7 @@ TEST 48: pgfmanual-en-tikz-graphs-48
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x47.5, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 c
 .............\discretionary (penalty 50)
@@ -27650,6 +28349,7 @@ TEST 48: pgfmanual-en-tikz-graphs-48
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27788,6 +28488,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ..........\pdfliteral origin{1 0.2 0.2 RG }
 ..........\pdfliteral origin{1 0.2 0.2 rg }
 ..........\hbox(4.30554+1.49998)x8.99771, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.2 0.2 rg 1 0.2 0.2 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 r
@@ -27795,6 +28496,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27830,6 +28532,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(4.30554+1.94444)x9.25581, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 g
@@ -27837,6 +28540,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27873,6 +28577,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ..........\pdfliteral origin{1 0.2 0.2 RG }
 ..........\pdfliteral origin{1 0.2 0.2 rg }
 ..........\hbox(4.30554+1.49998)x8.99771, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.2 0.2 rg 1 0.2 0.2 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 r
@@ -27880,6 +28585,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27915,6 +28621,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(4.30554+1.94444)x9.25581, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 g
@@ -27922,6 +28629,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -27958,6 +28666,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ..........\pdfliteral origin{1 0.2 0.2 RG }
 ..........\pdfliteral origin{1 0.2 0.2 rg }
 ..........\hbox(4.30554+1.49998)x8.99771, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.2 0.2 rg 1 0.2 0.2 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 r
@@ -27965,6 +28674,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28000,6 +28710,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ..........\pdfliteral origin{0 0.5 0 RG }
 ..........\pdfliteral origin{0 0.5 0 rg }
 ..........\hbox(4.30554+1.94444)x9.25581, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 g
@@ -28007,6 +28718,7 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28048,11 +28760,13 @@ TEST 49: pgfmanual-en-tikz-graphs-50
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x18.09, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 o
 .............\kern0.28 (font)
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28463,11 +29177,13 @@ TEST 50: pgfmanual-en-tikz-graphs-51
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.30554+0.0)x5.28589, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 a
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28501,11 +29217,13 @@ TEST 50: pgfmanual-en-tikz-graphs-51
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94444+0.0)x4.29166, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 b
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28539,11 +29257,13 @@ TEST 50: pgfmanual-en-tikz-graphs-51
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94444+0.0)x5.20486, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 d
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -28646,7 +29366,9 @@ TEST 50: pgfmanual-en-tikz-graphs-51
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28775,7 +29497,9 @@ TEST 50: pgfmanual-en-tikz-graphs-51
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28905,7 +29629,9 @@ TEST 51: pgfmanual-en-tikz-graphs-52
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28949,7 +29675,9 @@ TEST 51: pgfmanual-en-tikz-graphs-52
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -28991,7 +29719,9 @@ TEST 51: pgfmanual-en-tikz-graphs-52
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29033,7 +29763,9 @@ TEST 51: pgfmanual-en-tikz-graphs-52
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29168,7 +29900,9 @@ TEST 51: pgfmanual-en-tikz-graphs-52
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29212,7 +29946,9 @@ TEST 51: pgfmanual-en-tikz-graphs-52
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29254,7 +29990,9 @@ TEST 51: pgfmanual-en-tikz-graphs-52
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29362,7 +30100,9 @@ TEST 51: pgfmanual-en-tikz-graphs-52
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29549,7 +30289,9 @@ TEST 52: pgfmanual-en-tikz-graphs-53
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29593,7 +30335,9 @@ TEST 52: pgfmanual-en-tikz-graphs-53
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29635,7 +30379,9 @@ TEST 52: pgfmanual-en-tikz-graphs-53
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29679,7 +30425,9 @@ TEST 52: pgfmanual-en-tikz-graphs-53
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29721,7 +30469,9 @@ TEST 52: pgfmanual-en-tikz-graphs-53
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -29829,7 +30579,9 @@ TEST 52: pgfmanual-en-tikz-graphs-53
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -30409,7 +31161,9 @@ TEST 53: pgfmanual-en-tikz-graphs-54
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -30455,7 +31209,9 @@ TEST 53: pgfmanual-en-tikz-graphs-54
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -30501,7 +31257,9 @@ TEST 53: pgfmanual-en-tikz-graphs-54
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -30547,7 +31305,9 @@ TEST 53: pgfmanual-en-tikz-graphs-54
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -30593,7 +31353,9 @@ TEST 53: pgfmanual-en-tikz-graphs-54
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -30639,7 +31401,9 @@ TEST 53: pgfmanual-en-tikz-graphs-54
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31118,7 +31882,9 @@ TEST 54: pgfmanual-en-tikz-graphs-55
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31164,9 +31930,11 @@ TEST 54: pgfmanual-en-tikz-graphs-55
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x13.89, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
 .................\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31212,11 +31980,13 @@ TEST 54: pgfmanual-en-tikz-graphs-55
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x22.22, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
 .................\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .................\TU/lmr/m/n/10 b
 .................\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31262,11 +32032,13 @@ TEST 54: pgfmanual-en-tikz-graphs-55
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x21.66, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
 .................\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .................\TU/lmr/m/n/10 b
 .................\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31312,9 +32084,11 @@ TEST 54: pgfmanual-en-tikz-graphs-55
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x13.89, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
 .................\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31360,9 +32134,11 @@ TEST 54: pgfmanual-en-tikz-graphs-55
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x13.33, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
 .................\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31442,7 +32218,9 @@ TEST 55: pgfmanual-en-tikz-graphs-56
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31486,7 +32264,9 @@ TEST 55: pgfmanual-en-tikz-graphs-56
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31528,7 +32308,9 @@ TEST 55: pgfmanual-en-tikz-graphs-56
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31570,7 +32352,9 @@ TEST 55: pgfmanual-en-tikz-graphs-56
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31818,7 +32602,9 @@ TEST 56: pgfmanual-en-tikz-graphs-57
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31846,7 +32632,9 @@ TEST 56: pgfmanual-en-tikz-graphs-57
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31888,10 +32676,12 @@ TEST 56: pgfmanual-en-tikz-graphs-57
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.11)x13.34, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
 ...............\TU/lmr/m/n/10 o
 ...............\kern0.28 (font)
 ...............\TU/lmr/m/n/10 o
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -31958,9 +32748,11 @@ TEST 57: pgfmanual-en-tikz-graphs-58
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x5.28589, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 a
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -31988,7 +32780,9 @@ TEST 57: pgfmanual-en-tikz-graphs-58
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32034,7 +32828,9 @@ TEST 57: pgfmanual-en-tikz-graphs-58
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32093,9 +32889,11 @@ TEST 57: pgfmanual-en-tikz-graphs-58
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\TU/lmr/m/n/10 d
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32186,7 +32984,9 @@ TEST 58: pgfmanual-en-tikz-graphs-59
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32228,7 +33028,9 @@ TEST 58: pgfmanual-en-tikz-graphs-59
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32423,7 +33225,9 @@ TEST 59: pgfmanual-en-tikz-graphs-60
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32465,7 +33269,9 @@ TEST 59: pgfmanual-en-tikz-graphs-60
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32643,7 +33449,9 @@ TEST 60: pgfmanual-en-tikz-graphs-61
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32685,7 +33493,9 @@ TEST 60: pgfmanual-en-tikz-graphs-61
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32727,7 +33537,9 @@ TEST 60: pgfmanual-en-tikz-graphs-61
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32769,7 +33581,9 @@ TEST 60: pgfmanual-en-tikz-graphs-61
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32829,7 +33643,9 @@ TEST 60: pgfmanual-en-tikz-graphs-61
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32871,7 +33687,9 @@ TEST 60: pgfmanual-en-tikz-graphs-61
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32913,7 +33731,9 @@ TEST 60: pgfmanual-en-tikz-graphs-61
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -32955,7 +33775,9 @@ TEST 60: pgfmanual-en-tikz-graphs-61
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33660,7 +34482,9 @@ TEST 61: pgfmanual-en-tikz-graphs-62
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33713,7 +34537,9 @@ TEST 61: pgfmanual-en-tikz-graphs-62
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33766,7 +34592,9 @@ TEST 61: pgfmanual-en-tikz-graphs-62
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33819,7 +34647,9 @@ TEST 61: pgfmanual-en-tikz-graphs-62
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33872,7 +34702,9 @@ TEST 61: pgfmanual-en-tikz-graphs-62
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33925,7 +34757,9 @@ TEST 61: pgfmanual-en-tikz-graphs-62
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -33978,7 +34812,9 @@ TEST 61: pgfmanual-en-tikz-graphs-62
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34031,7 +34867,9 @@ TEST 61: pgfmanual-en-tikz-graphs-62
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34790,7 +35628,9 @@ TEST 62: pgfmanual-en-tikz-graphs-63
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34832,7 +35672,9 @@ TEST 62: pgfmanual-en-tikz-graphs-63
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34892,7 +35734,9 @@ TEST 62: pgfmanual-en-tikz-graphs-63
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -34934,7 +35778,9 @@ TEST 62: pgfmanual-en-tikz-graphs-63
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35010,9 +35856,11 @@ TEST 62: pgfmanual-en-tikz-graphs-63
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 x
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35065,9 +35913,11 @@ TEST 62: pgfmanual-en-tikz-graphs-63
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 x
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35127,9 +35977,11 @@ TEST 62: pgfmanual-en-tikz-graphs-63
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 x
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35182,9 +36034,11 @@ TEST 62: pgfmanual-en-tikz-graphs-63
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 x
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35272,7 +36126,9 @@ TEST 63: pgfmanual-en-tikz-graphs-64
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35314,7 +36170,9 @@ TEST 63: pgfmanual-en-tikz-graphs-64
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35376,7 +36234,9 @@ TEST 63: pgfmanual-en-tikz-graphs-64
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 x
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35416,7 +36276,9 @@ TEST 63: pgfmanual-en-tikz-graphs-64
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35482,7 +36344,9 @@ TEST 63: pgfmanual-en-tikz-graphs-64
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+2.05)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35522,7 +36386,9 @@ TEST 63: pgfmanual-en-tikz-graphs-64
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35597,9 +36463,11 @@ TEST 63: pgfmanual-en-tikz-graphs-64
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.31+0.0)x4.44, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 z
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35683,7 +36551,9 @@ TEST 64: pgfmanual-en-tikz-graphs-65
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35725,7 +36595,9 @@ TEST 64: pgfmanual-en-tikz-graphs-65
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35792,9 +36664,11 @@ TEST 64: pgfmanual-en-tikz-graphs-65
 ..............\pdfliteral origin{0 0 1 RG }
 ..............\pdfliteral origin{0 0 1 rg }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...............\TU/lmr/m/n/10 x
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35835,7 +36709,9 @@ TEST 64: pgfmanual-en-tikz-graphs-65
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -35906,9 +36782,11 @@ TEST 64: pgfmanual-en-tikz-graphs-65
 ..............\pdfliteral origin{0 0 1 RG }
 ..............\pdfliteral origin{0 0 1 rg }
 ..............\hbox(4.31+2.05)x5.28, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...............\TU/lmr/m/n/10 y
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -35949,7 +36827,9 @@ TEST 64: pgfmanual-en-tikz-graphs-65
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36027,9 +36907,11 @@ TEST 64: pgfmanual-en-tikz-graphs-65
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 b
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -36114,7 +36996,9 @@ TEST 65: pgfmanual-en-tikz-graphs-66
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36156,7 +37040,9 @@ TEST 65: pgfmanual-en-tikz-graphs-66
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36218,7 +37104,9 @@ TEST 65: pgfmanual-en-tikz-graphs-66
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 x
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -36258,7 +37146,9 @@ TEST 65: pgfmanual-en-tikz-graphs-66
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36324,7 +37214,9 @@ TEST 65: pgfmanual-en-tikz-graphs-66
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+2.05)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -36364,7 +37256,9 @@ TEST 65: pgfmanual-en-tikz-graphs-66
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36439,9 +37333,11 @@ TEST 65: pgfmanual-en-tikz-graphs-66
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.31+0.0)x4.44, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 z
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -36525,7 +37421,9 @@ TEST 66: pgfmanual-en-tikz-graphs-67
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36567,7 +37465,9 @@ TEST 66: pgfmanual-en-tikz-graphs-67
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36629,7 +37529,9 @@ TEST 66: pgfmanual-en-tikz-graphs-67
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 x
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -36669,7 +37571,9 @@ TEST 66: pgfmanual-en-tikz-graphs-67
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36735,7 +37639,9 @@ TEST 66: pgfmanual-en-tikz-graphs-67
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.31+2.05)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -36775,7 +37681,9 @@ TEST 66: pgfmanual-en-tikz-graphs-67
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36850,9 +37758,11 @@ TEST 66: pgfmanual-en-tikz-graphs-67
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(4.31+0.0)x4.44, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 z
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -36936,7 +37846,9 @@ TEST 67: pgfmanual-en-tikz-graphs-68
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -36980,7 +37892,9 @@ TEST 67: pgfmanual-en-tikz-graphs-68
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37022,7 +37936,9 @@ TEST 67: pgfmanual-en-tikz-graphs-68
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37168,7 +38084,9 @@ TEST 68: pgfmanual-en-tikz-graphs-69
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37210,7 +38128,9 @@ TEST 68: pgfmanual-en-tikz-graphs-69
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37300,7 +38220,9 @@ TEST 68: pgfmanual-en-tikz-graphs-69
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37424,7 +38346,9 @@ TEST 69: pgfmanual-en-tikz-graphs-70
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37468,7 +38392,9 @@ TEST 69: pgfmanual-en-tikz-graphs-70
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37510,7 +38436,9 @@ TEST 69: pgfmanual-en-tikz-graphs-70
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37744,7 +38672,9 @@ TEST 70: pgfmanual-en-tikz-graphs-71
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37788,7 +38718,9 @@ TEST 70: pgfmanual-en-tikz-graphs-71
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37832,7 +38764,9 @@ TEST 70: pgfmanual-en-tikz-graphs-71
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37874,7 +38808,9 @@ TEST 70: pgfmanual-en-tikz-graphs-71
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37946,7 +38882,9 @@ TEST 70: pgfmanual-en-tikz-graphs-71
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -37990,7 +38928,9 @@ TEST 70: pgfmanual-en-tikz-graphs-71
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38032,7 +38972,9 @@ TEST 70: pgfmanual-en-tikz-graphs-71
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38104,7 +39046,9 @@ TEST 70: pgfmanual-en-tikz-graphs-71
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38491,7 +39435,9 @@ TEST 71: pgfmanual-en-tikz-graphs-72
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38533,7 +39479,9 @@ TEST 71: pgfmanual-en-tikz-graphs-72
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38593,7 +39541,9 @@ TEST 71: pgfmanual-en-tikz-graphs-72
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38635,7 +39585,9 @@ TEST 71: pgfmanual-en-tikz-graphs-72
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38754,7 +39706,9 @@ TEST 71: pgfmanual-en-tikz-graphs-72
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38796,7 +39750,9 @@ TEST 71: pgfmanual-en-tikz-graphs-72
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -38958,7 +39914,9 @@ TEST 72: pgfmanual-en-tikz-graphs-73
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39000,7 +39958,9 @@ TEST 72: pgfmanual-en-tikz-graphs-73
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39060,7 +40020,9 @@ TEST 72: pgfmanual-en-tikz-graphs-73
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39102,7 +40064,9 @@ TEST 72: pgfmanual-en-tikz-graphs-73
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39233,7 +40197,9 @@ TEST 72: pgfmanual-en-tikz-graphs-73
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39275,7 +40241,9 @@ TEST 72: pgfmanual-en-tikz-graphs-73
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39437,7 +40405,9 @@ TEST 73: pgfmanual-en-tikz-graphs-74
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39479,7 +40449,9 @@ TEST 73: pgfmanual-en-tikz-graphs-74
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39539,7 +40511,9 @@ TEST 73: pgfmanual-en-tikz-graphs-74
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39581,7 +40555,9 @@ TEST 73: pgfmanual-en-tikz-graphs-74
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39700,7 +40676,9 @@ TEST 73: pgfmanual-en-tikz-graphs-74
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39742,7 +40720,9 @@ TEST 73: pgfmanual-en-tikz-graphs-74
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -39960,7 +40940,9 @@ TEST 74: pgfmanual-en-tikz-graphs-75
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40002,7 +40984,9 @@ TEST 74: pgfmanual-en-tikz-graphs-75
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40062,7 +41046,9 @@ TEST 74: pgfmanual-en-tikz-graphs-75
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40104,7 +41090,9 @@ TEST 74: pgfmanual-en-tikz-graphs-75
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40314,7 +41302,9 @@ TEST 75: pgfmanual-en-tikz-graphs-76
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40356,7 +41346,9 @@ TEST 75: pgfmanual-en-tikz-graphs-76
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40416,7 +41408,9 @@ TEST 75: pgfmanual-en-tikz-graphs-76
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40458,7 +41452,9 @@ TEST 75: pgfmanual-en-tikz-graphs-76
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40535,7 +41531,9 @@ TEST 75: pgfmanual-en-tikz-graphs-76
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 X
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -40600,7 +41598,9 @@ TEST 75: pgfmanual-en-tikz-graphs-76
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40642,7 +41642,9 @@ TEST 75: pgfmanual-en-tikz-graphs-76
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40804,7 +41806,9 @@ TEST 76: pgfmanual-en-tikz-graphs-77
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40846,7 +41850,9 @@ TEST 76: pgfmanual-en-tikz-graphs-77
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40906,7 +41912,9 @@ TEST 76: pgfmanual-en-tikz-graphs-77
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -40948,7 +41956,9 @@ TEST 76: pgfmanual-en-tikz-graphs-77
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41062,7 +42072,9 @@ TEST 76: pgfmanual-en-tikz-graphs-77
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41104,7 +42116,9 @@ TEST 76: pgfmanual-en-tikz-graphs-77
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41267,7 +42281,9 @@ TEST 77: pgfmanual-en-tikz-graphs-78
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41309,7 +42325,9 @@ TEST 77: pgfmanual-en-tikz-graphs-78
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41439,6 +42457,8 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41480,7 +42500,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41549,7 +42571,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 9
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -41591,7 +42615,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41635,7 +42661,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41677,7 +42705,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41758,7 +42788,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 2
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -41815,7 +42847,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -41856,7 +42890,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+2.05)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -41945,9 +42981,11 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ..............\pdfliteral origin{1 0 0 RG }
 ..............\pdfliteral origin{1 0 0 rg }
 ..............\hbox(6.77+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...............\TU/lmr/m/n/10 4
 ...............\pdfcolorstack 0 pop
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42005,7 +43043,9 @@ TEST 78: pgfmanual-en-tikz-graphs-80
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.76+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 7
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42084,6 +43124,8 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42127,6 +43169,8 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42168,6 +43212,8 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42211,6 +43257,8 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42252,6 +43300,8 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42324,7 +43374,9 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42372,7 +43424,9 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42450,7 +43504,9 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42498,7 +43554,9 @@ TEST 79: pgfmanual-en-tikz-graphs-81
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42583,6 +43641,8 @@ TEST 80: pgfmanual-en-tikz-graphs-82
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42628,6 +43688,8 @@ TEST 80: pgfmanual-en-tikz-graphs-82
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42685,7 +43747,9 @@ TEST 80: pgfmanual-en-tikz-graphs-82
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42731,6 +43795,8 @@ TEST 80: pgfmanual-en-tikz-graphs-82
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42776,6 +43842,8 @@ TEST 80: pgfmanual-en-tikz-graphs-82
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -42847,7 +43915,9 @@ TEST 80: pgfmanual-en-tikz-graphs-82
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42892,7 +43962,9 @@ TEST 80: pgfmanual-en-tikz-graphs-82
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -42971,7 +44043,9 @@ TEST 81: pgfmanual-en-tikz-graphs-83
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43013,7 +44087,9 @@ TEST 81: pgfmanual-en-tikz-graphs-83
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43057,7 +44133,9 @@ TEST 81: pgfmanual-en-tikz-graphs-83
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43099,7 +44177,9 @@ TEST 81: pgfmanual-en-tikz-graphs-83
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43190,7 +44270,9 @@ TEST 81: pgfmanual-en-tikz-graphs-83
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43338,11 +44420,13 @@ TEST 82: pgfmanual-en-tikz-graphs-84
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43384,11 +44468,13 @@ TEST 82: pgfmanual-en-tikz-graphs-84
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43440,11 +44526,13 @@ TEST 82: pgfmanual-en-tikz-graphs-84
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43486,11 +44574,13 @@ TEST 82: pgfmanual-en-tikz-graphs-84
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43532,11 +44622,13 @@ TEST 82: pgfmanual-en-tikz-graphs-84
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43766,11 +44858,13 @@ TEST 83: pgfmanual-en-tikz-graphs-85
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43812,11 +44906,13 @@ TEST 83: pgfmanual-en-tikz-graphs-85
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43868,11 +44964,13 @@ TEST 83: pgfmanual-en-tikz-graphs-85
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43914,11 +45012,13 @@ TEST 83: pgfmanual-en-tikz-graphs-85
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -43960,11 +45060,13 @@ TEST 83: pgfmanual-en-tikz-graphs-85
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44167,11 +45269,13 @@ TEST 84: pgfmanual-en-tikz-graphs-86
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44213,11 +45317,13 @@ TEST 84: pgfmanual-en-tikz-graphs-86
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44269,11 +45375,13 @@ TEST 84: pgfmanual-en-tikz-graphs-86
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44315,11 +45423,13 @@ TEST 84: pgfmanual-en-tikz-graphs-86
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44361,11 +45471,13 @@ TEST 84: pgfmanual-en-tikz-graphs-86
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44610,7 +45722,9 @@ TEST 85: pgfmanual-en-tikz-graphs-87
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44654,7 +45768,9 @@ TEST 85: pgfmanual-en-tikz-graphs-87
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44696,7 +45812,9 @@ TEST 85: pgfmanual-en-tikz-graphs-87
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44738,7 +45856,9 @@ TEST 85: pgfmanual-en-tikz-graphs-87
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -44871,7 +45991,9 @@ TEST 85: pgfmanual-en-tikz-graphs-87
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45038,7 +46160,9 @@ TEST 86: pgfmanual-en-tikz-graphs-88
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45082,7 +46206,9 @@ TEST 86: pgfmanual-en-tikz-graphs-88
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45124,7 +46250,9 @@ TEST 86: pgfmanual-en-tikz-graphs-88
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45166,7 +46294,9 @@ TEST 86: pgfmanual-en-tikz-graphs-88
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45278,7 +46408,9 @@ TEST 86: pgfmanual-en-tikz-graphs-88
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45438,7 +46570,9 @@ TEST 87: pgfmanual-en-tikz-graphs-90
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45491,7 +46625,9 @@ TEST 87: pgfmanual-en-tikz-graphs-90
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45544,7 +46680,9 @@ TEST 87: pgfmanual-en-tikz-graphs-90
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45597,7 +46735,9 @@ TEST 87: pgfmanual-en-tikz-graphs-90
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45650,7 +46790,9 @@ TEST 87: pgfmanual-en-tikz-graphs-90
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -45958,7 +47100,9 @@ TEST 88: pgfmanual-en-tikz-graphs-91
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46011,7 +47155,9 @@ TEST 88: pgfmanual-en-tikz-graphs-91
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46064,7 +47210,9 @@ TEST 88: pgfmanual-en-tikz-graphs-91
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46117,7 +47265,9 @@ TEST 88: pgfmanual-en-tikz-graphs-91
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46170,7 +47320,9 @@ TEST 88: pgfmanual-en-tikz-graphs-91
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46508,7 +47660,9 @@ TEST 89: pgfmanual-en-tikz-graphs-92
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46561,7 +47715,9 @@ TEST 89: pgfmanual-en-tikz-graphs-92
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46614,7 +47770,9 @@ TEST 89: pgfmanual-en-tikz-graphs-92
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46667,7 +47825,9 @@ TEST 89: pgfmanual-en-tikz-graphs-92
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -46720,7 +47880,9 @@ TEST 89: pgfmanual-en-tikz-graphs-92
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47058,7 +48220,9 @@ TEST 90: pgfmanual-en-tikz-graphs-93
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47111,7 +48275,9 @@ TEST 90: pgfmanual-en-tikz-graphs-93
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47164,7 +48330,9 @@ TEST 90: pgfmanual-en-tikz-graphs-93
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47217,7 +48385,9 @@ TEST 90: pgfmanual-en-tikz-graphs-93
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47270,7 +48440,9 @@ TEST 90: pgfmanual-en-tikz-graphs-93
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47632,11 +48804,13 @@ TEST 91: pgfmanual-en-tikz-graphs-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -47677,7 +48851,9 @@ TEST 91: pgfmanual-en-tikz-graphs-94
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.31+0.0)x5.28, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 x
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47721,7 +48897,9 @@ TEST 91: pgfmanual-en-tikz-graphs-94
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47763,7 +48941,9 @@ TEST 91: pgfmanual-en-tikz-graphs-94
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47805,7 +48985,9 @@ TEST 91: pgfmanual-en-tikz-graphs-94
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -47965,7 +49147,9 @@ TEST 92: pgfmanual-en-tikz-graphs-95
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48007,7 +49191,9 @@ TEST 92: pgfmanual-en-tikz-graphs-95
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48049,7 +49235,9 @@ TEST 92: pgfmanual-en-tikz-graphs-95
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48102,7 +49290,9 @@ TEST 92: pgfmanual-en-tikz-graphs-95
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48143,7 +49333,9 @@ TEST 92: pgfmanual-en-tikz-graphs-95
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48184,7 +49376,9 @@ TEST 92: pgfmanual-en-tikz-graphs-95
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48385,7 +49579,9 @@ TEST 93: pgfmanual-en-tikz-graphs-96
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48427,7 +49623,9 @@ TEST 93: pgfmanual-en-tikz-graphs-96
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48469,7 +49667,9 @@ TEST 93: pgfmanual-en-tikz-graphs-96
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48529,7 +49729,9 @@ TEST 93: pgfmanual-en-tikz-graphs-96
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48571,7 +49773,9 @@ TEST 93: pgfmanual-en-tikz-graphs-96
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48613,7 +49817,9 @@ TEST 93: pgfmanual-en-tikz-graphs-96
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48948,7 +50154,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -48990,7 +50198,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49050,7 +50260,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49092,7 +50304,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49134,7 +50348,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49273,7 +50489,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49315,7 +50533,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49357,7 +50577,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49638,7 +50860,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+0.0)x2.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 i
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49680,7 +50904,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+2.05)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49722,7 +50948,9 @@ TEST 94: pgfmanual-en-tikz-graphs-97
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.28, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 k
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49916,11 +51144,13 @@ TEST 95: pgfmanual-en-tikz-graphs-98
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -49962,11 +51192,13 @@ TEST 95: pgfmanual-en-tikz-graphs-98
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50008,11 +51240,13 @@ TEST 95: pgfmanual-en-tikz-graphs-98
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.49998)x8.99771, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 r
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50065,11 +51299,13 @@ TEST 95: pgfmanual-en-tikz-graphs-98
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 1
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50110,11 +51346,13 @@ TEST 95: pgfmanual-en-tikz-graphs-98
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 2
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50155,11 +51393,13 @@ TEST 95: pgfmanual-en-tikz-graphs-98
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+1.94444)x9.25581, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 g
 .............\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..............\OT1/cmr/m/n/7 3
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50459,7 +51699,9 @@ TEST 96: pgfmanual-en-tikz-graphs-99
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50505,7 +51747,9 @@ TEST 96: pgfmanual-en-tikz-graphs-99
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50549,7 +51793,9 @@ TEST 96: pgfmanual-en-tikz-graphs-99
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50591,7 +51837,9 @@ TEST 96: pgfmanual-en-tikz-graphs-99
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50633,7 +51881,9 @@ TEST 96: pgfmanual-en-tikz-graphs-99
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50764,7 +52014,9 @@ TEST 96: pgfmanual-en-tikz-graphs-99
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50855,11 +52107,13 @@ TEST 97: pgfmanual-en-tikz-graphs-100
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x18.09, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 o
 .............\kern0.28 (font)
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50907,7 +52161,9 @@ TEST 97: pgfmanual-en-tikz-graphs-100
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -50960,7 +52216,9 @@ TEST 97: pgfmanual-en-tikz-graphs-100
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51013,7 +52271,9 @@ TEST 97: pgfmanual-en-tikz-graphs-100
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51066,7 +52326,9 @@ TEST 97: pgfmanual-en-tikz-graphs-100
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51119,7 +52381,9 @@ TEST 97: pgfmanual-en-tikz-graphs-100
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51359,6 +52623,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51408,6 +52674,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51457,6 +52725,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51506,6 +52776,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51554,6 +52826,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51607,6 +52881,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51734,6 +53010,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51782,6 +53060,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -51835,6 +53115,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52051,6 +53333,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52100,6 +53384,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52148,6 +53434,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52201,6 +53489,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52328,6 +53618,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52376,6 +53668,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52429,6 +53723,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52766,6 +54062,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52815,6 +54113,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52864,6 +54164,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52912,6 +54214,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -52965,6 +54269,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53092,6 +54398,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53140,6 +54448,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53193,6 +54503,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53409,6 +54721,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53458,6 +54772,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53506,6 +54822,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53559,6 +54877,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53686,6 +55006,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53734,6 +55056,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -53787,6 +55111,8 @@ TEST 98: pgfmanual-en-tikz-graphs-101
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54347,7 +55673,9 @@ TEST 99: pgfmanual-en-tikz-graphs-102
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54391,7 +55719,9 @@ TEST 99: pgfmanual-en-tikz-graphs-102
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54433,7 +55763,9 @@ TEST 99: pgfmanual-en-tikz-graphs-102
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54475,7 +55807,9 @@ TEST 99: pgfmanual-en-tikz-graphs-102
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54610,7 +55944,9 @@ TEST 99: pgfmanual-en-tikz-graphs-102
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54654,7 +55990,9 @@ TEST 99: pgfmanual-en-tikz-graphs-102
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54696,7 +56034,9 @@ TEST 99: pgfmanual-en-tikz-graphs-102
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54738,7 +56078,9 @@ TEST 99: pgfmanual-en-tikz-graphs-102
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54907,7 +56249,9 @@ TEST 100: pgfmanual-en-tikz-graphs-103
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -54947,7 +56291,9 @@ TEST 100: pgfmanual-en-tikz-graphs-103
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55019,7 +56365,9 @@ TEST 100: pgfmanual-en-tikz-graphs-103
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55141,7 +56489,9 @@ TEST 101: pgfmanual-en-tikz-graphs-104
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55181,7 +56531,9 @@ TEST 101: pgfmanual-en-tikz-graphs-104
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55254,7 +56606,9 @@ TEST 101: pgfmanual-en-tikz-graphs-104
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55376,7 +56730,9 @@ TEST 102: pgfmanual-en-tikz-graphs-105
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55418,7 +56774,9 @@ TEST 102: pgfmanual-en-tikz-graphs-105
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55458,7 +56816,9 @@ TEST 102: pgfmanual-en-tikz-graphs-105
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55624,6 +56984,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.11)x5.0, direction TLT
 ..............\hbox(12.48+0.11)x5.0, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -55658,6 +57019,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55700,6 +57062,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -55736,6 +57099,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55778,6 +57142,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.11)x8.825, direction TLT
 ..............\hbox(12.48+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -55814,6 +57179,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55856,6 +57222,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -55894,6 +57261,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -55971,6 +57339,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.11)x8.825, direction TLT
 ..............\hbox(12.48+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -56009,6 +57378,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56051,6 +57421,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(21.05+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(21.05+0.11)x8.825, direction TLT
 ..............\hbox(15.05+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -56089,6 +57460,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56164,6 +57536,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.53+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(18.53+0.11)x8.825, direction TLT
 ..............\hbox(12.53+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -56202,6 +57575,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56281,6 +57655,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -56319,6 +57694,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56361,6 +57737,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.57+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.57+0.11)x8.825, direction TLT
 ..............\hbox(14.57+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -56399,6 +57776,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56556,6 +57934,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.57+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.57+0.11)x8.825, direction TLT
 ..............\hbox(14.57+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -56594,6 +57973,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56714,6 +58094,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -56750,6 +58131,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56792,6 +58174,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -56830,6 +58213,7 @@ TEST 103: pgfmanual-en-tikz-graphs-106
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56942,7 +58326,9 @@ TEST 104: pgfmanual-en-tikz-graphs-107
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -56984,7 +58370,9 @@ TEST 104: pgfmanual-en-tikz-graphs-107
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57059,7 +58447,9 @@ TEST 104: pgfmanual-en-tikz-graphs-107
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57138,7 +58528,9 @@ TEST 104: pgfmanual-en-tikz-graphs-107
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57180,7 +58572,9 @@ TEST 104: pgfmanual-en-tikz-graphs-107
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57255,7 +58649,9 @@ TEST 104: pgfmanual-en-tikz-graphs-107
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57297,7 +58693,9 @@ TEST 104: pgfmanual-en-tikz-graphs-107
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57372,7 +58770,9 @@ TEST 104: pgfmanual-en-tikz-graphs-107
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57494,7 +58894,9 @@ TEST 105: pgfmanual-en-tikz-graphs-108
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57536,7 +58938,9 @@ TEST 105: pgfmanual-en-tikz-graphs-108
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57611,7 +59015,9 @@ TEST 105: pgfmanual-en-tikz-graphs-108
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57690,7 +59096,9 @@ TEST 105: pgfmanual-en-tikz-graphs-108
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57732,7 +59140,9 @@ TEST 105: pgfmanual-en-tikz-graphs-108
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57807,7 +59217,9 @@ TEST 105: pgfmanual-en-tikz-graphs-108
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57849,7 +59261,9 @@ TEST 105: pgfmanual-en-tikz-graphs-108
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -57924,7 +59338,9 @@ TEST 105: pgfmanual-en-tikz-graphs-108
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58048,7 +59464,9 @@ TEST 106: pgfmanual-en-tikz-graphs-109
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58090,7 +59508,9 @@ TEST 106: pgfmanual-en-tikz-graphs-109
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58165,7 +59585,9 @@ TEST 106: pgfmanual-en-tikz-graphs-109
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58284,7 +59706,9 @@ TEST 107: pgfmanual-en-tikz-graphs-110
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58326,7 +59750,9 @@ TEST 107: pgfmanual-en-tikz-graphs-110
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58401,7 +59827,9 @@ TEST 107: pgfmanual-en-tikz-graphs-110
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58520,7 +59948,9 @@ TEST 108: pgfmanual-en-tikz-graphs-111
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58562,7 +59992,9 @@ TEST 108: pgfmanual-en-tikz-graphs-111
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58637,7 +60069,9 @@ TEST 108: pgfmanual-en-tikz-graphs-111
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58756,7 +60190,9 @@ TEST 109: pgfmanual-en-tikz-graphs-112
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58798,7 +60234,9 @@ TEST 109: pgfmanual-en-tikz-graphs-112
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58873,7 +60311,9 @@ TEST 109: pgfmanual-en-tikz-graphs-112
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -58992,7 +60432,9 @@ TEST 110: pgfmanual-en-tikz-graphs-113
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59034,7 +60476,9 @@ TEST 110: pgfmanual-en-tikz-graphs-113
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59111,7 +60555,9 @@ TEST 110: pgfmanual-en-tikz-graphs-113
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59153,7 +60599,9 @@ TEST 110: pgfmanual-en-tikz-graphs-113
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59195,7 +60643,9 @@ TEST 110: pgfmanual-en-tikz-graphs-113
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59372,7 +60822,9 @@ TEST 111: pgfmanual-en-tikz-graphs-114
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59414,7 +60866,9 @@ TEST 111: pgfmanual-en-tikz-graphs-114
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59491,7 +60945,9 @@ TEST 111: pgfmanual-en-tikz-graphs-114
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59533,7 +60989,9 @@ TEST 111: pgfmanual-en-tikz-graphs-114
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59575,7 +61033,9 @@ TEST 111: pgfmanual-en-tikz-graphs-114
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59754,7 +61214,9 @@ TEST 112: pgfmanual-en-tikz-graphs-115
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59796,7 +61258,9 @@ TEST 112: pgfmanual-en-tikz-graphs-115
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59873,7 +61337,9 @@ TEST 112: pgfmanual-en-tikz-graphs-115
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59915,7 +61381,9 @@ TEST 112: pgfmanual-en-tikz-graphs-115
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -59957,7 +61425,9 @@ TEST 112: pgfmanual-en-tikz-graphs-115
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60136,7 +61606,9 @@ TEST 113: pgfmanual-en-tikz-graphs-116
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60178,7 +61650,9 @@ TEST 113: pgfmanual-en-tikz-graphs-116
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60255,7 +61729,9 @@ TEST 113: pgfmanual-en-tikz-graphs-116
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60297,7 +61773,9 @@ TEST 113: pgfmanual-en-tikz-graphs-116
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60339,7 +61817,9 @@ TEST 113: pgfmanual-en-tikz-graphs-116
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60525,7 +62005,9 @@ TEST 114: pgfmanual-en-tikz-graphs-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60579,7 +62061,9 @@ TEST 114: pgfmanual-en-tikz-graphs-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60633,7 +62117,9 @@ TEST 114: pgfmanual-en-tikz-graphs-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60687,7 +62173,9 @@ TEST 114: pgfmanual-en-tikz-graphs-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60741,7 +62229,9 @@ TEST 114: pgfmanual-en-tikz-graphs-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60795,7 +62285,9 @@ TEST 114: pgfmanual-en-tikz-graphs-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60906,7 +62398,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -60959,7 +62453,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61012,7 +62508,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61065,7 +62563,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61118,7 +62618,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61171,7 +62673,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61224,7 +62728,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61277,7 +62783,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61330,7 +62838,9 @@ TEST 115: pgfmanual-en-tikz-graphs-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61686,7 +63196,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61739,7 +63251,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61792,7 +63306,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61845,7 +63361,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61898,7 +63416,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -61951,7 +63471,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62004,7 +63526,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62057,7 +63581,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62110,7 +63636,9 @@ TEST 116: pgfmanual-en-tikz-graphs-119
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62451,7 +63979,9 @@ TEST 117: pgfmanual-en-tikz-graphs-120
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62494,7 +64024,9 @@ TEST 117: pgfmanual-en-tikz-graphs-120
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62567,7 +64099,9 @@ TEST 117: pgfmanual-en-tikz-graphs-120
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62644,7 +64178,9 @@ TEST 117: pgfmanual-en-tikz-graphs-120
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62725,7 +64261,9 @@ TEST 117: pgfmanual-en-tikz-graphs-120
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62810,7 +64348,9 @@ TEST 117: pgfmanual-en-tikz-graphs-120
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62938,11 +64478,13 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -62987,6 +64529,7 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x39.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
@@ -62996,6 +64539,7 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63040,11 +64584,13 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x22.31, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 h
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63087,6 +64633,7 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x61.14, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 v
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 e
@@ -63102,6 +64649,7 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63196,6 +64744,7 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x42.52, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 r
@@ -63205,6 +64754,7 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63295,10 +64845,12 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x18.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63341,12 +64893,14 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x26.7, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63415,6 +64969,7 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x30.61, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
@@ -63422,6 +64977,7 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63566,9 +65122,11 @@ TEST 118: pgfmanual-en-tikz-graphs-121
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x15.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63717,10 +65275,12 @@ TEST 119: pgfmanual-en-tikz-graphs-122
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x18.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63761,12 +65321,14 @@ TEST 119: pgfmanual-en-tikz-graphs-122
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x26.7, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63837,6 +65399,7 @@ TEST 119: pgfmanual-en-tikz-graphs-122
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x30.61, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
@@ -63844,6 +65407,7 @@ TEST 119: pgfmanual-en-tikz-graphs-122
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -63961,6 +65525,7 @@ TEST 120: pgfmanual-en-tikz-graphs-123
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x24.33438, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 a
 .............\glue(\thickmuskip) 2.77771 plus 2.77771
@@ -63968,6 +65533,7 @@ TEST 120: pgfmanual-en-tikz-graphs-123
 .............\glue(\thickmuskip) 2.77771 plus 2.77771
 .............\OML/cmm/m/it/10 x
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64012,6 +65578,7 @@ TEST 120: pgfmanual-en-tikz-graphs-123
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(15.65013+9.11122)x50.41306, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 b
 .............\glue(\thickmuskip) 2.77771 plus 2.77771
@@ -64030,6 +65597,7 @@ TEST 120: pgfmanual-en-tikz-graphs-123
 .............\OML/cmm/m/it/10 d
 .............\OML/cmm/m/it/10 x
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64107,7 +65675,9 @@ TEST 120: pgfmanual-en-tikz-graphs-123
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64223,11 +65793,13 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64272,6 +65844,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x84.19, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 n
 .............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
@@ -64292,6 +65865,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64336,11 +65910,13 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x22.31, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 h
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64383,6 +65959,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x61.14, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 v
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 e
@@ -64398,6 +65975,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64500,6 +66078,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x42.52, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 r
@@ -64509,6 +66088,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64607,10 +66187,12 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x18.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64653,12 +66235,14 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x26.7, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64731,6 +66315,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x30.61, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
@@ -64738,6 +66323,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64814,6 +66400,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x42.54001, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 m
@@ -64823,6 +66410,7 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64865,7 +66453,9 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -64938,7 +66528,9 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65125,9 +66717,11 @@ TEST 121: pgfmanual-en-tikz-graphs-124
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x15.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65316,11 +66910,13 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65365,6 +66961,7 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x84.19, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 n
 .............\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
@@ -65385,6 +66982,7 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65429,11 +67027,13 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x22.31, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 h
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65476,6 +67076,7 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x61.14, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 v
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 e
@@ -65491,6 +67092,7 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65593,6 +67195,7 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x42.52, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 r
@@ -65602,6 +67205,7 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65700,10 +67304,12 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x18.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65746,12 +67352,14 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x26.7, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65824,6 +67432,7 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x42.54001, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 m
@@ -65833,6 +67442,7 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 x
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65875,7 +67485,9 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -65948,7 +67560,9 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66131,9 +67745,11 @@ TEST 122: pgfmanual-en-tikz-graphs-125
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x15.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66320,7 +67936,9 @@ TEST 123: pgfmanual-en-tikz-graphs-126
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66364,7 +67982,9 @@ TEST 123: pgfmanual-en-tikz-graphs-126
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66412,7 +68032,9 @@ TEST 123: pgfmanual-en-tikz-graphs-126
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66494,7 +68116,9 @@ TEST 124: pgfmanual-en-tikz-graphs-127
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66536,7 +68160,9 @@ TEST 124: pgfmanual-en-tikz-graphs-127
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66611,7 +68237,9 @@ TEST 124: pgfmanual-en-tikz-graphs-127
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66690,7 +68318,9 @@ TEST 124: pgfmanual-en-tikz-graphs-127
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66732,7 +68362,9 @@ TEST 124: pgfmanual-en-tikz-graphs-127
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66807,7 +68439,9 @@ TEST 124: pgfmanual-en-tikz-graphs-127
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66849,7 +68483,9 @@ TEST 124: pgfmanual-en-tikz-graphs-127
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -66924,7 +68560,9 @@ TEST 124: pgfmanual-en-tikz-graphs-127
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67048,7 +68686,9 @@ TEST 125: pgfmanual-en-tikz-graphs-128
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67090,7 +68730,9 @@ TEST 125: pgfmanual-en-tikz-graphs-128
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67165,7 +68807,9 @@ TEST 125: pgfmanual-en-tikz-graphs-128
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67244,7 +68888,9 @@ TEST 125: pgfmanual-en-tikz-graphs-128
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67286,7 +68932,9 @@ TEST 125: pgfmanual-en-tikz-graphs-128
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67361,7 +69009,9 @@ TEST 125: pgfmanual-en-tikz-graphs-128
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67403,7 +69053,9 @@ TEST 125: pgfmanual-en-tikz-graphs-128
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67478,7 +69130,9 @@ TEST 125: pgfmanual-en-tikz-graphs-128
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67602,7 +69256,9 @@ TEST 126: pgfmanual-en-tikz-graphs-129
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67644,7 +69300,9 @@ TEST 126: pgfmanual-en-tikz-graphs-129
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67716,7 +69374,9 @@ TEST 126: pgfmanual-en-tikz-graphs-129
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67792,7 +69452,9 @@ TEST 126: pgfmanual-en-tikz-graphs-129
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67834,7 +69496,9 @@ TEST 126: pgfmanual-en-tikz-graphs-129
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67906,7 +69570,9 @@ TEST 126: pgfmanual-en-tikz-graphs-129
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -67948,7 +69614,9 @@ TEST 126: pgfmanual-en-tikz-graphs-129
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68020,7 +69688,9 @@ TEST 126: pgfmanual-en-tikz-graphs-129
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68141,7 +69811,9 @@ TEST 127: pgfmanual-en-tikz-graphs-130
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68183,7 +69855,9 @@ TEST 127: pgfmanual-en-tikz-graphs-130
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68225,7 +69899,9 @@ TEST 127: pgfmanual-en-tikz-graphs-130
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68267,7 +69943,9 @@ TEST 127: pgfmanual-en-tikz-graphs-130
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68349,7 +70027,9 @@ TEST 128: pgfmanual-en-tikz-graphs-131
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68391,7 +70071,9 @@ TEST 128: pgfmanual-en-tikz-graphs-131
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68433,7 +70115,9 @@ TEST 128: pgfmanual-en-tikz-graphs-131
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68475,7 +70159,9 @@ TEST 128: pgfmanual-en-tikz-graphs-131
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68557,7 +70243,9 @@ TEST 129: pgfmanual-en-tikz-graphs-132
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68599,7 +70287,9 @@ TEST 129: pgfmanual-en-tikz-graphs-132
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68641,7 +70331,9 @@ TEST 129: pgfmanual-en-tikz-graphs-132
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68683,7 +70375,9 @@ TEST 129: pgfmanual-en-tikz-graphs-132
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68765,7 +70459,9 @@ TEST 130: pgfmanual-en-tikz-graphs-133
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68807,7 +70503,9 @@ TEST 130: pgfmanual-en-tikz-graphs-133
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68849,7 +70547,9 @@ TEST 130: pgfmanual-en-tikz-graphs-133
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68891,7 +70591,9 @@ TEST 130: pgfmanual-en-tikz-graphs-133
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -68973,7 +70675,9 @@ TEST 131: pgfmanual-en-tikz-graphs-134
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69015,7 +70719,9 @@ TEST 131: pgfmanual-en-tikz-graphs-134
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69057,7 +70763,9 @@ TEST 131: pgfmanual-en-tikz-graphs-134
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69099,7 +70807,9 @@ TEST 131: pgfmanual-en-tikz-graphs-134
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69193,7 +70903,9 @@ TEST 132: pgfmanual-en-tikz-graphs-135
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69246,7 +70958,9 @@ TEST 132: pgfmanual-en-tikz-graphs-135
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69299,7 +71013,9 @@ TEST 132: pgfmanual-en-tikz-graphs-135
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69352,7 +71068,9 @@ TEST 132: pgfmanual-en-tikz-graphs-135
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69405,7 +71123,9 @@ TEST 132: pgfmanual-en-tikz-graphs-135
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69701,9 +71421,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.11)x12.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69747,9 +71469,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69791,9 +71515,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.11)x12.22, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69837,9 +71563,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.22)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69881,9 +71609,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x12.22, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69927,9 +71657,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x10.84, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -69971,9 +71703,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+2.06)x12.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70081,9 +71815,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.22)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70224,9 +71960,11 @@ TEST 133: pgfmanual-en-tikz-graphs-136
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+2.05)x10.84, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70424,9 +72162,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 a
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70479,9 +72219,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{0 0.5 0 RG }
 ............\pdfliteral origin{0 0.5 0 rg }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 .............\TU/lmr/m/n/10 b
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70533,9 +72275,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{0 0.5 0 RG }
 ............\pdfliteral origin{0 0.5 0 rg }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 .............\TU/lmr/m/n/10 c
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70592,9 +72336,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\TU/lmr/m/n/10 d
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70650,9 +72396,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\TU/lmr/m/n/10 e
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70710,9 +72458,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\TU/lmr/m/n/10 f
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70768,9 +72518,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\TU/lmr/m/n/10 g
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -70892,9 +72644,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{0 0 1 RG }
 ............\pdfliteral origin{0 0 1 rg }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .............\TU/lmr/m/n/10 h
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71046,9 +72800,11 @@ TEST 134: pgfmanual-en-tikz-graphs-137
 ............\pdfliteral origin{0 0.5 0 RG }
 ............\pdfliteral origin{0 0.5 0 rg }
 ............\hbox(6.57+2.05)x3.06, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 .............\TU/lmr/m/n/10 j
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71245,7 +73001,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71291,7 +73049,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71335,7 +73095,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71381,7 +73143,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71425,7 +73189,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71469,7 +73235,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71511,7 +73279,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71621,7 +73391,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71764,7 +73536,9 @@ TEST 135: pgfmanual-en-tikz-graphs-138
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+2.05)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -71957,9 +73731,11 @@ TEST 136: pgfmanual-en-tikz-graphs-139
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x12.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72002,9 +73778,11 @@ TEST 136: pgfmanual-en-tikz-graphs-139
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72080,9 +73858,11 @@ TEST 136: pgfmanual-en-tikz-graphs-139
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.11)x12.22, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72162,9 +73942,11 @@ TEST 136: pgfmanual-en-tikz-graphs-139
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.22)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72209,9 +73991,11 @@ TEST 136: pgfmanual-en-tikz-graphs-139
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x12.22, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72254,9 +74038,11 @@ TEST 136: pgfmanual-en-tikz-graphs-139
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.22)x10.84, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72299,9 +74085,11 @@ TEST 136: pgfmanual-en-tikz-graphs-139
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72447,9 +74235,11 @@ TEST 136: pgfmanual-en-tikz-graphs-139
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+2.05)x10.84, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72599,6 +74389,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.11)x5.0, direction TLT
 ..............\hbox(12.48+0.11)x5.0, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -72633,6 +74424,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72675,6 +74467,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -72711,6 +74504,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72753,6 +74547,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.11)x8.825, direction TLT
 ..............\hbox(12.48+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -72789,6 +74584,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72831,6 +74627,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -72869,6 +74666,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -72946,6 +74744,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.11)x8.825, direction TLT
 ..............\hbox(12.48+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -72984,6 +74783,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -73026,6 +74826,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(21.05+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(21.05+0.11)x8.825, direction TLT
 ..............\hbox(15.05+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -73064,6 +74865,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -73139,6 +74941,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.53+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(18.53+0.11)x8.825, direction TLT
 ..............\hbox(12.53+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -73177,6 +74980,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -73256,6 +75060,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -73294,6 +75099,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -73336,6 +75142,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.57+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.57+0.11)x8.825, direction TLT
 ..............\hbox(14.57+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -73374,6 +75181,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -73531,6 +75339,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.57+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.57+0.11)x8.825, direction TLT
 ..............\hbox(14.57+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -73569,6 +75378,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -73689,6 +75499,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -73725,6 +75536,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -73767,6 +75579,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.11)x8.825, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.11)x8.825, direction TLT
 ..............\hbox(14.94+0.11)x8.825, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -73805,6 +75618,7 @@ TEST 137: pgfmanual-en-tikz-graphs-140
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -73922,6 +75736,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.97)x27.43167, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.97)x27.43167, direction TLT
 ..............\hbox(12.48+0.11)x27.43167, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -73966,6 +75781,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 0
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -74011,6 +75827,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.97)x49.29666, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.97)x49.29666, direction TLT
 ..............\hbox(14.94+0.11)x49.29666, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -74062,6 +75879,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 8
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -74107,6 +75925,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.97)x49.29666, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.97)x49.29666, direction TLT
 ..............\hbox(12.48+0.11)x49.29666, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -74158,6 +75977,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 7
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -74203,6 +76023,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.97)x49.87666, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.97)x49.87666, direction TLT
 ..............\hbox(14.94+0.11)x49.87666, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -74261,6 +76082,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 7
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -74341,6 +76163,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.48+0.97)x49.87666, direction TLT
+.............\begindir TLT
 .............\vbox(18.48+0.97)x49.87666, direction TLT
 ..............\hbox(12.48+0.11)x49.87666, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -74399,6 +76222,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 7
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -74444,6 +76268,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(21.05+0.97)x53.28166, direction TLT
+.............\begindir TLT
 .............\vbox(21.05+0.97)x53.28166, direction TLT
 ..............\hbox(15.05+0.11)x53.28166, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -74503,6 +76328,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 7
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -74581,6 +76407,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(18.53+0.97)x53.28166, direction TLT
+.............\begindir TLT
 .............\vbox(18.53+0.97)x53.28166, direction TLT
 ..............\hbox(12.53+0.11)x53.28166, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -74640,6 +76467,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 7
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -74722,6 +76550,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.97)x52.70166, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.97)x52.70166, direction TLT
 ..............\hbox(14.94+0.11)x52.70166, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -74781,6 +76610,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 6
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -74826,6 +76656,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.57+0.97)x53.28166, direction TLT
+.............\begindir TLT
 .............\vbox(20.57+0.97)x53.28166, direction TLT
 ..............\hbox(14.57+0.11)x53.28166, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -74886,6 +76717,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 6
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75046,6 +76878,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.57+0.97)x53.28166, direction TLT
+.............\begindir TLT
 .............\vbox(20.57+0.97)x53.28166, direction TLT
 ..............\hbox(14.57+0.11)x53.28166, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -75105,6 +76938,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 7
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75228,6 +77062,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.97)x52.70166, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.97)x52.70166, direction TLT
 ..............\hbox(14.94+0.11)x52.70166, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -75280,6 +77115,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 5
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75325,6 +77161,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(20.94+0.97)x52.70166, direction TLT
+.............\begindir TLT
 .............\vbox(20.94+0.97)x52.70166, direction TLT
 ..............\hbox(14.94+0.11)x52.70166, direction TLT
 ...............\glue(\tabskip) 0.0
@@ -75384,6 +77221,7 @@ TEST 138: pgfmanual-en-tikz-graphs-141
 ................\TU/lmr/m/n/5 5
 ................\glue 0.0 plus 1.0fil
 ...............\glue(\tabskip) 0.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75503,9 +77341,11 @@ TEST 139: pgfmanual-en-tikz-graphs-142
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x12.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75548,9 +77388,11 @@ TEST 139: pgfmanual-en-tikz-graphs-142
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.22)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75628,9 +77470,11 @@ TEST 139: pgfmanual-en-tikz-graphs-142
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x12.22, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75673,9 +77517,11 @@ TEST 139: pgfmanual-en-tikz-graphs-142
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75718,9 +77564,11 @@ TEST 139: pgfmanual-en-tikz-graphs-142
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.11)x12.22, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75858,9 +77706,11 @@ TEST 139: pgfmanual-en-tikz-graphs-142
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x10.84, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75903,9 +77753,11 @@ TEST 139: pgfmanual-en-tikz-graphs-142
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+2.06)x12.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -75948,9 +77800,11 @@ TEST 139: pgfmanual-en-tikz-graphs-142
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x13.34, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
 .............\TU/lmr/m/n/10 :
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76077,9 +77931,11 @@ TEST 140: pgfmanual-en-tikz-graphs-143
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 a
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76134,9 +77990,11 @@ TEST 140: pgfmanual-en-tikz-graphs-143
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 b
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76189,9 +78047,11 @@ TEST 140: pgfmanual-en-tikz-graphs-143
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 c
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76272,9 +78132,11 @@ TEST 140: pgfmanual-en-tikz-graphs-143
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 d
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76359,9 +78221,11 @@ TEST 140: pgfmanual-en-tikz-graphs-143
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 e
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76416,9 +78280,11 @@ TEST 140: pgfmanual-en-tikz-graphs-143
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 f
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76471,9 +78337,11 @@ TEST 140: pgfmanual-en-tikz-graphs-143
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 g
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76582,9 +78450,11 @@ TEST 140: pgfmanual-en-tikz-graphs-143
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\TU/lmr/m/n/10 h
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76770,7 +78640,9 @@ TEST 141: pgfmanual-en-tikz-graphs-144
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76827,7 +78699,9 @@ TEST 141: pgfmanual-en-tikz-graphs-144
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76884,7 +78758,9 @@ TEST 141: pgfmanual-en-tikz-graphs-144
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -76991,7 +78867,9 @@ TEST 142: pgfmanual-en-tikz-graphs-145
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77044,7 +78922,9 @@ TEST 142: pgfmanual-en-tikz-graphs-145
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77097,7 +78977,9 @@ TEST 142: pgfmanual-en-tikz-graphs-145
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77150,7 +79032,9 @@ TEST 142: pgfmanual-en-tikz-graphs-145
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77375,7 +79259,9 @@ TEST 143: pgfmanual-en-tikz-graphs-146
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77428,7 +79314,9 @@ TEST 143: pgfmanual-en-tikz-graphs-146
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77481,7 +79369,9 @@ TEST 143: pgfmanual-en-tikz-graphs-146
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77548,7 +79438,9 @@ TEST 143: pgfmanual-en-tikz-graphs-146
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77601,7 +79493,9 @@ TEST 143: pgfmanual-en-tikz-graphs-146
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77654,7 +79548,9 @@ TEST 143: pgfmanual-en-tikz-graphs-146
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77773,7 +79669,9 @@ TEST 144: pgfmanual-en-tikz-graphs-147
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77826,7 +79724,9 @@ TEST 144: pgfmanual-en-tikz-graphs-147
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77879,7 +79779,9 @@ TEST 144: pgfmanual-en-tikz-graphs-147
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77946,7 +79848,9 @@ TEST 144: pgfmanual-en-tikz-graphs-147
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -77999,7 +79903,9 @@ TEST 144: pgfmanual-en-tikz-graphs-147
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78052,7 +79958,9 @@ TEST 144: pgfmanual-en-tikz-graphs-147
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78105,7 +80013,9 @@ TEST 144: pgfmanual-en-tikz-graphs-147
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78498,7 +80408,9 @@ TEST 145: pgfmanual-en-tikz-graphs-148
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78551,7 +80463,9 @@ TEST 145: pgfmanual-en-tikz-graphs-148
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78604,7 +80518,9 @@ TEST 145: pgfmanual-en-tikz-graphs-148
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78657,7 +80573,9 @@ TEST 145: pgfmanual-en-tikz-graphs-148
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78710,7 +80628,9 @@ TEST 145: pgfmanual-en-tikz-graphs-148
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78763,7 +80683,9 @@ TEST 145: pgfmanual-en-tikz-graphs-148
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -78816,7 +80738,9 @@ TEST 145: pgfmanual-en-tikz-graphs-148
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -79328,7 +81252,9 @@ TEST 146: pgfmanual-en-tikz-graphs-149
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -79381,7 +81307,9 @@ TEST 146: pgfmanual-en-tikz-graphs-149
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -79434,7 +81362,9 @@ TEST 146: pgfmanual-en-tikz-graphs-149
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -79487,7 +81417,9 @@ TEST 146: pgfmanual-en-tikz-graphs-149
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -79554,7 +81486,9 @@ TEST 146: pgfmanual-en-tikz-graphs-149
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -79607,7 +81541,9 @@ TEST 146: pgfmanual-en-tikz-graphs-149
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -79660,7 +81596,9 @@ TEST 146: pgfmanual-en-tikz-graphs-149
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -79713,7 +81651,9 @@ TEST 146: pgfmanual-en-tikz-graphs-149
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -80204,7 +82144,9 @@ TEST 147: pgfmanual-en-tikz-graphs-150
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -80257,7 +82199,9 @@ TEST 147: pgfmanual-en-tikz-graphs-150
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -80310,7 +82254,9 @@ TEST 147: pgfmanual-en-tikz-graphs-150
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -80377,7 +82323,9 @@ TEST 147: pgfmanual-en-tikz-graphs-150
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -80430,7 +82378,9 @@ TEST 147: pgfmanual-en-tikz-graphs-150
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -80483,7 +82433,9 @@ TEST 147: pgfmanual-en-tikz-graphs-150
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -80536,7 +82488,9 @@ TEST 147: pgfmanual-en-tikz-graphs-150
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81147,7 +83101,9 @@ TEST 148: pgfmanual-en-tikz-graphs-151
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81200,7 +83156,9 @@ TEST 148: pgfmanual-en-tikz-graphs-151
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81253,7 +83211,9 @@ TEST 148: pgfmanual-en-tikz-graphs-151
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81413,7 +83373,9 @@ TEST 149: pgfmanual-en-tikz-graphs-152
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81466,7 +83428,9 @@ TEST 149: pgfmanual-en-tikz-graphs-152
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81519,7 +83483,9 @@ TEST 149: pgfmanual-en-tikz-graphs-152
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81572,7 +83538,9 @@ TEST 149: pgfmanual-en-tikz-graphs-152
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81625,7 +83593,9 @@ TEST 149: pgfmanual-en-tikz-graphs-152
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81678,7 +83648,9 @@ TEST 149: pgfmanual-en-tikz-graphs-152
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -81731,7 +83703,9 @@ TEST 149: pgfmanual-en-tikz-graphs-152
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82011,7 +83985,9 @@ TEST 150: pgfmanual-en-tikz-graphs-153
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82065,7 +84041,9 @@ TEST 150: pgfmanual-en-tikz-graphs-153
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82119,7 +84097,9 @@ TEST 150: pgfmanual-en-tikz-graphs-153
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82270,7 +84250,9 @@ TEST 150: pgfmanual-en-tikz-graphs-153
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82324,7 +84306,9 @@ TEST 150: pgfmanual-en-tikz-graphs-153
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82378,7 +84362,9 @@ TEST 150: pgfmanual-en-tikz-graphs-153
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82540,7 +84526,9 @@ TEST 151: pgfmanual-en-tikz-graphs-154
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82594,7 +84582,9 @@ TEST 151: pgfmanual-en-tikz-graphs-154
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82648,7 +84638,9 @@ TEST 151: pgfmanual-en-tikz-graphs-154
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82702,7 +84694,9 @@ TEST 151: pgfmanual-en-tikz-graphs-154
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82890,7 +84884,9 @@ TEST 151: pgfmanual-en-tikz-graphs-154
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82943,7 +84939,9 @@ TEST 151: pgfmanual-en-tikz-graphs-154
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -82996,7 +84994,9 @@ TEST 151: pgfmanual-en-tikz-graphs-154
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83049,7 +85049,9 @@ TEST 151: pgfmanual-en-tikz-graphs-154
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83235,7 +85237,9 @@ TEST 152: pgfmanual-en-tikz-graphs-155
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83277,7 +85281,9 @@ TEST 152: pgfmanual-en-tikz-graphs-155
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83321,7 +85327,9 @@ TEST 152: pgfmanual-en-tikz-graphs-155
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83363,7 +85371,9 @@ TEST 152: pgfmanual-en-tikz-graphs-155
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83405,7 +85415,9 @@ TEST 152: pgfmanual-en-tikz-graphs-155
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83555,7 +85567,9 @@ TEST 153: pgfmanual-en-tikz-graphs-156
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83597,7 +85611,9 @@ TEST 153: pgfmanual-en-tikz-graphs-156
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83639,7 +85655,9 @@ TEST 153: pgfmanual-en-tikz-graphs-156
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83681,7 +85699,9 @@ TEST 153: pgfmanual-en-tikz-graphs-156
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83723,7 +85743,9 @@ TEST 153: pgfmanual-en-tikz-graphs-156
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83890,7 +85912,9 @@ TEST 154: pgfmanual-en-tikz-graphs-157
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83943,7 +85967,9 @@ TEST 154: pgfmanual-en-tikz-graphs-157
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -83996,7 +86022,9 @@ TEST 154: pgfmanual-en-tikz-graphs-157
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -84049,7 +86077,9 @@ TEST 154: pgfmanual-en-tikz-graphs-157
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -84102,7 +86132,9 @@ TEST 154: pgfmanual-en-tikz-graphs-157
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -84155,7 +86187,9 @@ TEST 154: pgfmanual-en-tikz-graphs-157
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -84208,7 +86242,9 @@ TEST 154: pgfmanual-en-tikz-graphs-157
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -84759,7 +86795,9 @@ TEST 155: pgfmanual-en-tikz-graphs-158
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -84801,7 +86839,9 @@ TEST 155: pgfmanual-en-tikz-graphs-158
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -84843,7 +86883,9 @@ TEST 155: pgfmanual-en-tikz-graphs-158
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -84964,7 +87006,9 @@ TEST 155: pgfmanual-en-tikz-graphs-158
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85006,7 +87050,9 @@ TEST 155: pgfmanual-en-tikz-graphs-158
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85048,7 +87094,9 @@ TEST 155: pgfmanual-en-tikz-graphs-158
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85219,7 +87267,9 @@ TEST 156: pgfmanual-en-tikz-graphs-159
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85272,7 +87322,9 @@ TEST 156: pgfmanual-en-tikz-graphs-159
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85325,7 +87377,9 @@ TEST 156: pgfmanual-en-tikz-graphs-159
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85378,7 +87432,9 @@ TEST 156: pgfmanual-en-tikz-graphs-159
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85431,7 +87487,9 @@ TEST 156: pgfmanual-en-tikz-graphs-159
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85484,7 +87542,9 @@ TEST 156: pgfmanual-en-tikz-graphs-159
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -85537,7 +87597,9 @@ TEST 156: pgfmanual-en-tikz-graphs-159
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86145,7 +88207,9 @@ TEST 157: pgfmanual-en-tikz-graphs-160
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86187,7 +88251,9 @@ TEST 157: pgfmanual-en-tikz-graphs-160
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86229,7 +88295,9 @@ TEST 157: pgfmanual-en-tikz-graphs-160
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86329,7 +88397,9 @@ TEST 157: pgfmanual-en-tikz-graphs-160
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86371,7 +88441,9 @@ TEST 157: pgfmanual-en-tikz-graphs-160
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86413,7 +88485,9 @@ TEST 157: pgfmanual-en-tikz-graphs-160
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86563,7 +88637,9 @@ TEST 158: pgfmanual-en-tikz-graphs-161
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86616,7 +88692,9 @@ TEST 158: pgfmanual-en-tikz-graphs-161
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86669,7 +88747,9 @@ TEST 158: pgfmanual-en-tikz-graphs-161
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86722,7 +88802,9 @@ TEST 158: pgfmanual-en-tikz-graphs-161
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86775,7 +88857,9 @@ TEST 158: pgfmanual-en-tikz-graphs-161
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86828,7 +88912,9 @@ TEST 158: pgfmanual-en-tikz-graphs-161
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -86881,7 +88967,9 @@ TEST 158: pgfmanual-en-tikz-graphs-161
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87463,7 +89551,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87505,7 +89595,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87565,7 +89657,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87607,7 +89701,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87649,7 +89745,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87860,7 +89958,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87902,7 +90002,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87944,7 +90046,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+0.0)x2.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 i
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -87986,7 +90090,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+2.05)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -88327,7 +90433,9 @@ TEST 159: pgfmanual-en-tikz-graphs-162
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.28, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 k
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -88584,7 +90692,9 @@ TEST 160: pgfmanual-en-tikz-graphs-163
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -88626,7 +90736,9 @@ TEST 160: pgfmanual-en-tikz-graphs-163
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -88668,7 +90780,9 @@ TEST 160: pgfmanual-en-tikz-graphs-163
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -88710,7 +90824,9 @@ TEST 160: pgfmanual-en-tikz-graphs-163
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -88752,7 +90868,9 @@ TEST 160: pgfmanual-en-tikz-graphs-163
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -88794,7 +90912,9 @@ TEST 160: pgfmanual-en-tikz-graphs-163
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89125,7 +91245,9 @@ TEST 161: pgfmanual-en-tikz-graphs-164
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89178,7 +91300,9 @@ TEST 161: pgfmanual-en-tikz-graphs-164
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89231,7 +91355,9 @@ TEST 161: pgfmanual-en-tikz-graphs-164
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89284,7 +91410,9 @@ TEST 161: pgfmanual-en-tikz-graphs-164
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89337,7 +91465,9 @@ TEST 161: pgfmanual-en-tikz-graphs-164
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89757,7 +91887,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89799,7 +91931,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89841,7 +91975,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89901,7 +92037,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89943,7 +92081,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -89985,7 +92125,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90128,7 +92270,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.53+2.06)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90170,7 +92314,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 h
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90294,7 +92440,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+0.0)x2.78, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 i
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90336,7 +92484,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+2.05)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 j
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90378,7 +92528,9 @@ TEST 162: pgfmanual-en-tikz-graphs-165
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.0)x5.28, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 k
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90550,7 +92702,9 @@ TEST 163: pgfmanual-en-tikz-graphs-166
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90594,7 +92748,9 @@ TEST 163: pgfmanual-en-tikz-graphs-166
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90636,7 +92792,9 @@ TEST 163: pgfmanual-en-tikz-graphs-166
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90746,7 +92904,9 @@ TEST 163: pgfmanual-en-tikz-graphs-166
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90788,7 +92948,9 @@ TEST 163: pgfmanual-en-tikz-graphs-166
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -90904,7 +93066,9 @@ TEST 163: pgfmanual-en-tikz-graphs-166
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.0)x3.06, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 f
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91060,7 +93224,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91113,7 +93279,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91166,7 +93334,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91219,7 +93389,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91272,7 +93444,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91325,7 +93499,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91378,7 +93554,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91431,7 +93609,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91484,7 +93664,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91537,8 +93719,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91591,8 +93775,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91645,8 +93831,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91713,7 +93901,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91766,7 +93956,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91819,7 +94011,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91872,7 +94066,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91925,7 +94121,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -91978,7 +94176,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -92031,7 +94231,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -92084,7 +94286,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -92137,7 +94341,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -92190,8 +94396,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -92244,8 +94452,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -92298,8 +94508,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -92899,7 +95111,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -92952,7 +95166,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93005,7 +95221,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93058,7 +95276,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 4
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93111,7 +95331,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93164,7 +95386,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93217,7 +95441,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.76+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 7
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93270,7 +95496,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 8
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93323,7 +95551,9 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 9
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93376,8 +95606,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93430,8 +95662,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -93484,8 +95718,10 @@ TEST 164: pgfmanual-en-tikz-graphs-167
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-matrices.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-matrices.tlg
@@ -131,11 +131,13 @@ TEST 1: pgfmanual-en-tikz-matrices-1
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x22.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 H
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 o
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -309,7 +311,9 @@ TEST 2: pgfmanual-en-tikz-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(9.16708+0.16592)x9.51967, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/20.74 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -368,7 +372,9 @@ TEST 2: pgfmanual-en-tikz-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(14.16542+0.0)x14.37282, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/20.74 X
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -427,7 +433,9 @@ TEST 2: pgfmanual-en-tikz-matrices-2
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(9.25005+4.23096)x9.51967, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/20.74 g
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -548,7 +556,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -593,7 +603,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.0)x7.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 X
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -638,7 +650,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.53+2.06)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 g
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -687,7 +701,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -732,7 +748,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.0)x7.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 X
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -777,7 +795,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.53+2.06)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 g
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -856,7 +876,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -901,7 +923,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.0)x7.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 X
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -946,7 +970,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.53+2.06)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 g
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -995,7 +1021,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1040,7 +1068,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.0)x7.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 X
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1085,7 +1115,9 @@ TEST 3: pgfmanual-en-tikz-matrices-3
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.53+2.06)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 g
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1184,11 +1216,13 @@ TEST 4: pgfmanual-en-tikz-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x23.06, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 H
 .....................\TU/lmr/m/n/10 a
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 o
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1247,7 +1281,9 @@ TEST 4: pgfmanual-en-tikz-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.0)x7.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 X
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1306,7 +1342,9 @@ TEST 4: pgfmanual-en-tikz-matrices-4
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.53+2.06)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 g
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1421,7 +1459,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1462,7 +1502,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1503,7 +1545,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1548,7 +1592,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1589,7 +1635,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1630,7 +1678,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1675,7 +1725,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1716,7 +1768,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1757,7 +1811,9 @@ TEST 5: pgfmanual-en-tikz-matrices-5
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1853,9 +1909,11 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1896,7 +1954,9 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1937,7 +1997,9 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -1982,8 +2044,10 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2024,8 +2088,10 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2066,7 +2132,9 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2111,7 +2179,9 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2152,9 +2222,11 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2195,7 +2267,9 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2274,11 +2348,13 @@ TEST 6: pgfmanual-en-tikz-matrices-6
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2363,9 +2439,11 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2406,7 +2484,9 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2447,7 +2527,9 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2492,8 +2574,10 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2534,8 +2618,10 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2576,7 +2662,9 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2621,7 +2709,9 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2662,9 +2752,11 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2705,7 +2797,9 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2763,11 +2857,13 @@ TEST 7: pgfmanual-en-tikz-matrices-7
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2852,9 +2948,11 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2895,7 +2993,9 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2936,7 +3036,9 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -2981,8 +3083,10 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3023,8 +3127,10 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3065,7 +3171,9 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3110,7 +3218,9 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3151,9 +3261,11 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3194,7 +3306,9 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3252,11 +3366,13 @@ TEST 8: pgfmanual-en-tikz-matrices-8
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3341,9 +3457,11 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3384,7 +3502,9 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3425,7 +3545,9 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3472,8 +3594,10 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3514,8 +3638,10 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3556,7 +3682,9 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3603,7 +3731,9 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3644,9 +3774,11 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3687,7 +3819,9 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3745,11 +3879,13 @@ TEST 9: pgfmanual-en-tikz-matrices-9
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4039,11 +4175,13 @@ TEST 10: pgfmanual-en-tikz-matrices-10
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4128,7 +4266,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4169,7 +4309,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4210,7 +4352,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4255,7 +4399,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4296,7 +4442,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4337,7 +4485,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4382,7 +4532,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4423,7 +4575,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4464,7 +4618,9 @@ TEST 11: pgfmanual-en-tikz-matrices-11
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4560,7 +4716,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4601,7 +4759,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4642,7 +4802,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4687,7 +4849,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4728,7 +4892,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4769,7 +4935,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4814,7 +4982,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4855,7 +5025,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4896,7 +5068,9 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4954,12 +5128,14 @@ TEST 12: pgfmanual-en-tikz-matrices-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.0)x26.66, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5044,7 +5220,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5085,7 +5263,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5126,7 +5306,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5171,7 +5353,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5212,7 +5396,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5253,7 +5439,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5298,7 +5486,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5339,7 +5529,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5380,7 +5572,9 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5438,12 +5632,14 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x26.66, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5489,12 +5685,14 @@ TEST 13: pgfmanual-en-tikz-matrices-13
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.66+0.22)x26.66, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 m
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5581,7 +5779,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5626,7 +5826,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5671,7 +5873,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5720,7 +5924,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5765,7 +5971,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5810,7 +6018,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5859,7 +6069,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5904,7 +6116,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5949,7 +6163,9 @@ TEST 14: pgfmanual-en-tikz-matrices-14
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6043,9 +6259,11 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 8
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6087,9 +6305,11 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 1
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6131,9 +6351,11 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 6
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6177,7 +6399,9 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6217,9 +6441,11 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{0 0.5 0 RG }
 ....................\pdfliteral origin{0 0.5 0 rg }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 .....................\TU/lmr/m/n/10 5
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6259,7 +6485,9 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6302,7 +6530,9 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6342,9 +6572,11 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{0 0.5 0 RG }
 ....................\pdfliteral origin{0 0.5 0 rg }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 0.5 0 rg 0 0.5 0 RG}
 .....................\TU/lmr/m/n/10 9
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6385,9 +6617,11 @@ TEST 15: pgfmanual-en-tikz-matrices-15
 ....................\pdfliteral origin{0 0 1 RG }
 ....................\pdfliteral origin{0 0 1 rg }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 .....................\TU/lmr/m/n/10 2
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6479,9 +6713,11 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6518,9 +6754,11 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
 .....................\TU/lmr/m/n/10 5
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6559,9 +6797,11 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
 .....................\TU/lmr/m/n/10 8
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6602,8 +6842,10 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6640,8 +6882,10 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6680,8 +6924,10 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6722,7 +6968,9 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6759,7 +7007,9 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6798,7 +7048,9 @@ TEST 16: pgfmanual-en-tikz-matrices-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6897,6 +7149,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{1 G }
 ....................\pdfliteral origin{1 g }
 ....................\hbox(0.0+0.86198)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(0.0+0.0)x56.9055, direction TLT
 ......................\hbox(0.0+0.0)x56.9055, glue set 1.42264, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -6912,6 +7165,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6956,6 +7210,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{1 G }
 ....................\pdfliteral origin{1 g }
 ....................\hbox(6.94+0.86198)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+0.11)x56.9055, direction TLT
 ......................\hbox(6.94+0.11)x56.9055, glue set 0.86914, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -6978,6 +7233,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7022,6 +7278,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{1 G }
 ....................\pdfliteral origin{1 g }
 ....................\hbox(7.16+0.86198)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(7.16+0.22)x56.9055, direction TLT
 ......................\hbox(7.16+0.22)x56.9055, glue set 0.48663, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7048,6 +7305,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7092,6 +7350,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{1 G }
 ....................\pdfliteral origin{1 g }
 ....................\hbox(7.05+0.86198)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(7.05+0.11)x56.9055, direction TLT
 ......................\hbox(7.05+0.11)x56.9055, glue set 0.17938, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7123,6 +7382,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7167,6 +7427,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{1 G }
 ....................\pdfliteral origin{1 g }
 ....................\hbox(6.91+0.86198)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.91+1.94)x56.9055, direction TLT
 ......................\hbox(6.91+1.94)x56.9055, glue set 0.38313, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7197,6 +7458,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7247,6 +7509,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+0.11)x56.9055, direction TLT
 ......................\hbox(6.94+0.11)x56.9055, glue set 0.39006, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7272,6 +7535,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7316,6 +7580,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7332,6 +7597,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7376,6 +7642,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7392,6 +7659,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7436,6 +7704,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7452,6 +7721,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7496,6 +7766,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7512,6 +7783,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7560,6 +7832,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+0.11)x56.9055, direction TLT
 ......................\hbox(6.94+0.11)x56.9055, glue set 0.39006, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7585,6 +7858,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7623,6 +7897,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7639,6 +7914,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7677,6 +7953,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7693,6 +7970,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7731,6 +8009,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7747,6 +8026,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7785,6 +8065,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7801,6 +8082,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7851,6 +8133,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(7.06+0.11)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(7.06+0.11)x56.9055, direction TLT
 ......................\hbox(7.06+0.11)x56.9055, glue set 0.39706, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7876,6 +8159,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7920,6 +8204,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(0.0+0.0)x56.9055, direction TLT
 ......................\hbox(0.0+0.0)x56.9055, glue set 1.42264, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7933,6 +8218,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7977,6 +8263,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(0.0+0.0)x56.9055, direction TLT
 ......................\hbox(0.0+0.0)x56.9055, glue set 1.42264, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -7990,6 +8277,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8034,6 +8322,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(0.0+0.0)x56.9055, direction TLT
 ......................\hbox(0.0+0.0)x56.9055, glue set 1.42264, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8047,6 +8336,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8091,6 +8381,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8107,6 +8398,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8155,6 +8447,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+0.11)x56.9055, direction TLT
 ......................\hbox(6.94+0.11)x56.9055, glue set 0.37631, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8180,6 +8473,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8218,6 +8512,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(0.0+0.0)x56.9055, direction TLT
 ......................\hbox(0.0+0.0)x56.9055, glue set 1.42264, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8231,6 +8526,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8269,6 +8565,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8285,6 +8582,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8323,6 +8621,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8339,6 +8638,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8377,6 +8677,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8393,6 +8694,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8443,6 +8745,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.91+0.11)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.91+0.11)x56.9055, direction TLT
 ......................\hbox(6.91+0.11)x56.9055, glue set 0.40756, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8468,6 +8771,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8512,6 +8816,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(0.0+0.0)x56.9055, direction TLT
 ......................\hbox(0.0+0.0)x56.9055, glue set 1.42264, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8525,6 +8830,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8569,6 +8875,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(0.0+0.0)x56.9055, direction TLT
 ......................\hbox(0.0+0.0)x56.9055, glue set 1.42264, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8582,6 +8889,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8626,6 +8934,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8642,6 +8951,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8686,6 +8996,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.44444+0.0)x56.9055, direction TLT
+.....................\begindir TLT
 .....................\vbox(4.44444+0.0)x56.9055, direction TLT
 ......................\hbox(4.44444+0.0)x56.9055, glue set 1.29764, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -8702,6 +9013,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8766,6 +9078,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(45.2+45.2)x63.97144, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x63.97144, direction TLT
 ............\hbox(0.0+0.0)x63.97144, glue set 31.98572fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -8779,6 +9092,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8809,6 +9123,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 0 0 0 K }
 ..........\pdfliteral origin{1 0 0 0 k }
 ..........\hbox(18.94+0.11)x31.79, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 0 k 1 0 0 0 K}
 ...........\vbox(18.94+0.11)x31.79, direction TLT
 ............\hbox(6.94+1.94)x31.79, direction TLT
@@ -8847,6 +9162,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8927,7 +9243,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8966,7 +9284,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9005,7 +9325,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 6
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9048,7 +9370,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9087,7 +9411,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 5
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9126,7 +9452,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9169,7 +9497,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 4
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9208,7 +9538,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 9
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9247,7 +9579,9 @@ TEST 18: pgfmanual-en-tikz-matrices-20
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9340,7 +9674,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 8
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9379,7 +9715,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9418,7 +9756,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(2.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 –
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9461,7 +9801,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9500,7 +9842,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(2.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 –
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9539,7 +9883,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.76+0.22)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 7
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9582,7 +9928,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(2.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 –
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9621,7 +9969,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(2.77+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 –
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9660,7 +10010,9 @@ TEST 19: pgfmanual-en-tikz-matrices-21
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9752,9 +10104,11 @@ TEST 20: pgfmanual-en-tikz-matrices-22
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9797,8 +10151,10 @@ TEST 20: pgfmanual-en-tikz-matrices-22
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9841,7 +10197,9 @@ TEST 20: pgfmanual-en-tikz-matrices-22
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9906,9 +10264,11 @@ TEST 20: pgfmanual-en-tikz-matrices-22
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.22)x15.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
 .....................\TU/lmr/m/n/10 3
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9951,8 +10311,10 @@ TEST 20: pgfmanual-en-tikz-matrices-22
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x10.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
 .....................\TU/lmr/m/n/10 2
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9995,7 +10357,9 @@ TEST 20: pgfmanual-en-tikz-matrices-22
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.66+0.0)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 1
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10124,7 +10488,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10163,7 +10529,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x5.56, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 b
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10202,7 +10570,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x4.44, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 c
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10241,7 +10611,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x5.56, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 d
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10284,7 +10656,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10323,7 +10697,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x5.56, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 b
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10362,7 +10738,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x4.44, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 c
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10401,7 +10779,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x5.56, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 d
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10444,7 +10824,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10483,7 +10865,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x5.56, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 b
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10522,7 +10906,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x4.44, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 c
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10561,7 +10947,9 @@ TEST 21: pgfmanual-en-tikz-matrices-23
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x5.56, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 d
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10685,11 +11073,13 @@ TEST 22: pgfmanual-en-tikz-matrices-24
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x22.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 H
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 o
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10831,10 +11221,12 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x7.91803, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 U
 .....................\kern1.09026 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10910,6 +11302,7 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+1.49998)x35.75824, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\hbox(6.83331+1.49998)x35.75824, direction TLT
 ......................\OML/cmm/m/it/10 X
@@ -10922,6 +11315,7 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ......................\OML/cmm/m/it/10 Y
 ......................\kern2.22223 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -10960,10 +11354,12 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x9.06943, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 X
 .....................\kern0.7847 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -11017,10 +11413,12 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x8.02779, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 Y
 .....................\kern2.22223 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -11059,10 +11457,12 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x7.54167, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 Z
 .....................\kern0.71527 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -11123,9 +11523,11 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.01389+0.0)x4.53473, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/7 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11186,9 +11588,11 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.01389+1.3611)x4.12234, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/7 p
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11214,10 +11618,12 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.8611+1.3611)x4.68408, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/7 f
 ...........\kern0.78473 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11243,10 +11649,12 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.01389+1.3611)x4.15245, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/7 g
 ...........\kern0.25116 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11270,10 +11678,12 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.01389+1.3611)x3.91634, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/7 q
 ...........\kern0.25116 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11297,10 +11707,12 @@ TEST 23: pgfmanual-en-tikz-matrices-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.01389+1.3611)x4.30675, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/7 y
 ...........\kern0.25116 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11399,9 +11811,11 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x7.50002, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 A
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -11461,10 +11875,12 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x8.0868, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 B
 .....................\kern0.50172 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -11507,10 +11923,12 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x7.95831, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 E
 .....................\kern0.57637 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -11553,10 +11971,12 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x7.86249, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 C
 .....................\kern0.71527 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -11616,10 +12036,12 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83331+0.0)x8.55695, direction TLT
+.....................\begindir TLT
 .....................\mathon
 .....................\OML/cmm/m/it/10 D
 .....................\kern0.27779 (italic)
 .....................\mathoff
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -11677,7 +12099,9 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.978+1.845)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/9 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11716,7 +12140,9 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.345+1.845)x2.835, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/9 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11750,7 +12176,9 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.978+0.099)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/9 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11786,7 +12214,9 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.255+0.099)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/9 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11822,7 +12252,9 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.978+0.099)x4.725, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/9 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11877,7 +12309,9 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.255+0.099)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/9 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11901,7 +12335,9 @@ TEST 24: pgfmanual-en-tikz-matrices-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.978+0.099)x4.248, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/9 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11987,6 +12423,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12029,6 +12467,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12071,6 +12511,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12113,6 +12555,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12161,6 +12605,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12203,6 +12649,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12245,6 +12693,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12287,6 +12737,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12327,6 +12779,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12369,6 +12823,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12411,6 +12867,8 @@ TEST 25: pgfmanual-en-tikz-matrices-27
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12693,6 +13151,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.15+1.94)x27.81, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 x
 .....................\discretionary (penalty 50)
@@ -12702,6 +13161,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 r
 .....................\TU/lmr/m/n/10 t
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12760,6 +13220,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+12.11)x50.0, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+12.11)x50.0, direction TLT
 ......................\hbox(6.94+0.11)x50.0, glue set 0.31924, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -12798,6 +13259,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12849,6 +13311,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.15+2.05)x29.82, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 s
 .....................\TU/lmr/m/n/10 y
 .....................\TU/lmr/m/n/10 s
@@ -12857,6 +13320,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 .....................\TU/lmr/m/n/10 t
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 m
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -12930,6 +13394,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(7.05+24.11)x50.0, direction TLT
+.....................\begindir TLT
 .....................\vbox(7.05+24.11)x50.0, direction TLT
 ......................\hbox(7.05+2.05)x50.0, glue set 0.42325, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -12983,6 +13448,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -13056,6 +13522,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+12.11)x50.0, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+12.11)x50.0, direction TLT
 ......................\hbox(6.94+1.94)x50.0, glue set 0.49275, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -13089,6 +13556,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -13147,6 +13615,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+24.11)x50.0, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+24.11)x50.0, direction TLT
 ......................\hbox(6.94+0.11)x50.0, glue set 0.35425, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -13205,6 +13674,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -13280,6 +13750,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+12.11)x45.0, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.94+12.11)x45.0, direction TLT
 ......................\hbox(6.94+0.11)x45.0, glue set 8.42fil, direction TLT
 .......................\glue(\leftskip) 0.0 plus 1.0fil
@@ -13319,6 +13790,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 1.0fil
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -13403,6 +13875,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.15+1.94)x50.0, direction TLT
+.....................\begindir TLT
 .....................\vbox(6.15+1.94)x50.0, direction TLT
 ......................\hbox(6.15+1.94)x50.0, glue set 0.79025, direction TLT
 .......................\glue(\leftskip) 0.0 plus 20.0
@@ -13420,6 +13893,7 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 .......................\penalty 10000
 .......................\glue(\parfillskip) 0.0
 .......................\glue(\rightskip) 0.0 plus 20.0
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -13552,10 +14026,12 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+2.05)x13.38, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 s
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13596,8 +14072,10 @@ TEST 26: pgfmanual-en-tikz-matrices-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x10.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-paths.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-paths.tlg
@@ -231,8 +231,10 @@ TEST 5: pgfmanual-en-tikz-paths-5
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -351,10 +353,12 @@ TEST 7: pgfmanual-en-tikz-paths-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x13.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -595,7 +599,9 @@ TEST 12: pgfmanual-en-tikz-paths-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -623,7 +629,9 @@ TEST 12: pgfmanual-en-tikz-paths-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1391,10 +1399,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x6.43404, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 ^^K
 ...........\kern0.03702 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1422,10 +1432,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+1.94444)x6.18402, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 ^^L
 ...........\kern0.52777 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2330,6 +2342,7 @@ TEST 36: pgfmanual-en-tikz-paths-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+1.94)x42.81999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 p
 ...........\discretionary (penalty 50)
@@ -2343,6 +2356,7 @@ TEST 36: pgfmanual-en-tikz-paths-37
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2509,7 +2523,9 @@ TEST 37: pgfmanual-en-tikz-paths-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2603,7 +2619,9 @@ TEST 38: pgfmanual-en-tikz-paths-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2637,7 +2655,9 @@ TEST 38: pgfmanual-en-tikz-paths-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2696,7 +2716,9 @@ TEST 39: pgfmanual-en-tikz-paths-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2730,7 +2752,9 @@ TEST 39: pgfmanual-en-tikz-paths-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2789,7 +2813,9 @@ TEST 40: pgfmanual-en-tikz-paths-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2848,7 +2874,9 @@ TEST 41: pgfmanual-en-tikz-paths-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2874,7 +2902,9 @@ TEST 41: pgfmanual-en-tikz-paths-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2998,7 +3028,9 @@ TEST 44: pgfmanual-en-tikz-paths-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3026,7 +3058,9 @@ TEST 44: pgfmanual-en-tikz-paths-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3054,7 +3088,9 @@ TEST 44: pgfmanual-en-tikz-paths-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3095,7 +3131,9 @@ TEST 44: pgfmanual-en-tikz-paths-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3156,11 +3194,13 @@ TEST 45: pgfmanual-en-tikz-paths-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x9.30177, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(3.01389+0.0)x4.83765, shifted 1.49998, direction TLT
 ............\OML/cmm/m/it/7 a
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3192,11 +3232,13 @@ TEST 45: pgfmanual-en-tikz-paths-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.48079, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.8611+0.0)x4.01666, shifted 1.49998, direction TLT
 ............\OML/cmm/m/it/7 b
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3236,7 +3278,9 @@ TEST 45: pgfmanual-en-tikz-paths-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3260,7 +3304,9 @@ TEST 45: pgfmanual-en-tikz-paths-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3684,7 +3730,9 @@ TEST 50: pgfmanual-en-tikz-paths-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-pics.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-pics.tlg
@@ -1061,8 +1061,10 @@ TEST 9: pgfmanual-en-tikz-pics-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1751,10 +1753,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x6.43404, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^K
 .............\kern0.03702 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-plots.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-plots.tlg
@@ -344,9 +344,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -382,6 +384,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x19.46533, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
 ...........\kern1.0764 (italic)
@@ -389,6 +392,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/10 x
 ...........\OT1/cmr/m/n/10 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -446,6 +450,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(7.5+2.5)x38.51382, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -459,6 +464,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -517,6 +523,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(7.5+2.5)x52.45825, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -536,6 +543,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -594,6 +602,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(8.44843+3.44841)x52.64998, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -624,6 +633,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ............\OML/cmm/m/it/7 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -893,9 +903,11 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -931,6 +943,7 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x19.46533, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
 ...........\kern1.0764 (italic)
@@ -938,6 +951,7 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ...........\OML/cmm/m/it/10 x
 ...........\OT1/cmr/m/n/10 )
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -994,6 +1008,7 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(7.5+2.5)x38.51382, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -1007,6 +1022,7 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1064,6 +1080,7 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(7.5+2.5)x52.45825, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -1083,6 +1100,7 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1140,6 +1158,7 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(8.44843+3.44841)x52.64998, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 f
@@ -1170,6 +1189,7 @@ runsystem(gnuplot pgfmanual-en-tikz-plots.exp.gnuplot)...executed.
 ............\OML/cmm/m/it/7 x
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-scopes.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-scopes.tlg
@@ -93,6 +93,7 @@ TEST 2: pgfmanual-en-tikz-scopes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x26.98, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 w
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 o
@@ -100,6 +101,7 @@ TEST 2: pgfmanual-en-tikz-scopes-2
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -243,7 +245,9 @@ TEST 4: pgfmanual-en-tikz-scopes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -271,7 +275,9 @@ TEST 4: pgfmanual-en-tikz-scopes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -523,6 +529,7 @@ TEST 7: pgfmanual-en-tikz-scopes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x50.03, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -535,6 +542,7 @@ TEST 7: pgfmanual-en-tikz-scopes-9
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1020,9 +1028,11 @@ TEST 13: pgfmanual-en-tikz-scopes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x13.92, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1060,10 +1070,12 @@ TEST 13: pgfmanual-en-tikz-scopes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x18.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1130,6 +1142,7 @@ TEST 14: pgfmanual-en-tikz-scopes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x30.29, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\discretionary (penalty 50)
@@ -1139,6 +1152,7 @@ TEST 14: pgfmanual-en-tikz-scopes-17
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1176,10 +1190,12 @@ TEST 14: pgfmanual-en-tikz-scopes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x18.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-shapes.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-shapes.tlg
@@ -38,6 +38,7 @@ TEST 1: pgfmanual-en-tikz-shapes-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x53.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
@@ -52,6 +53,7 @@ TEST 1: pgfmanual-en-tikz-shapes-1
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -84,6 +86,7 @@ TEST 1: pgfmanual-en-tikz-shapes-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x41.48, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ﬁ
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 s
@@ -94,6 +97,7 @@ TEST 1: pgfmanual-en-tikz-shapes-1
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -119,6 +123,7 @@ TEST 1: pgfmanual-en-tikz-shapes-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.87999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
@@ -130,6 +135,7 @@ TEST 1: pgfmanual-en-tikz-shapes-1
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -193,9 +199,11 @@ TEST 2: pgfmanual-en-tikz-shapes-2
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 A
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -227,9 +235,11 @@ TEST 2: pgfmanual-en-tikz-shapes-2
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\TU/lmr/m/n/10 B
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -261,9 +271,11 @@ TEST 2: pgfmanual-en-tikz-shapes-2
 ..........\pdfliteral origin{0 1 0 RG }
 ..........\pdfliteral origin{0 1 0 rg }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 1 0 rg 0 1 0 RG}
 ...........\TU/lmr/m/n/10 C
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -290,7 +302,9 @@ TEST 2: pgfmanual-en-tikz-shapes-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -356,6 +370,7 @@ TEST 3: pgfmanual-en-tikz-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x41.48, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ﬁ
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 s
@@ -366,6 +381,7 @@ TEST 3: pgfmanual-en-tikz-shapes-3
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -397,6 +413,7 @@ TEST 3: pgfmanual-en-tikz-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x53.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
@@ -411,6 +428,7 @@ TEST 3: pgfmanual-en-tikz-shapes-3
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -442,6 +460,7 @@ TEST 3: pgfmanual-en-tikz-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.87999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
@@ -453,6 +472,7 @@ TEST 3: pgfmanual-en-tikz-shapes-3
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -494,6 +514,7 @@ TEST 3: pgfmanual-en-tikz-shapes-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x51.15999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 u
@@ -506,6 +527,7 @@ TEST 3: pgfmanual-en-tikz-shapes-3
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -567,6 +589,7 @@ TEST 4: pgfmanual-en-tikz-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x53.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
@@ -581,6 +604,7 @@ TEST 4: pgfmanual-en-tikz-shapes-4
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -613,6 +637,7 @@ TEST 4: pgfmanual-en-tikz-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x41.48, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ﬁ
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 s
@@ -623,6 +648,7 @@ TEST 4: pgfmanual-en-tikz-shapes-4
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -683,6 +709,7 @@ TEST 4: pgfmanual-en-tikz-shapes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.87999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
@@ -694,6 +721,7 @@ TEST 4: pgfmanual-en-tikz-shapes-4
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -758,6 +786,7 @@ TEST 5: pgfmanual-en-tikz-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x53.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
@@ -772,6 +801,7 @@ TEST 5: pgfmanual-en-tikz-shapes-5
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -804,6 +834,7 @@ TEST 5: pgfmanual-en-tikz-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x41.48, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ﬁ
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 s
@@ -814,6 +845,7 @@ TEST 5: pgfmanual-en-tikz-shapes-5
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -847,6 +879,7 @@ TEST 5: pgfmanual-en-tikz-shapes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.87999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 h
 ...........\TU/lmr/m/n/10 i
@@ -858,6 +891,7 @@ TEST 5: pgfmanual-en-tikz-shapes-5
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -946,6 +980,7 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x41.1, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 i
@@ -956,6 +991,7 @@ Package pgf Warning: Your graphic driver pgfsys-luatex.def does not support anim
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1014,7 +1050,9 @@ TEST 7: pgfmanual-en-tikz-shapes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1040,7 +1078,9 @@ TEST 7: pgfmanual-en-tikz-shapes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1066,7 +1106,9 @@ TEST 7: pgfmanual-en-tikz-shapes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1125,7 +1167,9 @@ TEST 8: pgfmanual-en-tikz-shapes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1151,7 +1195,9 @@ TEST 8: pgfmanual-en-tikz-shapes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1177,7 +1223,9 @@ TEST 8: pgfmanual-en-tikz-shapes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1236,9 +1284,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1266,9 +1316,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1296,9 +1348,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1326,9 +1380,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1356,9 +1412,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1386,9 +1444,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1416,9 +1476,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1446,9 +1508,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1476,9 +1540,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1506,9 +1572,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1536,9 +1604,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1566,9 +1636,11 @@ TEST 9: pgfmanual-en-tikz-shapes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1632,7 +1704,9 @@ TEST 10: pgfmanual-en-tikz-shapes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1660,7 +1734,9 @@ TEST 10: pgfmanual-en-tikz-shapes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1724,7 +1800,9 @@ TEST 11: pgfmanual-en-tikz-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1769,7 +1847,9 @@ TEST 11: pgfmanual-en-tikz-shapes-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1827,10 +1907,12 @@ TEST 12: pgfmanual-en-tikz-shapes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x29.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
 ...........\TU/lmr/m/n/10 B
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1890,7 +1972,9 @@ TEST 13: pgfmanual-en-tikz-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1918,7 +2002,9 @@ TEST 13: pgfmanual-en-tikz-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1960,7 +2046,9 @@ TEST 13: pgfmanual-en-tikz-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1988,7 +2076,9 @@ TEST 13: pgfmanual-en-tikz-shapes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2072,6 +2162,8 @@ TEST 14: pgfmanual-en-tikz-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2099,6 +2191,8 @@ TEST 14: pgfmanual-en-tikz-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2126,6 +2220,8 @@ TEST 14: pgfmanual-en-tikz-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2153,6 +2249,8 @@ TEST 14: pgfmanual-en-tikz-shapes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2269,12 +2367,14 @@ TEST 15: pgfmanual-en-tikz-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x20.84, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 h
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2302,12 +2402,14 @@ TEST 15: pgfmanual-en-tikz-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x21.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2339,6 +2441,7 @@ TEST 15: pgfmanual-en-tikz-shapes-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x30.29, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\discretionary (penalty 50)
@@ -2348,6 +2451,7 @@ TEST 15: pgfmanual-en-tikz-shapes-15
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2416,11 +2520,13 @@ TEST 16: pgfmanual-en-tikz-shapes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x21.12, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ﬁ
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2448,12 +2554,14 @@ TEST 16: pgfmanual-en-tikz-shapes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x26.98, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 a
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 w
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2486,12 +2594,14 @@ TEST 16: pgfmanual-en-tikz-shapes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x26.16, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2597,11 +2707,13 @@ TEST 17: pgfmanual-en-tikz-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x21.12, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ﬁ
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2629,12 +2741,14 @@ TEST 17: pgfmanual-en-tikz-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x26.98, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 a
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 w
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2668,12 +2782,14 @@ TEST 17: pgfmanual-en-tikz-shapes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x26.16, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2769,9 +2885,11 @@ TEST 18: pgfmanual-en-tikz-shapes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2799,9 +2917,11 @@ TEST 18: pgfmanual-en-tikz-shapes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x17.77, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2864,6 +2984,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x22.22217, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\glue(\medmuskip) 2.22217 plus 1.11108 minus 2.22217
@@ -2871,6 +2992,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\glue(\medmuskip) 2.22217 plus 1.11108 minus 2.22217
 ...........\OT1/cmr/m/n/10 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2931,12 +3053,14 @@ TEST 20: pgfmanual-en-tikz-shapes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+1.94)x28.14, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 q
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2970,6 +3094,7 @@ TEST 20: pgfmanual-en-tikz-shapes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -2978,6 +3103,7 @@ TEST 20: pgfmanual-en-tikz-shapes-20
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3039,6 +3165,7 @@ TEST 21: pgfmanual-en-tikz-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.94)x35.88, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 s
 ...........\discretionary (penalty 50)
@@ -3050,6 +3177,7 @@ TEST 21: pgfmanual-en-tikz-shapes-21
 ...........\TU/lmr/m/n/10 t
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3082,6 +3210,7 @@ TEST 21: pgfmanual-en-tikz-shapes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.94)x35.88, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 s
 ...........\discretionary (penalty 50)
@@ -3093,6 +3222,7 @@ TEST 21: pgfmanual-en-tikz-shapes-21
 ...........\TU/lmr/m/n/10 t
 ...........\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3153,7 +3283,9 @@ TEST 22: pgfmanual-en-tikz-shapes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3182,7 +3314,9 @@ TEST 22: pgfmanual-en-tikz-shapes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3211,7 +3345,9 @@ TEST 22: pgfmanual-en-tikz-shapes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3240,7 +3376,9 @@ TEST 22: pgfmanual-en-tikz-shapes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3299,10 +3437,12 @@ TEST 23: pgfmanual-en-tikz-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3331,10 +3471,12 @@ TEST 23: pgfmanual-en-tikz-shapes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3394,7 +3536,9 @@ TEST 24: pgfmanual-en-tikz-shapes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3424,7 +3568,9 @@ TEST 24: pgfmanual-en-tikz-shapes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3647,11 +3793,13 @@ TEST 25: pgfmanual-en-tikz-shapes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3665,12 +3813,14 @@ TEST 25: pgfmanual-en-tikz-shapes-25
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+0.0)x10.00003, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\mathon
 ..........\OT1/cmr/m/n/10 0
 ..........\OT1/cmr/m/n/10 0
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3737,11 +3887,13 @@ TEST 26: pgfmanual-en-tikz-shapes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3755,12 +3907,14 @@ TEST 26: pgfmanual-en-tikz-shapes-26
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(6.44444+0.0)x10.00003, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\mathon
 ..........\OT1/cmr/m/n/10 0
 ..........\OT1/cmr/m/n/10 0
 ..........\mathoff
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -3822,11 +3976,13 @@ TEST 27: pgfmanual-en-tikz-shapes-27
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+0.11)x13.92, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3860,11 +4016,13 @@ TEST 27: pgfmanual-en-tikz-shapes-27
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+0.11)x13.92, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3901,11 +4059,13 @@ TEST 27: pgfmanual-en-tikz-shapes-27
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+0.11)x13.92, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3967,12 +4127,14 @@ TEST 28: pgfmanual-en-tikz-shapes-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x21.73003, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 i
 ...........\TU/lmr/m/it/10 t
 ...........\TU/lmr/m/it/10 a
 ...........\TU/lmr/m/it/10 l
 ...........\TU/lmr/m/it/10 i
 ...........\TU/lmr/m/it/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4031,11 +4193,13 @@ TEST 29: pgfmanual-en-tikz-shapes-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.305+1.025)x11.875, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 t
 ...........\TU/lmr/m/n/5 i
 ...........\TU/lmr/m/n/5 n
 ...........\kern-0.175 (font)
 ...........\TU/lmr/m/n/5 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4083,11 +4247,13 @@ TEST 29: pgfmanual-en-tikz-shapes-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.246+0.099)x21.12302, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 s
 ...........\TU/lmr/m/n/9 m
 ...........\TU/lmr/m/n/9 a
 ...........\TU/lmr/m/n/9 l
 ...........\TU/lmr/m/n/9 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4144,12 +4310,14 @@ TEST 30: pgfmanual-en-tikz-shapes-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x21.73003, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 i
 ...........\TU/lmr/m/it/10 t
 ...........\TU/lmr/m/it/10 a
 ...........\TU/lmr/m/it/10 l
 ...........\TU/lmr/m/it/10 i
 ...........\TU/lmr/m/it/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4208,11 +4376,13 @@ TEST 31: pgfmanual-en-tikz-shapes-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.305+1.025)x11.875, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 t
 ...........\TU/lmr/m/n/5 i
 ...........\TU/lmr/m/n/5 n
 ...........\kern-0.175 (font)
 ...........\TU/lmr/m/n/5 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4260,11 +4430,13 @@ TEST 31: pgfmanual-en-tikz-shapes-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.246+0.099)x21.12302, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 s
 ...........\TU/lmr/m/n/9 m
 ...........\TU/lmr/m/n/9 a
 ...........\TU/lmr/m/n/9 l
 ...........\TU/lmr/m/n/9 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4332,11 +4504,13 @@ TEST 32: pgfmanual-en-tikz-shapes-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.26+0.11)x20.44002, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 s
 ...........\TU/lmr/m/it/10 t
 ...........\TU/lmr/m/it/10 a
 ...........\TU/lmr/m/it/10 t
 ...........\TU/lmr/m/it/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4350,6 +4524,7 @@ TEST 32: pgfmanual-en-tikz-shapes-32
 ........\pdfliteral origin{q }
 ........\hbox(0.0+0.0)x0.0, direction TLT
 .........\hbox(4.92+1.552)x25.016, direction TLT
+..........\begindir TLT
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\TU/lmr/m/n/8 o
@@ -4360,6 +4535,7 @@ TEST 32: pgfmanual-en-tikz-shapes-32
 ..........\TU/lmr/m/n/8 p
 ..........\TU/lmr/m/n/8 u
 ..........\TU/lmr/m/n/8 t
+..........\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 .......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -4417,6 +4593,7 @@ TEST 33: pgfmanual-en-tikz-shapes-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(14.5+9.5)x116.34001, direction TLT
+...........\begindir TLT
 ...........\hbox(14.5+9.5)x116.34001, direction TLT
 ............\vbox(14.5+9.5)x116.34001, direction TLT
 .............\hbox(8.39996+3.60004)x116.34001, direction TLT
@@ -4508,6 +4685,7 @@ TEST 33: pgfmanual-en-tikz-shapes-33
 ...............\glue 0.0 plus 1.0fil
 ...............\glue 6.0
 ..............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4566,6 +4744,7 @@ TEST 34: pgfmanual-en-tikz-shapes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(18.94+0.11)x65.65, direction TLT
+...........\begindir TLT
 ...........\vbox(18.94+0.11)x65.65, direction TLT
 ............\hbox(6.94+0.11)x65.65, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4607,6 +4786,7 @@ TEST 34: pgfmanual-en-tikz-shapes-34
 ..............\TU/lmr/m/n/10 .
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4665,6 +4845,7 @@ TEST 35: pgfmanual-en-tikz-shapes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(18.94+0.11)x65.65, direction TLT
+...........\begindir TLT
 ...........\vbox(18.94+0.11)x65.65, direction TLT
 ............\hbox(6.94+0.11)x65.65, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4708,6 +4889,7 @@ TEST 35: pgfmanual-en-tikz-shapes-35
 ..............\TU/lmr/m/n/10 .
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4770,6 +4952,7 @@ TEST 36: pgfmanual-en-tikz-shapes-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(33.25+2.06)x99.01, direction TLT
+...........\begindir TLT
 ...........\vbox(33.25+2.06)x99.01, direction TLT
 ............\hbox(16.94+0.11)x99.01, direction TLT
 .............\glue(\tabskip) 0.0
@@ -4846,6 +5029,7 @@ TEST 36: pgfmanual-en-tikz-shapes-36
 ..............\TU/lmr/m/n/10 s
 ..............\TU/lmr/m/n/10 .
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4910,6 +5094,7 @@ TEST 37: pgfmanual-en-tikz-shapes-37
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+38.06)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+38.06)x85.35826, direction TLT
 ............\hbox(6.94+0.11)x85.35826, glue set 0.59596, direction TLT
 .............\localpar
@@ -5007,6 +5192,7 @@ TEST 37: pgfmanual-en-tikz-shapes-37
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5069,6 +5255,7 @@ TEST 38: pgfmanual-en-tikz-shapes-38
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(30.94+2.06)x99.01, direction TLT
+...........\begindir TLT
 ...........\vbox(30.94+2.06)x99.01, direction TLT
 ............\hbox(18.94+0.11)x99.01, direction TLT
 .............\glue(\tabskip) 0.0
@@ -5145,6 +5332,7 @@ TEST 38: pgfmanual-en-tikz-shapes-38
 ..............\TU/lmr/m/n/10 .
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5207,6 +5395,7 @@ TEST 39: pgfmanual-en-tikz-shapes-39
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+38.06)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+38.06)x85.35826, direction TLT
 ............\hbox(6.94+0.11)x85.35826, glue set 0.59596, direction TLT
 .............\localpar
@@ -5304,6 +5493,7 @@ TEST 39: pgfmanual-en-tikz-shapes-39
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5366,6 +5556,7 @@ TEST 40: pgfmanual-en-tikz-shapes-40
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+48.11)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+48.11)x85.35826, direction TLT
 ............\hbox(6.94+0.11)x85.35826, glue set 47.47826fil, direction TLT
 .............\localpar
@@ -5464,6 +5655,7 @@ TEST 40: pgfmanual-en-tikz-shapes-40
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5526,6 +5718,7 @@ TEST 41: pgfmanual-en-tikz-shapes-41
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(30.94+2.06)x99.01, direction TLT
+...........\begindir TLT
 ...........\vbox(30.94+2.06)x99.01, direction TLT
 ............\hbox(18.94+0.11)x99.01, direction TLT
 .............\glue(\tabskip) 0.0
@@ -5602,6 +5795,7 @@ TEST 41: pgfmanual-en-tikz-shapes-41
 ..............\TU/lmr/m/n/10 s
 ..............\TU/lmr/m/n/10 .
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5664,6 +5858,7 @@ TEST 42: pgfmanual-en-tikz-shapes-42
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+38.06)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+38.06)x85.35826, direction TLT
 ............\hbox(6.94+0.11)x85.35826, glue set 0.59596, direction TLT
 .............\glue(\leftskip) 0.0 plus 20.0
@@ -5765,6 +5960,7 @@ TEST 42: pgfmanual-en-tikz-shapes-42
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5827,6 +6023,7 @@ TEST 43: pgfmanual-en-tikz-shapes-43
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+48.11)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+48.11)x85.35826, direction TLT
 ............\hbox(6.94+0.11)x85.35826, glue set 47.47826fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -5930,6 +6127,7 @@ TEST 43: pgfmanual-en-tikz-shapes-43
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5992,6 +6190,7 @@ TEST 44: pgfmanual-en-tikz-shapes-44
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(30.94+2.06)x99.01, direction TLT
+...........\begindir TLT
 ...........\vbox(30.94+2.06)x99.01, direction TLT
 ............\hbox(18.94+0.11)x99.01, direction TLT
 .............\glue(\tabskip) 0.0
@@ -6072,6 +6271,7 @@ TEST 44: pgfmanual-en-tikz-shapes-44
 ..............\TU/lmr/m/n/10 .
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6134,6 +6334,7 @@ TEST 45: pgfmanual-en-tikz-shapes-45
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+38.06)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+38.06)x85.35826, direction TLT
 ............\hbox(6.94+0.11)x85.35826, glue set 0.29799, direction TLT
 .............\glue(\leftskip) 0.0 plus 20.0
@@ -6235,6 +6436,7 @@ TEST 45: pgfmanual-en-tikz-shapes-45
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6297,6 +6499,7 @@ TEST 46: pgfmanual-en-tikz-shapes-46
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+48.11)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+48.11)x85.35826, direction TLT
 ............\hbox(6.94+0.11)x85.35826, glue set 23.73914fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -6400,6 +6603,7 @@ TEST 46: pgfmanual-en-tikz-shapes-46
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6537,6 +6741,7 @@ Underfull \hbox (badness 3460) in paragraph at lines ...
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+38.06)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+38.06)x85.35826, direction TLT
 ............\hbox(6.94+0.11)x85.35826, glue set 2.38805, direction TLT
 .............\localpar
@@ -6634,6 +6839,7 @@ Underfull \hbox (badness 3460) in paragraph at lines ...
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6692,7 +6898,9 @@ TEST 48: pgfmanual-en-tikz-shapes-49
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6740,7 +6948,9 @@ TEST 48: pgfmanual-en-tikz-shapes-49
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(10.0+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6804,6 +7014,7 @@ TEST 49: pgfmanual-en-tikz-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x41.48, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 ﬁ
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 s
@@ -6814,6 +7025,7 @@ TEST 49: pgfmanual-en-tikz-shapes-50
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6839,6 +7051,7 @@ TEST 49: pgfmanual-en-tikz-shapes-50
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x53.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 c
@@ -6853,6 +7066,7 @@ TEST 49: pgfmanual-en-tikz-shapes-50
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6916,7 +7130,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6942,7 +7158,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6968,7 +7186,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7002,7 +7222,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7028,7 +7250,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7054,7 +7278,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7088,7 +7314,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+0.0)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 x
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7114,7 +7342,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.31+2.05)x5.28, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7140,7 +7370,9 @@ TEST 50: pgfmanual-en-tikz-shapes-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x3.89, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7206,6 +7438,7 @@ TEST 51: pgfmanual-en-tikz-shapes-52
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
@@ -7214,6 +7447,7 @@ TEST 51: pgfmanual-en-tikz-shapes-52
 ...........\TU/lmr/m/n/10 v
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7279,6 +7513,7 @@ TEST 52: pgfmanual-en-tikz-shapes-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
@@ -7287,6 +7522,7 @@ TEST 52: pgfmanual-en-tikz-shapes-53
 ...........\TU/lmr/m/n/10 v
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7352,6 +7588,7 @@ TEST 53: pgfmanual-en-tikz-shapes-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x42.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
@@ -7365,6 +7602,7 @@ TEST 53: pgfmanual-en-tikz-shapes-54
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7428,6 +7666,7 @@ TEST 54: pgfmanual-en-tikz-shapes-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x49.2, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
@@ -7443,6 +7682,7 @@ TEST 54: pgfmanual-en-tikz-shapes-55
 ...........\TU/lmr/m/n/10 h
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7535,6 +7775,7 @@ TEST 55: pgfmanual-en-tikz-shapes-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
@@ -7543,6 +7784,7 @@ TEST 55: pgfmanual-en-tikz-shapes-56
 ...........\TU/lmr/m/n/10 v
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7635,6 +7877,7 @@ TEST 56: pgfmanual-en-tikz-shapes-57
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
@@ -7643,6 +7886,7 @@ TEST 56: pgfmanual-en-tikz-shapes-57
 ...........\TU/lmr/m/n/10 v
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7735,6 +7979,7 @@ TEST 57: pgfmanual-en-tikz-shapes-58
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x25.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 b
 ...........\kern0.28 (font)
@@ -7743,6 +7988,7 @@ TEST 57: pgfmanual-en-tikz-shapes-58
 ...........\TU/lmr/m/n/10 v
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7836,6 +8082,7 @@ TEST 58: pgfmanual-en-tikz-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.88, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 m
@@ -7846,6 +8093,7 @@ TEST 58: pgfmanual-en-tikz-shapes-59
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7875,6 +8123,7 @@ TEST 58: pgfmanual-en-tikz-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.525+0.11)x86.12999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 5
 ...........\TU/lmr/m/n/5 m
 ...........\TU/lmr/m/n/5 m
@@ -7904,6 +8153,7 @@ TEST 58: pgfmanual-en-tikz-shapes-59
 ...........\TU/lmr/m/n/5 a
 ...........\TU/lmr/m/n/5 s
 ...........\TU/lmr/m/n/5 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7934,6 +8184,7 @@ TEST 58: pgfmanual-en-tikz-shapes-59
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.525+0.055)x69.42499, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 c
 ...........\TU/lmr/m/n/5 m
@@ -7958,6 +8209,7 @@ TEST 58: pgfmanual-en-tikz-shapes-59
 ...........\TU/lmr/m/n/5 r
 ...........\TU/lmr/m/n/5 t
 ...........\TU/lmr/m/n/5 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8051,6 +8303,7 @@ TEST 59: pgfmanual-en-tikz-shapes-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.88, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 m
@@ -8061,6 +8314,7 @@ TEST 59: pgfmanual-en-tikz-shapes-60
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8092,6 +8346,7 @@ TEST 59: pgfmanual-en-tikz-shapes-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.525+0.055)x75.59996, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 a
 ...........\TU/lmr/m/n/5 b
 ...........\kern0.175 (font)
@@ -8118,6 +8373,7 @@ TEST 59: pgfmanual-en-tikz-shapes-60
 ...........\kern0.175 (font)
 ...........\TU/lmr/m/n/5 d
 ...........\TU/lmr/m/n/5 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8159,9 +8415,11 @@ TEST 59: pgfmanual-en-tikz-shapes-60
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x17.77, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 m
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8259,6 +8517,7 @@ TEST 60: pgfmanual-en-tikz-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x50.59999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
@@ -8272,6 +8531,7 @@ TEST 60: pgfmanual-en-tikz-shapes-61
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8303,12 +8563,14 @@ TEST 60: pgfmanual-en-tikz-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.05)x18.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8340,7 +8602,9 @@ TEST 60: pgfmanual-en-tikz-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8370,6 +8634,7 @@ TEST 60: pgfmanual-en-tikz-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x32.81999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 i
@@ -8379,6 +8644,7 @@ TEST 60: pgfmanual-en-tikz-shapes-61
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8410,12 +8676,14 @@ TEST 60: pgfmanual-en-tikz-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.05)x18.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8447,7 +8715,9 @@ TEST 60: pgfmanual-en-tikz-shapes-61
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8545,6 +8815,7 @@ TEST 61: pgfmanual-en-tikz-shapes-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x50.59999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
@@ -8558,6 +8829,7 @@ TEST 61: pgfmanual-en-tikz-shapes-62
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8589,12 +8861,14 @@ TEST 61: pgfmanual-en-tikz-shapes-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.05)x18.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8626,7 +8900,9 @@ TEST 61: pgfmanual-en-tikz-shapes-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8658,6 +8934,7 @@ TEST 61: pgfmanual-en-tikz-shapes-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x32.81999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 i
@@ -8667,6 +8944,7 @@ TEST 61: pgfmanual-en-tikz-shapes-62
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8698,12 +8976,14 @@ TEST 61: pgfmanual-en-tikz-shapes-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.05)x18.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8735,7 +9015,9 @@ TEST 61: pgfmanual-en-tikz-shapes-62
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8848,7 +9130,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8880,7 +9164,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8912,7 +9198,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8944,7 +9232,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8976,7 +9266,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9011,7 +9303,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9046,7 +9340,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9081,7 +9377,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9116,7 +9414,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9153,7 +9453,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9185,7 +9487,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9217,7 +9521,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9249,7 +9555,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9281,7 +9589,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9316,7 +9626,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9351,7 +9663,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9386,7 +9700,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9421,7 +9737,9 @@ TEST 62: pgfmanual-en-tikz-shapes-63
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9532,7 +9850,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9562,7 +9882,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9593,7 +9915,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9625,7 +9949,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9657,7 +9983,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9689,7 +10017,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9718,7 +10048,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9747,7 +10079,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9779,7 +10113,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9814,7 +10150,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9844,7 +10182,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9875,7 +10215,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9907,7 +10249,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9939,7 +10283,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -9971,7 +10317,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10000,7 +10348,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10029,7 +10379,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10061,7 +10413,9 @@ TEST 63: pgfmanual-en-tikz-shapes-64
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10176,7 +10530,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10208,7 +10564,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10240,7 +10598,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10272,7 +10632,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10304,7 +10666,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10336,7 +10700,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10368,7 +10734,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10400,7 +10768,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10432,7 +10802,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10467,7 +10839,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10499,7 +10873,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10531,7 +10907,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10563,7 +10941,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10595,7 +10975,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10627,7 +11009,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10659,7 +11043,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10691,7 +11077,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10723,7 +11111,9 @@ TEST 64: pgfmanual-en-tikz-shapes-65
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10818,7 +11208,9 @@ TEST 65: pgfmanual-en-tikz-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(14.16542+0.0)x14.37282, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10847,7 +11239,9 @@ TEST 65: pgfmanual-en-tikz-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(9.16708+0.16592)x9.51967, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10876,7 +11270,9 @@ TEST 65: pgfmanual-en-tikz-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.9182+4.21022)x10.0589, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10904,7 +11300,9 @@ TEST 65: pgfmanual-en-tikz-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(14.16542+0.0)x14.37282, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10931,7 +11329,9 @@ TEST 65: pgfmanual-en-tikz-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(9.16708+0.16592)x9.51967, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -10958,7 +11358,9 @@ TEST 65: pgfmanual-en-tikz-shapes-66
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.9182+4.21022)x10.0589, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11017,11 +11419,13 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11053,7 +11457,9 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11097,7 +11503,9 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11141,7 +11549,9 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11185,7 +11595,9 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 e
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11231,7 +11643,9 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11299,6 +11713,7 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(29.62265+29.62267)x54.74507, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x54.74507, direction TLT
 ............\hbox(0.0+0.0)x54.74507, glue set 27.37254fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -11312,6 +11727,7 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11363,6 +11779,7 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(17.82407+17.82407)x54.74507, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x54.74507, direction TLT
 ............\hbox(0.0+0.0)x54.74507, glue set 27.37254fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -11376,6 +11793,7 @@ TEST 66: pgfmanual-en-tikz-shapes-67
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11457,6 +11875,7 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(29.62265+29.62267)x54.74507, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x54.74507, direction TLT
 ............\hbox(0.0+0.0)x54.74507, glue set 27.37254fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -11470,6 +11889,7 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11519,6 +11939,7 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(17.82407+17.82407)x54.74507, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x54.74507, direction TLT
 ............\hbox(0.0+0.0)x54.74507, glue set 27.37254fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -11532,6 +11953,7 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11565,11 +11987,13 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11601,7 +12025,9 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11645,7 +12071,9 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11689,7 +12117,9 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11733,7 +12163,9 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 e
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11779,7 +12211,9 @@ TEST 67: pgfmanual-en-tikz-shapes-68
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x4.44, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 c
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11897,7 +12331,9 @@ TEST 68: pgfmanual-en-tikz-shapes-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11930,7 +12366,9 @@ TEST 68: pgfmanual-en-tikz-shapes-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11963,7 +12401,9 @@ TEST 68: pgfmanual-en-tikz-shapes-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -11996,7 +12436,9 @@ TEST 68: pgfmanual-en-tikz-shapes-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12034,7 +12476,9 @@ TEST 68: pgfmanual-en-tikz-shapes-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12067,7 +12511,9 @@ TEST 68: pgfmanual-en-tikz-shapes-69
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13463,7 +13909,9 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13500,8 +13948,10 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13538,8 +13988,10 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13576,8 +14028,10 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13614,8 +14068,10 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13693,7 +14149,9 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13790,8 +14248,10 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13888,8 +14348,10 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -13986,8 +14448,10 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 6
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14084,8 +14548,10 @@ TEST 69: pgfmanual-en-tikz-shapes-70
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14147,7 +14613,9 @@ TEST 70: pgfmanual-en-tikz-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14173,9 +14641,11 @@ TEST 70: pgfmanual-en-tikz-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 /
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14201,10 +14671,12 @@ TEST 70: pgfmanual-en-tikz-shapes-71
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x20.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 /
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14345,7 +14817,9 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14369,11 +14843,13 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14397,10 +14873,12 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14424,11 +14902,13 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14454,9 +14934,11 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14482,11 +14964,13 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 6
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14512,10 +14996,12 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14541,11 +15027,13 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14571,7 +15059,9 @@ TEST 71: pgfmanual-en-tikz-shapes-72
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14631,7 +15121,9 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14657,11 +15149,13 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14687,10 +15181,12 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14716,11 +15212,13 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14746,9 +15244,11 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14774,11 +15274,13 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 6
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14804,10 +15306,12 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14833,11 +15337,13 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14863,7 +15369,9 @@ TEST 72: pgfmanual-en-tikz-shapes-73
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14924,7 +15432,9 @@ TEST 73: pgfmanual-en-tikz-shapes-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14950,9 +15460,11 @@ TEST 73: pgfmanual-en-tikz-shapes-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 /
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -14978,10 +15490,12 @@ TEST 73: pgfmanual-en-tikz-shapes-74
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x20.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 /
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15042,7 +15556,9 @@ TEST 74: pgfmanual-en-tikz-shapes-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15068,9 +15584,11 @@ TEST 74: pgfmanual-en-tikz-shapes-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 /
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15096,10 +15614,12 @@ TEST 74: pgfmanual-en-tikz-shapes-75
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.5+2.5)x20.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 /
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15165,7 +15685,9 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15201,7 +15723,9 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15237,7 +15761,9 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15273,7 +15799,9 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15309,7 +15837,9 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+0.11)x4.44, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15345,7 +15875,9 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.0)x3.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15381,7 +15913,9 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.53+2.06)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15417,7 +15951,9 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x5.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15463,11 +15999,13 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 a
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 –
 ............= \TU/lmr/m/n/10 –
 ...........\TU/lmr/m/n/10 b
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15515,11 +16053,13 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 –
 ............= \TU/lmr/m/n/10 –
 ...........\TU/lmr/m/n/10 c
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15565,11 +16105,13 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 –
 ............= \TU/lmr/m/n/10 –
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15617,11 +16159,13 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 –
 ............= \TU/lmr/m/n/10 –
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15667,11 +16211,13 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x12.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 e
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 –
 ............= \TU/lmr/m/n/10 –
 ...........\TU/lmr/m/n/10 f
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15719,11 +16265,13 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x13.06, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 –
 ............= \TU/lmr/m/n/10 –
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15769,11 +16317,13 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x15.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 g
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 –
 ............= \TU/lmr/m/n/10 –
 ...........\TU/lmr/m/n/10 h
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15821,11 +16371,13 @@ TEST 75: pgfmanual-en-tikz-shapes-76
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 h
 ...........\discretionary (penalty 50)
 ............< \TU/lmr/m/n/10 –
 ............= \TU/lmr/m/n/10 –
 ...........\TU/lmr/m/n/10 a
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15947,7 +16499,9 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15979,9 +16533,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16013,9 +16569,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16045,9 +16603,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16077,9 +16637,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16111,9 +16673,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16145,9 +16709,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16179,9 +16745,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16211,9 +16779,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16243,9 +16813,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16275,7 +16847,9 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16307,11 +16881,13 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16343,9 +16919,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16375,9 +16953,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16409,9 +16989,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16441,9 +17023,11 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16473,11 +17057,13 @@ TEST 76: pgfmanual-en-tikz-shapes-77
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x22.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16577,11 +17163,13 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16613,11 +17201,13 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16649,11 +17239,13 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 2
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16685,11 +17277,13 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -16728,7 +17322,9 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16765,7 +17361,9 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16802,7 +17400,9 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16843,7 +17443,9 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16882,7 +17484,9 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16923,7 +17527,9 @@ TEST 77: pgfmanual-en-tikz-shapes-78
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16985,7 +17591,9 @@ TEST 78: pgfmanual-en-tikz-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17011,10 +17619,12 @@ TEST 78: pgfmanual-en-tikz-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17040,9 +17650,11 @@ TEST 78: pgfmanual-en-tikz-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17068,10 +17680,12 @@ TEST 78: pgfmanual-en-tikz-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17097,7 +17711,9 @@ TEST 78: pgfmanual-en-tikz-shapes-79
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17163,9 +17779,11 @@ TEST 79: pgfmanual-en-tikz-shapes-80
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17201,10 +17819,12 @@ TEST 79: pgfmanual-en-tikz-shapes-80
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x5.2616, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 y
 ...........\kern0.35878 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17264,7 +17884,9 @@ TEST 80: pgfmanual-en-tikz-shapes-81
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17290,10 +17912,12 @@ TEST 80: pgfmanual-en-tikz-shapes-81
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17319,9 +17943,11 @@ TEST 80: pgfmanual-en-tikz-shapes-81
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17347,10 +17973,12 @@ TEST 80: pgfmanual-en-tikz-shapes-81
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+0.22)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 .
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17376,7 +18004,9 @@ TEST 80: pgfmanual-en-tikz-shapes-81
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17442,9 +18072,11 @@ TEST 81: pgfmanual-en-tikz-shapes-82
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17480,10 +18112,12 @@ TEST 81: pgfmanual-en-tikz-shapes-82
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x5.2616, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 y
 ...........\kern0.35878 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17543,6 +18177,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+0.06)x31.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 a
 ...........\TU/lmtt/m/n/10 t
 ...........\glue(\spaceskip) 5.25
@@ -17550,6 +18185,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ...........\TU/lmtt/m/n/10 n
 ...........\TU/lmtt/m/n/10 d
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17575,6 +18211,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+2.28)x68.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 v
 ...........\TU/lmtt/m/n/10 e
 ...........\TU/lmtt/m/n/10 r
@@ -17589,6 +18226,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ...........\TU/lmtt/m/n/10 n
 ...........\TU/lmtt/m/n/10 d
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17614,6 +18252,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+0.06)x42.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 n
 ...........\TU/lmtt/m/n/10 e
 ...........\TU/lmtt/m/n/10 a
@@ -17623,6 +18262,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ...........\TU/lmtt/m/n/10 n
 ...........\TU/lmtt/m/n/10 d
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17648,6 +18288,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+2.28)x31.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 m
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 d
@@ -17655,6 +18296,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ...........\TU/lmtt/m/n/10 a
 ...........\TU/lmtt/m/n/10 y
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17680,6 +18322,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.54+0.06)x52.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 n
 ...........\TU/lmtt/m/n/10 e
 ...........\TU/lmtt/m/n/10 a
@@ -17691,6 +18334,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ...........\TU/lmtt/m/n/10 r
 ...........\TU/lmtt/m/n/10 t
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17716,6 +18360,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.54+2.28)x78.75, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 v
 ...........\TU/lmtt/m/n/10 e
 ...........\TU/lmtt/m/n/10 r
@@ -17732,6 +18377,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ...........\TU/lmtt/m/n/10 r
 ...........\TU/lmtt/m/n/10 t
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17757,6 +18403,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.54+0.06)x42.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 a
 ...........\TU/lmtt/m/n/10 t
 ...........\glue(\spaceskip) 5.25
@@ -17766,6 +18413,7 @@ TEST 82: pgfmanual-en-tikz-shapes-83
 ...........\TU/lmtt/m/n/10 r
 ...........\TU/lmtt/m/n/10 t
 ...........\kern0.0 (italic)
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17827,7 +18475,9 @@ TEST 83: pgfmanual-en-tikz-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17859,7 +18509,9 @@ TEST 83: pgfmanual-en-tikz-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.08, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17891,7 +18543,9 @@ TEST 83: pgfmanual-en-tikz-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17923,7 +18577,9 @@ TEST 83: pgfmanual-en-tikz-shapes-84
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 D
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -17985,6 +18641,8 @@ TEST 84: pgfmanual-en-tikz-shapes-85
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18016,6 +18674,8 @@ TEST 84: pgfmanual-en-tikz-shapes-85
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18055,6 +18715,8 @@ TEST 84: pgfmanual-en-tikz-shapes-85
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18094,6 +18756,8 @@ TEST 84: pgfmanual-en-tikz-shapes-85
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18165,6 +18829,8 @@ TEST 85: pgfmanual-en-tikz-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18186,9 +18852,11 @@ TEST 85: pgfmanual-en-tikz-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.6875, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 s
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18220,6 +18888,8 @@ TEST 85: pgfmanual-en-tikz-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18259,6 +18929,8 @@ TEST 85: pgfmanual-en-tikz-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18300,6 +18972,8 @@ TEST 85: pgfmanual-en-tikz-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18321,9 +18995,11 @@ TEST 85: pgfmanual-en-tikz-shapes-86
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15079+0.0)x3.61111, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 t
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18398,6 +19074,7 @@ TEST 86: pgfmanual-en-tikz-shapes-87
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.84, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 i
@@ -18408,6 +19085,7 @@ TEST 86: pgfmanual-en-tikz-shapes-87
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18440,6 +19118,7 @@ TEST 86: pgfmanual-en-tikz-shapes-87
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+0.11)x20.84, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 a
@@ -18450,6 +19129,7 @@ TEST 86: pgfmanual-en-tikz-shapes-87
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18517,6 +19197,7 @@ TEST 87: pgfmanual-en-tikz-shapes-88
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.84, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 i
@@ -18527,6 +19208,7 @@ TEST 87: pgfmanual-en-tikz-shapes-88
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18559,6 +19241,7 @@ TEST 87: pgfmanual-en-tikz-shapes-88
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+0.11)x20.84, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 a
@@ -18569,6 +19252,7 @@ TEST 87: pgfmanual-en-tikz-shapes-88
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18644,6 +19328,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.46, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -18656,6 +19341,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18681,6 +19367,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x30.29, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
 ...........\discretionary (penalty 50)
@@ -18690,6 +19377,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ...........\TU/lmr/m/n/10 u
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18713,12 +19401,14 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x14.59726, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 6
 ...........\OT1/cmr/m/n/10 0
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18744,6 +19434,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.83333)x22.37506, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 9
@@ -18751,6 +19442,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18774,11 +19466,13 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x9.59724, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 3
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18804,11 +19498,13 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x9.59724, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18834,6 +19530,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x19.59727, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 8
@@ -18841,6 +19538,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18866,6 +19564,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x19.59727, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 3
@@ -18873,6 +19572,7 @@ TEST 88: pgfmanual-en-tikz-shapes-89
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18938,6 +19638,7 @@ TEST 89: pgfmanual-en-tikz-shapes-90
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x45.84, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 i
@@ -18948,6 +19649,7 @@ TEST 89: pgfmanual-en-tikz-shapes-90
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -18978,9 +19680,11 @@ TEST 89: pgfmanual-en-tikz-shapes-90
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83+0.22)x7.36, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 R
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19044,6 +19748,7 @@ TEST 90: pgfmanual-en-tikz-shapes-91
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.46, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -19056,6 +19761,7 @@ TEST 90: pgfmanual-en-tikz-shapes-91
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19086,9 +19792,11 @@ TEST 90: pgfmanual-en-tikz-shapes-91
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 X
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19152,6 +19860,8 @@ TEST 91: pgfmanual-en-tikz-shapes-92
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19177,12 +19887,14 @@ TEST 91: pgfmanual-en-tikz-shapes-92
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+1.94444)x14.02196, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 a
 ...........\OML/cmm/m/it/10 ;
 ...........\glue(\thinmuskip) 1.66663
 ...........\OML/cmm/m/it/10 b
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19256,6 +19968,7 @@ TEST 92: pgfmanual-en-tikz-shapes-93
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.46, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -19268,6 +19981,7 @@ TEST 92: pgfmanual-en-tikz-shapes-93
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19293,7 +20007,9 @@ TEST 92: pgfmanual-en-tikz-shapes-93
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19317,7 +20033,9 @@ TEST 92: pgfmanual-en-tikz-shapes-93
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19343,7 +20061,9 @@ TEST 92: pgfmanual-en-tikz-shapes-93
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x6.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19410,6 +20130,8 @@ TEST 93: pgfmanual-en-tikz-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19433,11 +20155,13 @@ TEST 93: pgfmanual-en-tikz-shapes-94
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x8.95026, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 q
 ...........\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ............\OT1/cmr/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19519,6 +20243,7 @@ TEST 94: pgfmanual-en-tikz-shapes-95
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.46, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -19531,6 +20256,7 @@ TEST 94: pgfmanual-en-tikz-shapes-95
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19556,7 +20282,9 @@ TEST 94: pgfmanual-en-tikz-shapes-95
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19595,7 +20323,9 @@ TEST 94: pgfmanual-en-tikz-shapes-95
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19636,7 +20366,9 @@ TEST 94: pgfmanual-en-tikz-shapes-95
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x6.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19718,6 +20450,7 @@ TEST 95: pgfmanual-en-tikz-shapes-96
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.46, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -19730,6 +20463,7 @@ TEST 95: pgfmanual-en-tikz-shapes-96
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19755,7 +20489,9 @@ TEST 95: pgfmanual-en-tikz-shapes-96
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19841,7 +20577,9 @@ TEST 95: pgfmanual-en-tikz-shapes-96
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -19929,7 +20667,9 @@ TEST 95: pgfmanual-en-tikz-shapes-96
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x6.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20056,6 +20796,7 @@ TEST 96: pgfmanual-en-tikz-shapes-97
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.46, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -20068,6 +20809,7 @@ TEST 96: pgfmanual-en-tikz-shapes-97
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20093,7 +20835,9 @@ TEST 96: pgfmanual-en-tikz-shapes-97
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x7.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 X
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20137,7 +20881,9 @@ TEST 96: pgfmanual-en-tikz-shapes-97
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83+0.0)x6.11, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 Z
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20215,6 +20961,7 @@ TEST 97: pgfmanual-en-tikz-shapes-98
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.46, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -20227,6 +20974,7 @@ TEST 97: pgfmanual-en-tikz-shapes-98
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20250,11 +20998,13 @@ TEST 97: pgfmanual-en-tikz-shapes-98
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x20.64, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20330,6 +21080,7 @@ TEST 98: pgfmanual-en-tikz-shapes-99
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x37.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -20339,6 +21090,7 @@ TEST 98: pgfmanual-en-tikz-shapes-99
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20369,6 +21121,7 @@ TEST 98: pgfmanual-en-tikz-shapes-99
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+2.05)x37.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
@@ -20383,6 +21136,7 @@ TEST 98: pgfmanual-en-tikz-shapes-99
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20445,6 +21199,7 @@ TEST 99: pgfmanual-en-tikz-shapes-100
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x37.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -20454,6 +21209,7 @@ TEST 99: pgfmanual-en-tikz-shapes-100
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20484,6 +21240,7 @@ TEST 99: pgfmanual-en-tikz-shapes-100
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+2.05)x37.5, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
@@ -20498,6 +21255,7 @@ TEST 99: pgfmanual-en-tikz-shapes-100
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20584,7 +21342,9 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(7.16+0.0)x7.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 A
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20610,6 +21370,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x20.84, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 a
 .....................\discretionary (penalty 50)
@@ -20618,6 +21379,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 .....................\kern0.28 (font)
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 l
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20665,7 +21427,9 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.0)x7.08, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 B
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20689,6 +21453,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x20.84, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 a
 .....................\discretionary (penalty 50)
@@ -20697,6 +21462,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 .....................\kern0.28 (font)
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 l
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20743,7 +21509,9 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(7.05+0.22)x7.22, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 C
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20769,6 +21537,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.94+0.11)x20.84, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 a
 .....................\discretionary (penalty 50)
@@ -20777,6 +21546,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 .....................\kern0.28 (font)
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 l
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20824,7 +21594,9 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.0)x7.64, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 D
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20856,6 +21628,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.94+0.11)x20.84, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 a
@@ -20866,6 +21639,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 l
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20913,7 +21687,9 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.8+0.0)x6.81, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 E
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -20948,6 +21724,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 ....................\pdfliteral origin{1 0 0 RG }
 ....................\pdfliteral origin{1 0 0 rg }
 ....................\hbox(6.94+0.11)x20.84, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....................\TU/lmr/m/n/10 l
 .....................\TU/lmr/m/n/10 a
@@ -20958,6 +21735,7 @@ TEST 100: pgfmanual-en-tikz-shapes-101
 .....................\TU/lmr/m/n/10 e
 .....................\TU/lmr/m/n/10 l
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -21036,6 +21814,7 @@ TEST 101: pgfmanual-en-tikz-shapes-102
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -21044,6 +21823,7 @@ TEST 101: pgfmanual-en-tikz-shapes-102
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21069,12 +21849,14 @@ TEST 101: pgfmanual-en-tikz-shapes-102
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x14.59726, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 9
 ...........\OT1/cmr/m/n/10 0
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21098,6 +21880,7 @@ TEST 101: pgfmanual-en-tikz-shapes-102
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x19.59727, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 8
@@ -21105,6 +21888,7 @@ TEST 101: pgfmanual-en-tikz-shapes-102
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21169,6 +21953,7 @@ TEST 102: pgfmanual-en-tikz-shapes-103
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -21177,6 +21962,7 @@ TEST 102: pgfmanual-en-tikz-shapes-103
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21202,12 +21988,14 @@ TEST 102: pgfmanual-en-tikz-shapes-103
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x14.59726, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 9
 ...........\OT1/cmr/m/n/10 0
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21231,6 +22019,7 @@ TEST 102: pgfmanual-en-tikz-shapes-103
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x19.59727, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 8
@@ -21238,6 +22027,7 @@ TEST 102: pgfmanual-en-tikz-shapes-103
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21302,6 +22092,7 @@ TEST 103: pgfmanual-en-tikz-shapes-104
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -21310,6 +22101,7 @@ TEST 103: pgfmanual-en-tikz-shapes-104
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21340,6 +22132,7 @@ TEST 103: pgfmanual-en-tikz-shapes-104
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.88586+0.0)x14.59726, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 9
@@ -21348,6 +22141,7 @@ TEST 103: pgfmanual-en-tikz-shapes-104
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21377,6 +22171,7 @@ TEST 103: pgfmanual-en-tikz-shapes-104
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.88586+0.0)x19.59727, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
@@ -21386,6 +22181,7 @@ TEST 103: pgfmanual-en-tikz-shapes-104
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21448,10 +22244,12 @@ TEST 104: pgfmanual-en-tikz-shapes-105
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x13.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21477,6 +22275,7 @@ TEST 104: pgfmanual-en-tikz-shapes-105
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+2.05)x49.20001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
@@ -21490,6 +22289,7 @@ TEST 104: pgfmanual-en-tikz-shapes-105
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21551,10 +22351,12 @@ TEST 105: pgfmanual-en-tikz-shapes-106
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.11)x13.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 f
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21580,6 +22382,7 @@ TEST 105: pgfmanual-en-tikz-shapes-106
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.48+2.05)x50.31001, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 y
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
@@ -21593,6 +22396,7 @@ TEST 105: pgfmanual-en-tikz-shapes-106
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 n
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21657,6 +22461,7 @@ TEST 106: pgfmanual-en-tikz-shapes-107
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -21665,6 +22470,7 @@ TEST 106: pgfmanual-en-tikz-shapes-107
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21690,12 +22496,14 @@ TEST 106: pgfmanual-en-tikz-shapes-107
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x14.59726, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 9
 ...........\OT1/cmr/m/n/10 0
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21734,6 +22542,7 @@ TEST 106: pgfmanual-en-tikz-shapes-107
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x19.59727, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 8
@@ -21741,6 +22550,7 @@ TEST 106: pgfmanual-en-tikz-shapes-107
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21822,6 +22632,7 @@ TEST 107: pgfmanual-en-tikz-shapes-108
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.8, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 r
@@ -21830,6 +22641,7 @@ TEST 107: pgfmanual-en-tikz-shapes-108
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21855,7 +22667,9 @@ TEST 107: pgfmanual-en-tikz-shapes-108
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21879,7 +22693,9 @@ TEST 107: pgfmanual-en-tikz-shapes-108
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21945,6 +22761,7 @@ TEST 108: pgfmanual-en-tikz-shapes-109
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.16+0.22)x55.31999, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
@@ -21958,6 +22775,7 @@ TEST 108: pgfmanual-en-tikz-shapes-109
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 !
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -21987,6 +22805,7 @@ TEST 108: pgfmanual-en-tikz-shapes-109
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(10.09451+3.5556)x29.80554, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(0.0+11.11122)x4.72223, shifted -8.0556, direction TLT
 ............\OMX/cmex/m/n/10 R
@@ -22001,6 +22820,7 @@ TEST 108: pgfmanual-en-tikz-shapes-109
 ...........\OT1/cmr/m/n/10 d
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22055,6 +22875,7 @@ TEST 108: pgfmanual-en-tikz-shapes-109
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.94+0.11)x20.84, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 a
@@ -22065,6 +22886,7 @@ TEST 108: pgfmanual-en-tikz-shapes-109
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22105,6 +22927,7 @@ TEST 108: pgfmanual-en-tikz-shapes-109
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(6.94+0.11)x20.84, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 a
@@ -22115,6 +22938,7 @@ TEST 108: pgfmanual-en-tikz-shapes-109
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22173,9 +22997,11 @@ TEST 109: pgfmanual-en-tikz-shapes-110
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.28589, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 a
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22203,9 +23029,11 @@ TEST 109: pgfmanual-en-tikz-shapes-110
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x4.29166, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 b
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22249,9 +23077,11 @@ TEST 109: pgfmanual-en-tikz-shapes-110
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.32756, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22311,9 +23141,11 @@ TEST 109: pgfmanual-en-tikz-shapes-110
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x5.20486, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 d
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22417,9 +23249,11 @@ TEST 110: pgfmanual-en-tikz-shapes-111
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.28589, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 a
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22445,9 +23279,11 @@ TEST 110: pgfmanual-en-tikz-shapes-111
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x4.29166, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 b
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22473,9 +23309,11 @@ TEST 110: pgfmanual-en-tikz-shapes-111
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.32756, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22501,9 +23339,11 @@ TEST 110: pgfmanual-en-tikz-shapes-111
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x5.20486, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 d
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22660,9 +23500,11 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.28589, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 a
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22688,9 +23530,11 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x4.29166, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 b
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22716,9 +23560,11 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x4.32756, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 c
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22744,9 +23590,11 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94444+0.0)x5.20486, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 d
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -22790,9 +23638,11 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.44444+0.0)x5.00002, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OT1/cmr/m/n/10 5
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22849,6 +23699,7 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.57+2.06)x32.33, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 s
@@ -22858,6 +23709,7 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22935,6 +23787,7 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(4.48+2.05)x18.64, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 v
 .............\kern-0.28 (font)
@@ -22942,6 +23795,7 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 y
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22967,11 +23821,13 @@ TEST 111: pgfmanual-en-tikz-shapes-112
 ............\pdfliteral origin{1 0 0 RG }
 ............\pdfliteral origin{1 0 0 rg }
 ............\hbox(6.94+0.11)x16.12, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .............\TU/lmr/m/n/10 b
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 d
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23088,10 +23944,12 @@ TEST 113: pgfmanual-en-tikz-shapes-114
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23163,12 +24021,14 @@ TEST 114: pgfmanual-en-tikz-shapes-115
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23246,9 +24106,11 @@ TEST 115: pgfmanual-en-tikz-shapes-116
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.552+0.08)x14.16, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 m
 .............\TU/lmr/m/n/8 i
 .............\TU/lmr/m/n/8 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23316,10 +24178,12 @@ TEST 116: pgfmanual-en-tikz-shapes-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23345,12 +24209,14 @@ TEST 116: pgfmanual-en-tikz-shapes-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23376,11 +24242,13 @@ TEST 116: pgfmanual-en-tikz-shapes-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23406,9 +24274,11 @@ TEST 116: pgfmanual-en-tikz-shapes-117
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x15.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 n
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23476,10 +24346,12 @@ TEST 117: pgfmanual-en-tikz-shapes-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23505,12 +24377,14 @@ TEST 117: pgfmanual-en-tikz-shapes-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23536,11 +24410,13 @@ TEST 117: pgfmanual-en-tikz-shapes-118
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.15+0.11)x20.64, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23603,11 +24479,13 @@ TEST 118: pgfmanual-en-tikz-shapes-127
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23638,12 +24516,14 @@ TEST 118: pgfmanual-en-tikz-shapes-127
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x24.2, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 w
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23704,11 +24584,13 @@ TEST 119: pgfmanual-en-tikz-shapes-128
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x22.5, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 H
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 o
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -23738,12 +24620,14 @@ TEST 119: pgfmanual-en-tikz-shapes-128
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x24.2, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 w
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-transformations.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-transformations.tlg
@@ -1415,9 +1415,11 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1451,10 +1453,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x5.2616, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 y
 ...........\kern0.35878 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1488,10 +1492,12 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.0903, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 z
 ...........\kern0.4398 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1588,9 +1594,11 @@ TEST 19: pgfmanual-en-tikz-transformations-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1624,10 +1632,12 @@ TEST 19: pgfmanual-en-tikz-transformations-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x5.2616, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 y
 ...........\kern0.35878 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1661,10 +1671,12 @@ TEST 19: pgfmanual-en-tikz-transformations-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.0903, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 z
 ...........\kern0.4398 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1761,9 +1773,11 @@ TEST 20: pgfmanual-en-tikz-transformations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.71527, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 x
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1797,10 +1811,12 @@ TEST 20: pgfmanual-en-tikz-transformations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+1.94444)x5.2616, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 y
 ...........\kern0.35878 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1834,10 +1850,12 @@ TEST 20: pgfmanual-en-tikz-transformations-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(4.30554+0.0)x5.0903, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 z
 ...........\kern0.4398 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tikz-transparency.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-transparency.tlg
@@ -662,7 +662,9 @@ TEST 12: pgfmanual-en-tikz-transparency-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(14.66318+0.0)x14.37282, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 A
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -694,7 +696,9 @@ TEST 12: pgfmanual-en-tikz-transparency-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(14.16542+0.0)x13.56396, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/20.74 B
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -797,6 +801,7 @@ TEST 13: pgfmanual-en-tikz-transparency-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x51.43, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 U
 ...........\TU/lmr/m/n/10 p
 ...........\discretionary (penalty 50)
@@ -811,6 +816,7 @@ TEST 13: pgfmanual-en-tikz-transparency-13
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -846,6 +852,7 @@ TEST 13: pgfmanual-en-tikz-transparency-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x50.44, direction TLT
+...........\begindir TLT
 ...........\pdfliteral origin{/pgf@ca1 gs }
 ...........\pdfliteral origin{/pgf@CA1 gs }
 ...........\TU/lmr/m/n/10 L
@@ -861,6 +868,7 @@ TEST 13: pgfmanual-en-tikz-transparency-13
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1147,8 +1155,10 @@ LaTeX Font Info:    Trying to load font information for T1+ptm on input line ...
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1597,8 +1607,10 @@ TEST 23: pgfmanual-en-tikz-transparency-23
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1679,8 +1691,10 @@ TEST 24: pgfmanual-en-tikz-transparency-24
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1711,8 +1725,10 @@ TEST 24: pgfmanual-en-tikz-transparency-24
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1797,6 +1813,8 @@ TEST 25: pgfmanual-en-tikz-transparency-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2103,6 +2121,7 @@ TEST 28: pgfmanual-en-tikz-transparency-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+62.05)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(6.94+62.05)x99.58464, direction TLT
 ............\hbox(6.94+0.11)x99.58464, glue set 0.12413, direction TLT
 .............\localpar
@@ -2255,6 +2274,7 @@ TEST 28: pgfmanual-en-tikz-transparency-28
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2367,6 +2387,7 @@ TEST 30: pgfmanual-en-tikz-transparency-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x37.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 o
@@ -2376,6 +2397,7 @@ TEST 30: pgfmanual-en-tikz-transparency-30
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2433,6 +2455,7 @@ TEST 30: pgfmanual-en-tikz-transparency-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x37.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 o
@@ -2442,6 +2465,7 @@ TEST 30: pgfmanual-en-tikz-transparency-30
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2561,6 +2585,7 @@ TEST 32: pgfmanual-en-tikz-transparency-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x37.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 o
@@ -2570,6 +2595,7 @@ TEST 32: pgfmanual-en-tikz-transparency-32
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2672,6 +2698,7 @@ TEST 33: pgfmanual-en-tikz-transparency-33
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x37.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 o
@@ -2681,6 +2708,7 @@ TEST 33: pgfmanual-en-tikz-transparency-33
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2783,6 +2811,7 @@ TEST 34: pgfmanual-en-tikz-transparency-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.06)x37.51, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 S
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 o
@@ -2792,6 +2821,7 @@ TEST 34: pgfmanual-en-tikz-transparency-34
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 g
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2870,8 +2900,10 @@ TEST 35: pgfmanual-en-tikz-transparency-35
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }

--- a/testfiles-examples/pgfmanual-en-tikz-trees.tlg
+++ b/testfiles-examples/pgfmanual-en-tikz-trees.tlg
@@ -35,11 +35,13 @@ TEST 1: pgfmanual-en-tikz-trees-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -70,10 +72,12 @@ TEST 1: pgfmanual-en-tikz-trees-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -116,12 +120,14 @@ TEST 1: pgfmanual-en-tikz-trees-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -164,12 +170,14 @@ TEST 1: pgfmanual-en-tikz-trees-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -212,12 +220,14 @@ TEST 1: pgfmanual-en-tikz-trees-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -287,11 +297,13 @@ TEST 2: pgfmanual-en-tikz-trees-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -322,10 +334,12 @@ TEST 2: pgfmanual-en-tikz-trees-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -368,12 +382,14 @@ TEST 2: pgfmanual-en-tikz-trees-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -416,12 +432,14 @@ TEST 2: pgfmanual-en-tikz-trees-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -464,12 +482,14 @@ TEST 2: pgfmanual-en-tikz-trees-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -806,11 +826,13 @@ TEST 4: pgfmanual-en-tikz-trees-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -846,10 +868,12 @@ TEST 4: pgfmanual-en-tikz-trees-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -897,12 +921,14 @@ TEST 4: pgfmanual-en-tikz-trees-8
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -984,11 +1010,13 @@ TEST 5: pgfmanual-en-tikz-trees-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1095,11 +1123,13 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1196,6 +1226,7 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x26.42, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
@@ -1205,6 +1236,7 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ............< \TU/lmr/m/n/10 -
 ............= \TU/lmr/m/n/10 -
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1232,6 +1264,7 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x26.42, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
@@ -1241,6 +1274,7 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ............< \TU/lmr/m/n/10 -
 ............= \TU/lmr/m/n/10 -
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1268,6 +1302,7 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+1.94)x29.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 p
 ...........\kern0.28 (font)
@@ -1278,6 +1313,7 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 l
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1305,6 +1341,7 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.11)x34.75, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
@@ -1318,6 +1355,7 @@ TEST 6: pgfmanual-en-tikz-trees-10
 ............< \TU/lmr/m/n/10 -
 ............= \TU/lmr/m/n/10 -
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1519,6 +1557,7 @@ TEST 8: pgfmanual-en-tikz-trees-12
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
@@ -1526,6 +1565,7 @@ TEST 8: pgfmanual-en-tikz-trees-12
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1627,6 +1667,7 @@ TEST 9: pgfmanual-en-tikz-trees-13
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
@@ -1634,6 +1675,7 @@ TEST 9: pgfmanual-en-tikz-trees-13
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1729,11 +1771,13 @@ TEST 10: pgfmanual-en-tikz-trees-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1908,11 +1952,13 @@ TEST 11: pgfmanual-en-tikz-trees-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2091,6 +2137,7 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ..........\pdfliteral origin{0.5 G }
 ..........\pdfliteral origin{0.5 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.5 g 0.5 G}
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
@@ -2098,6 +2145,7 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2128,9 +2176,11 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmr/m/n/10 1
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2173,9 +2223,11 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmr/m/n/10 2
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2218,9 +2270,11 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmr/m/n/10 3
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2263,9 +2317,11 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ............\pdfliteral origin{0.5 G }
 ............\pdfliteral origin{0.5 g }
 ............\hbox(6.77+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0.5 g 0.5 G}
 .............\TU/lmr/m/n/10 4
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2335,6 +2391,7 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x67.34, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 b
@@ -2355,6 +2412,7 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2406,6 +2464,7 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x58.38, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 v
@@ -2423,6 +2482,7 @@ TEST 12: pgfmanual-en-tikz-trees-17
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2479,11 +2539,13 @@ TEST 13: pgfmanual-en-tikz-trees-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2643,11 +2705,13 @@ TEST 14: pgfmanual-en-tikz-trees-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3078,8 +3142,10 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x10.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3120,8 +3186,10 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3171,8 +3239,10 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 2
 ...............\TU/lmr/m/n/10 0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3224,7 +3294,9 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3277,7 +3349,9 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3330,8 +3404,10 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3383,7 +3459,9 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 9
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3436,7 +3514,9 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3489,8 +3569,10 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x10.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
 .............\TU/lmr/m/n/10 0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3540,8 +3622,10 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 9
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3593,7 +3677,9 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3646,8 +3732,10 @@ TEST 16: pgfmanual-en-tikz-trees-21
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 8
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3713,11 +3801,13 @@ TEST 17: pgfmanual-en-tikz-trees-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3809,11 +3899,13 @@ TEST 18: pgfmanual-en-tikz-trees-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3906,11 +3998,13 @@ TEST 19: pgfmanual-en-tikz-trees-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4070,7 +4164,9 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+0.22)x7.22, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4101,7 +4197,9 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+0.0)x7.5, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 H
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4144,7 +4242,9 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+0.0)x7.5, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 H
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4187,7 +4287,9 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+0.0)x7.5, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 H
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4230,7 +4332,9 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.22)x7.22, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 C
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4283,7 +4387,9 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 H
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4326,7 +4432,9 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 H
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4369,7 +4477,9 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+0.0)x7.5, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 H
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4424,6 +4534,7 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(7.16+2.06)x62.36, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\TU/lmr/m/n/10 T
 ...........\TU/lmr/m/n/10 h
@@ -4440,6 +4551,7 @@ TEST 20: pgfmanual-en-tikz-trees-25
 ...........\TU/lmr/m/n/10 g
 ...........\TU/lmr/m/n/10 !
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4498,6 +4610,7 @@ TEST 21: pgfmanual-en-tikz-trees-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x44.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 s
 ...........\TU/lmr/m/n/10 t
 ...........\TU/lmr/m/n/10 a
@@ -4509,6 +4622,7 @@ TEST 21: pgfmanual-en-tikz-trees-26
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 d
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4538,9 +4652,11 @@ TEST 21: pgfmanual-en-tikz-trees-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.11)x15.56, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4586,6 +4702,7 @@ TEST 21: pgfmanual-en-tikz-trees-26
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x78.41, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 t
 .............\TU/lmr/m/n/10 h
 .............\TU/lmr/m/n/10 e
@@ -4606,6 +4723,7 @@ TEST 21: pgfmanual-en-tikz-trees-26
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 e
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4676,11 +4794,13 @@ TEST 22: pgfmanual-en-tikz-trees-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4711,7 +4831,9 @@ TEST 22: pgfmanual-en-tikz-trees-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 1
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4754,7 +4876,9 @@ TEST 22: pgfmanual-en-tikz-trees-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4797,7 +4921,9 @@ TEST 22: pgfmanual-en-tikz-trees-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 3
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4840,7 +4966,9 @@ TEST 22: pgfmanual-en-tikz-trees-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 5
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4883,7 +5011,9 @@ TEST 22: pgfmanual-en-tikz-trees-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.22)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 6
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4954,11 +5084,13 @@ TEST 23: pgfmanual-en-tikz-trees-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5006,11 +5138,13 @@ TEST 23: pgfmanual-en-tikz-trees-28
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5108,11 +5242,13 @@ TEST 24: pgfmanual-en-tikz-trees-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5143,11 +5279,13 @@ TEST 24: pgfmanual-en-tikz-trees-29
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x22.83, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 s
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 a
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 l
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5188,6 +5326,7 @@ TEST 24: pgfmanual-en-tikz-trees-29
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.06)x34.76, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 b
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 g
@@ -5197,6 +5336,7 @@ TEST 24: pgfmanual-en-tikz-trees-29
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5227,9 +5367,11 @@ TEST 24: pgfmanual-en-tikz-trees-29
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(8.328+2.46)x15.67201, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/12 b
 .............\TU/lmr/m/n/12 i
 .............\TU/lmr/m/n/12 g
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5298,11 +5440,13 @@ TEST 25: pgfmanual-en-tikz-trees-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5333,10 +5477,12 @@ TEST 25: pgfmanual-en-tikz-trees-30
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5385,12 +5531,14 @@ TEST 25: pgfmanual-en-tikz-trees-30
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5436,12 +5584,14 @@ TEST 25: pgfmanual-en-tikz-trees-30
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5489,12 +5639,14 @@ TEST 25: pgfmanual-en-tikz-trees-30
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5569,11 +5721,13 @@ TEST 26: pgfmanual-en-tikz-trees-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5604,10 +5758,12 @@ TEST 26: pgfmanual-en-tikz-trees-32
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5647,12 +5803,14 @@ TEST 26: pgfmanual-en-tikz-trees-32
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5692,12 +5850,14 @@ TEST 26: pgfmanual-en-tikz-trees-32
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5737,12 +5897,14 @@ TEST 26: pgfmanual-en-tikz-trees-32
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5809,11 +5971,13 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5844,10 +6008,12 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5882,7 +6048,9 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.48+0.11)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 a
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5908,7 +6076,9 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 b
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5941,12 +6111,14 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5989,12 +6161,14 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6029,7 +6203,9 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6062,12 +6238,14 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6105,7 +6283,9 @@ TEST 27: pgfmanual-en-tikz-trees-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.31+0.0)x5.28, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 x
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6163,11 +6343,13 @@ TEST 28: pgfmanual-en-tikz-trees-36
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x18.09, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 o
 ...........\kern0.28 (font)
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6198,10 +6380,12 @@ TEST 28: pgfmanual-en-tikz-trees-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+0.11)x14.17, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 f
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6246,12 +6430,14 @@ TEST 28: pgfmanual-en-tikz-trees-36
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.87, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 r
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 h
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6293,12 +6479,14 @@ TEST 28: pgfmanual-en-tikz-trees-36
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6340,12 +6528,14 @@ TEST 28: pgfmanual-en-tikz-trees-36
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x20.84, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tutorial-Euclid.tlg
+++ b/testfiles-examples/pgfmanual-en-tutorial-Euclid.tlg
@@ -91,11 +91,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -128,12 +130,14 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -202,9 +206,11 @@ TEST 3: pgfmanual-en-tutorial-Euclid-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -237,10 +243,12 @@ TEST 3: pgfmanual-en-tutorial-Euclid-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -315,9 +323,11 @@ TEST 4: pgfmanual-en-tutorial-Euclid-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -350,10 +360,12 @@ TEST 4: pgfmanual-en-tutorial-Euclid-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -437,9 +449,11 @@ TEST 5: pgfmanual-en-tutorial-Euclid-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -472,10 +486,12 @@ TEST 5: pgfmanual-en-tutorial-Euclid-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -559,9 +575,11 @@ TEST 6: pgfmanual-en-tutorial-Euclid-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -594,10 +612,12 @@ TEST 6: pgfmanual-en-tutorial-Euclid-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -638,6 +658,8 @@ TEST 6: pgfmanual-en-tutorial-Euclid-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -661,10 +683,12 @@ TEST 6: pgfmanual-en-tutorial-Euclid-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -724,9 +748,11 @@ TEST 7: pgfmanual-en-tutorial-Euclid-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -759,10 +785,12 @@ TEST 7: pgfmanual-en-tutorial-Euclid-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -803,6 +831,8 @@ TEST 7: pgfmanual-en-tutorial-Euclid-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -826,10 +856,12 @@ TEST 7: pgfmanual-en-tutorial-Euclid-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -866,6 +898,8 @@ TEST 7: pgfmanual-en-tutorial-Euclid-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -891,10 +925,12 @@ TEST 7: pgfmanual-en-tutorial-Euclid-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.95831, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 E
 ...........\kern0.57637 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -944,10 +980,12 @@ TEST 7: pgfmanual-en-tutorial-Euclid-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1028,9 +1066,11 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1063,10 +1103,12 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1108,6 +1150,8 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1131,10 +1175,12 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1171,6 +1217,8 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1196,10 +1244,12 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.95831, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 E
 ...........\kern0.57637 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1247,10 +1297,12 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1284,12 +1336,14 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.51782+0.0)x10.66805, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\hbox(3.8889+0.0)x2.80556, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 0
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1355,6 +1409,8 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1380,10 +1436,12 @@ TEST 8: pgfmanual-en-tutorial-Euclid-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.81946, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 F
 ...........\kern1.3889 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1472,11 +1530,13 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 0.8 rg 0 0 0.8 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1509,12 +1569,14 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 0.8 rg 0 0 0.8 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1563,6 +1625,8 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1586,10 +1650,12 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1630,6 +1696,8 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1655,10 +1723,12 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.95831, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 E
 ...........\kern0.57637 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1706,12 +1776,14 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 0 0 rg 0.7 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1805,6 +1877,7 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.174+33.854)x284.52756, direction TLT
+...........\begindir TLT
 ...........\vbox(6.174+33.854)x284.52756, direction TLT
 ............\hbox(6.174+1.746)x284.52756, glue set 222.93155fil, direction TLT
 .............\localpar
@@ -2011,6 +2084,7 @@ TEST 9: pgfmanual-en-tutorial-Euclid-14
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2071,9 +2145,11 @@ TEST 10: pgfmanual-en-tutorial-Euclid-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2106,10 +2182,12 @@ TEST 10: pgfmanual-en-tutorial-Euclid-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2151,6 +2229,8 @@ TEST 10: pgfmanual-en-tutorial-Euclid-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2176,10 +2256,12 @@ TEST 10: pgfmanual-en-tutorial-Euclid-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x9.06943, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 X
 ...........\kern0.7847 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2239,9 +2321,11 @@ TEST 11: pgfmanual-en-tutorial-Euclid-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2274,10 +2358,12 @@ TEST 11: pgfmanual-en-tutorial-Euclid-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2319,6 +2405,8 @@ TEST 11: pgfmanual-en-tutorial-Euclid-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2344,10 +2432,12 @@ TEST 11: pgfmanual-en-tutorial-Euclid-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x9.06943, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 X
 ...........\kern0.7847 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2385,6 +2475,8 @@ TEST 11: pgfmanual-en-tutorial-Euclid-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2410,10 +2502,12 @@ TEST 11: pgfmanual-en-tutorial-Euclid-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2484,9 +2578,11 @@ TEST 12: pgfmanual-en-tutorial-Euclid-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2519,10 +2615,12 @@ TEST 12: pgfmanual-en-tutorial-Euclid-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2564,6 +2662,8 @@ TEST 12: pgfmanual-en-tutorial-Euclid-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2589,10 +2689,12 @@ TEST 12: pgfmanual-en-tutorial-Euclid-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2663,9 +2765,11 @@ TEST 13: pgfmanual-en-tutorial-Euclid-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2698,10 +2802,12 @@ TEST 13: pgfmanual-en-tutorial-Euclid-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2734,10 +2840,12 @@ TEST 13: pgfmanual-en-tutorial-Euclid-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2777,10 +2885,12 @@ TEST 13: pgfmanual-en-tutorial-Euclid-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2816,6 +2926,8 @@ TEST 13: pgfmanual-en-tutorial-Euclid-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2841,10 +2953,12 @@ TEST 13: pgfmanual-en-tutorial-Euclid-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x9.12497, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 H
 ...........\kern0.81247 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2881,10 +2995,12 @@ TEST 13: pgfmanual-en-tutorial-Euclid-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.81946, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 F
 ...........\kern1.3889 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2921,10 +3037,12 @@ TEST 13: pgfmanual-en-tutorial-Euclid-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.95831, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 E
 ...........\kern0.57637 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2984,9 +3102,11 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3019,10 +3139,12 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3055,10 +3177,12 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3098,10 +3222,12 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3138,10 +3264,12 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.81946, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 F
 ...........\kern1.3889 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3178,10 +3306,12 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.95831, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 E
 ...........\kern0.57637 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3217,6 +3347,8 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3242,10 +3374,12 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x9.12497, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 H
 ...........\kern0.81247 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3276,9 +3410,11 @@ TEST 14: pgfmanual-en-tutorial-Euclid-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 G
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3354,9 +3490,11 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3389,10 +3527,12 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3425,10 +3565,12 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3468,10 +3610,12 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3508,10 +3652,12 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.81946, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 F
 ...........\kern1.3889 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3548,10 +3694,12 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.95831, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 E
 ...........\kern0.57637 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3587,6 +3735,8 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3612,10 +3762,12 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x9.12497, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 H
 ...........\kern0.81247 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3657,9 +3809,11 @@ TEST 15: pgfmanual-en-tutorial-Euclid-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 G
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3754,11 +3908,13 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.50002, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 A
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3791,12 +3947,14 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.0868, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 0.8 rg 0 0 0.8 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 B
 ...........\kern0.50172 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3829,12 +3987,14 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 0.8 rg 0 0 0.8 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 C
 ...........\kern0.71527 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3885,10 +4045,12 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x8.55695, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 D
 ...........\kern0.27779 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3926,10 +4088,12 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.95831, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 E
 ...........\kern0.57637 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3970,10 +4134,12 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.81946, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 F
 ...........\kern1.3889 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4014,6 +4180,8 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4039,10 +4207,12 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x9.12497, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 H
 ...........\kern0.81247 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4086,9 +4256,11 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x7.86249, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 G
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4131,6 +4303,8 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4156,10 +4330,12 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x9.20833, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 K
 ...........\kern0.71527 (italic)
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4203,11 +4379,13 @@ TEST 16: pgfmanual-en-tutorial-Euclid-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.83331+0.0)x6.80557, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.7 0 0 rg 0.7 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 L
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tutorial-chains.tlg
+++ b/testfiles-examples/pgfmanual-en-tutorial-chains.tlg
@@ -41,8 +41,10 @@ TEST 1: pgfmanual-en-tutorial-chains-1
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -61,6 +63,7 @@ TEST 1: pgfmanual-en-tutorial-chains-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x70.67004, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 u
 ...........\TU/lmr/m/it/10 n
 ...........\discretionary (penalty 50)
@@ -85,6 +88,7 @@ TEST 1: pgfmanual-en-tutorial-chains-1
 ...........\TU/lmr/m/it/10 g
 ...........\TU/lmr/m/it/10 e
 ...........\TU/lmr/m/it/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -156,8 +160,10 @@ TEST 2: pgfmanual-en-tutorial-chains-2
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -186,7 +192,9 @@ TEST 2: pgfmanual-en-tutorial-chains-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(1.25+0.0)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -231,8 +239,10 @@ TEST 2: pgfmanual-en-tutorial-chains-2
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -261,11 +271,13 @@ TEST 2: pgfmanual-en-tutorial-chains-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+2.29)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -310,8 +322,10 @@ TEST 2: pgfmanual-en-tutorial-chains-2
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -340,7 +354,9 @@ TEST 2: pgfmanual-en-tutorial-chains-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+0.0)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -405,8 +421,10 @@ TEST 3: pgfmanual-en-tutorial-chains-3
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -432,7 +450,9 @@ TEST 3: pgfmanual-en-tutorial-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(1.25+0.0)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -468,8 +488,10 @@ TEST 3: pgfmanual-en-tutorial-chains-3
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -495,11 +517,13 @@ TEST 3: pgfmanual-en-tutorial-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+2.29)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -535,8 +559,10 @@ TEST 3: pgfmanual-en-tutorial-chains-3
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -562,7 +588,9 @@ TEST 3: pgfmanual-en-tutorial-chains-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+0.0)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -627,8 +655,10 @@ TEST 4: pgfmanual-en-tutorial-chains-5
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -654,7 +684,9 @@ TEST 4: pgfmanual-en-tutorial-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(1.25+0.0)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -690,8 +722,10 @@ TEST 4: pgfmanual-en-tutorial-chains-5
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -717,11 +751,13 @@ TEST 4: pgfmanual-en-tutorial-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+2.29)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -757,8 +793,10 @@ TEST 4: pgfmanual-en-tutorial-chains-5
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -784,7 +822,9 @@ TEST 4: pgfmanual-en-tutorial-chains-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+0.0)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -865,8 +905,10 @@ TEST 5: pgfmanual-en-tutorial-chains-6
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -892,7 +934,9 @@ TEST 5: pgfmanual-en-tutorial-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(1.25+0.0)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -928,8 +972,10 @@ TEST 5: pgfmanual-en-tutorial-chains-6
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -955,11 +1001,13 @@ TEST 5: pgfmanual-en-tutorial-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+2.29)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -995,8 +1043,10 @@ TEST 5: pgfmanual-en-tutorial-chains-6
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1022,7 +1072,9 @@ TEST 5: pgfmanual-en-tutorial-chains-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.11+0.0)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1087,8 +1139,10 @@ TEST 6: pgfmanual-en-tutorial-chains-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1114,7 +1168,9 @@ TEST 6: pgfmanual-en-tutorial-chains-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1150,8 +1206,10 @@ TEST 6: pgfmanual-en-tutorial-chains-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1177,11 +1235,13 @@ TEST 6: pgfmanual-en-tutorial-chains-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1217,8 +1277,10 @@ TEST 6: pgfmanual-en-tutorial-chains-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1244,7 +1306,9 @@ TEST 6: pgfmanual-en-tutorial-chains-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1306,8 +1370,10 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1326,6 +1392,7 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x70.67004, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 u
 ...........\TU/lmr/m/it/10 n
 ...........\discretionary (penalty 50)
@@ -1350,6 +1417,7 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ...........\TU/lmr/m/it/10 g
 ...........\TU/lmr/m/it/10 e
 ...........\TU/lmr/m/it/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1387,8 +1455,10 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1414,7 +1484,9 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1450,8 +1522,10 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1477,11 +1551,13 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1517,8 +1593,10 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1544,7 +1622,9 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1580,8 +1660,10 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1607,7 +1689,9 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 +
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1643,8 +1727,10 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1670,7 +1756,9 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1703,8 +1791,10 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1723,6 +1813,7 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x70.67004, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 u
 ...........\TU/lmr/m/it/10 n
 ...........\discretionary (penalty 50)
@@ -1747,6 +1838,7 @@ TEST 7: pgfmanual-en-tutorial-chains-9
 ...........\TU/lmr/m/it/10 g
 ...........\TU/lmr/m/it/10 e
 ...........\TU/lmr/m/it/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1811,8 +1903,10 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1838,7 +1932,9 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1874,8 +1970,10 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1901,7 +1999,9 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 +
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1937,8 +2037,10 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -1964,7 +2066,9 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1997,8 +2101,10 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2017,6 +2123,7 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x70.67004, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 u
 ...........\TU/lmr/m/it/10 n
 ...........\discretionary (penalty 50)
@@ -2041,6 +2148,7 @@ TEST 8: pgfmanual-en-tutorial-chains-10
 ...........\TU/lmr/m/it/10 g
 ...........\TU/lmr/m/it/10 e
 ...........\TU/lmr/m/it/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2112,8 +2220,10 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2142,7 +2252,9 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2185,8 +2297,10 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2215,7 +2329,9 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 +
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2261,8 +2377,10 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2291,7 +2409,9 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 -
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2327,8 +2447,10 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2347,6 +2469,7 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x70.67004, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/it/10 u
 ...........\TU/lmr/m/it/10 n
 ...........\discretionary (penalty 50)
@@ -2371,6 +2494,7 @@ TEST 9: pgfmanual-en-tutorial-chains-11
 ...........\TU/lmr/m/it/10 g
 ...........\TU/lmr/m/it/10 e
 ...........\TU/lmr/m/it/10 r
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2435,8 +2559,10 @@ TEST 10: pgfmanual-en-tutorial-chains-12
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2462,7 +2588,9 @@ TEST 10: pgfmanual-en-tutorial-chains-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2498,8 +2626,10 @@ TEST 10: pgfmanual-en-tutorial-chains-12
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2525,11 +2655,13 @@ TEST 10: pgfmanual-en-tutorial-chains-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2565,8 +2697,10 @@ TEST 10: pgfmanual-en-tutorial-chains-12
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2592,7 +2726,9 @@ TEST 10: pgfmanual-en-tutorial-chains-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2697,8 +2833,10 @@ TEST 11: pgfmanual-en-tutorial-chains-13
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2724,7 +2862,9 @@ TEST 11: pgfmanual-en-tutorial-chains-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2760,8 +2900,10 @@ TEST 11: pgfmanual-en-tutorial-chains-13
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2787,11 +2929,13 @@ TEST 11: pgfmanual-en-tutorial-chains-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2827,8 +2971,10 @@ TEST 11: pgfmanual-en-tutorial-chains-13
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2854,7 +3000,9 @@ TEST 11: pgfmanual-en-tutorial-chains-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2956,8 +3104,10 @@ TEST 12: pgfmanual-en-tutorial-chains-14
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -2983,7 +3133,9 @@ TEST 12: pgfmanual-en-tutorial-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 .
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3019,8 +3171,10 @@ TEST 12: pgfmanual-en-tutorial-chains-14
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3046,11 +3200,13 @@ TEST 12: pgfmanual-en-tutorial-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x26.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 d
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 g
 ...........\TU/lmtt/m/n/10 i
 ...........\TU/lmtt/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3086,8 +3242,10 @@ TEST 12: pgfmanual-en-tutorial-chains-14
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\pdfliteral origin{Q }
@@ -3113,7 +3271,9 @@ TEST 12: pgfmanual-en-tutorial-chains-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.465+1.0775)x5.25, direction TLT
+...........\begindir TLT
 ...........\TU/lmtt/m/n/10 E
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3282,8 +3442,10 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -3309,7 +3471,9 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 +
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3369,8 +3533,10 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -3389,6 +3555,7 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x70.67004, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/it/10 u
 .....................\TU/lmr/m/it/10 n
 .....................\discretionary (penalty 50)
@@ -3413,6 +3580,7 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 .....................\TU/lmr/m/it/10 g
 .....................\TU/lmr/m/it/10 e
 .....................\TU/lmr/m/it/10 r
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3460,8 +3628,10 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -3487,7 +3657,9 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 .
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3535,8 +3707,10 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -3562,11 +3736,13 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x26.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 d
 .....................\TU/lmtt/m/n/10 i
 .....................\TU/lmtt/m/n/10 g
 .....................\TU/lmtt/m/n/10 i
 .....................\TU/lmtt/m/n/10 t
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3614,8 +3790,10 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -3641,7 +3819,9 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 E
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3697,8 +3877,10 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -3717,6 +3899,7 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x70.67004, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/it/10 u
 .....................\TU/lmr/m/it/10 n
 .....................\discretionary (penalty 50)
@@ -3741,6 +3924,7 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 .....................\TU/lmr/m/it/10 g
 .....................\TU/lmr/m/it/10 e
 .....................\TU/lmr/m/it/10 r
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -3836,8 +4020,10 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -3863,7 +4049,9 @@ TEST 13: pgfmanual-en-tutorial-chains-15
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 -
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4097,8 +4285,10 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -4124,7 +4314,9 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 +
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4175,6 +4367,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4219,8 +4413,10 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -4239,6 +4435,7 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x70.67004, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/it/10 u
 .....................\TU/lmr/m/it/10 n
 .....................\discretionary (penalty 50)
@@ -4263,6 +4460,7 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 .....................\TU/lmr/m/it/10 g
 .....................\TU/lmr/m/it/10 e
 .....................\TU/lmr/m/it/10 r
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4309,6 +4507,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4356,8 +4556,10 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -4383,7 +4585,9 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 .
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4430,6 +4634,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4477,8 +4683,10 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -4504,11 +4712,13 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x26.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 d
 .....................\TU/lmtt/m/n/10 i
 .....................\TU/lmtt/m/n/10 g
 .....................\TU/lmtt/m/n/10 i
 .....................\TU/lmtt/m/n/10 t
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4555,6 +4765,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4601,6 +4813,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4647,6 +4861,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4694,8 +4910,10 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -4721,7 +4939,9 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 E
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4768,6 +4988,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4825,6 +5047,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4869,8 +5093,10 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -4889,6 +5115,7 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x70.67004, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/it/10 u
 .....................\TU/lmr/m/it/10 n
 .....................\discretionary (penalty 50)
@@ -4913,6 +5140,7 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 .....................\TU/lmr/m/it/10 g
 .....................\TU/lmr/m/it/10 e
 .....................\TU/lmr/m/it/10 r
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -4959,6 +5187,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5005,6 +5235,8 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(0.0+0.0)x0.0, direction TLT
+.....................\begindir TLT
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5177,8 +5409,10 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -5204,7 +5438,9 @@ TEST 14: pgfmanual-en-tutorial-chains-16
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 -
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5458,8 +5694,10 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -5485,7 +5723,9 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 +
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5551,8 +5791,10 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -5571,6 +5813,7 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x70.67004, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/it/10 u
 .....................\TU/lmr/m/it/10 n
 .....................\discretionary (penalty 50)
@@ -5595,6 +5838,7 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 .....................\TU/lmr/m/it/10 g
 .....................\TU/lmr/m/it/10 e
 .....................\TU/lmr/m/it/10 r
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5659,8 +5903,10 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -5686,7 +5932,9 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 .
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5751,8 +5999,10 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -5778,11 +6028,13 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x26.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 d
 .....................\TU/lmtt/m/n/10 i
 .....................\TU/lmtt/m/n/10 g
 .....................\TU/lmtt/m/n/10 i
 .....................\TU/lmtt/m/n/10 t
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5881,8 +6133,10 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -5908,7 +6162,9 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 E
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -5998,8 +6254,10 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -6018,6 +6276,7 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x70.67004, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/it/10 u
 .....................\TU/lmr/m/it/10 n
 .....................\discretionary (penalty 50)
@@ -6042,6 +6301,7 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 .....................\TU/lmr/m/it/10 g
 .....................\TU/lmr/m/it/10 e
 .....................\TU/lmr/m/it/10 r
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -6248,8 +6508,10 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -6275,7 +6537,9 @@ TEST 15: pgfmanual-en-tutorial-chains-18
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\TU/lmtt/m/n/10 -
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7664,8 +7928,10 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -7691,9 +7957,11 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 g 0 G}
 .....................\TU/lmtt/m/n/10 +
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7759,8 +8027,10 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -7779,6 +8049,7 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x70.67004, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 g 0 G}
 .....................\TU/lmr/m/it/10 u
 .....................\TU/lmr/m/it/10 n
@@ -7805,6 +8076,7 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 .....................\TU/lmr/m/it/10 e
 .....................\TU/lmr/m/it/10 r
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7869,8 +8141,10 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -7896,9 +8170,11 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 g 0 G}
 .....................\TU/lmtt/m/n/10 .
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -7963,8 +8239,10 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -7990,6 +8268,7 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x26.25, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 g 0 G}
 .....................\TU/lmtt/m/n/10 d
 .....................\TU/lmtt/m/n/10 i
@@ -7997,6 +8276,7 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 .....................\TU/lmtt/m/n/10 i
 .....................\TU/lmtt/m/n/10 t
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8095,8 +8375,10 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -8122,9 +8404,11 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 g 0 G}
 .....................\TU/lmtt/m/n/10 E
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8214,8 +8498,10 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -8234,6 +8520,7 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x70.67004, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 g 0 G}
 .....................\TU/lmr/m/it/10 u
 .....................\TU/lmr/m/it/10 n
@@ -8260,6 +8547,7 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 .....................\TU/lmr/m/it/10 e
 .....................\TU/lmr/m/it/10 r
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -8466,8 +8754,10 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ..................\glue -50.1875
 ..................\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...................\hbox(100.375+0.0)x100.375, direction TLT
+....................\begindir TLT
 ....................\hbox(100.375+0.0)x100.375, direction TLT
 .....................\box(100.375+0.0)x100.375
+....................\enddir TLT
 ................\pdfliteral origin{Q }
 ................\glue(\spaceskip) 0.0
 ................\pdfliteral origin{Q }
@@ -8493,9 +8783,11 @@ TEST 16: pgfmanual-en-tutorial-chains-19
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.465+1.0775)x5.25, direction TLT
+.....................\begindir TLT
 .....................\pdfcolorstack 0 push {0 g 0 G}
 .....................\TU/lmtt/m/n/10 -
 .....................\pdfcolorstack 0 pop
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -9753,6 +10045,7 @@ TEST 17: pgfmanual-en-tutorial-chains-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x71.48, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 u
 .............\TU/lmr/m/n/10 n
 .............\discretionary (penalty 50)
@@ -9776,6 +10069,7 @@ TEST 17: pgfmanual-en-tutorial-chains-20
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9817,7 +10111,9 @@ TEST 17: pgfmanual-en-tutorial-chains-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+0.11)x5.56, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9892,11 +10188,13 @@ TEST 17: pgfmanual-en-tutorial-chains-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.94+2.06)x20.01, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 d
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 g
 .............\TU/lmr/m/n/10 i
 .............\TU/lmr/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9975,7 +10273,9 @@ TEST 17: pgfmanual-en-tutorial-chains-20
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.8+0.0)x6.81, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 E
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10102,8 +10402,10 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -10122,6 +10424,7 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x70.67004, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/it/10 u
 .............\TU/lmr/m/it/10 n
 .............\discretionary (penalty 50)
@@ -10146,6 +10449,7 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 .............\TU/lmr/m/it/10 g
 .............\TU/lmr/m/it/10 e
 .............\TU/lmr/m/it/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10200,8 +10504,10 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -10227,7 +10533,9 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\TU/lmtt/m/n/10 .
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10305,8 +10613,10 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -10332,11 +10642,13 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x26.25, direction TLT
+.............\begindir TLT
 .............\TU/lmtt/m/n/10 d
 .............\TU/lmtt/m/n/10 i
 .............\TU/lmtt/m/n/10 g
 .............\TU/lmtt/m/n/10 i
 .............\TU/lmtt/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10416,8 +10728,10 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -10443,7 +10757,9 @@ TEST 18: pgfmanual-en-tutorial-chains-21
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\TU/lmtt/m/n/10 E
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10562,8 +10878,10 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -10582,6 +10900,7 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x70.67004, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/it/10 u
 .............\TU/lmr/m/it/10 n
 .............\discretionary (penalty 50)
@@ -10606,6 +10925,7 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 .............\TU/lmr/m/it/10 g
 .............\TU/lmr/m/it/10 e
 .............\TU/lmr/m/it/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10660,8 +10980,10 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -10687,7 +11009,9 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\TU/lmtt/m/n/10 .
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10765,8 +11089,10 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -10792,11 +11118,13 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x26.25, direction TLT
+.............\begindir TLT
 .............\TU/lmtt/m/n/10 d
 .............\TU/lmtt/m/n/10 i
 .............\TU/lmtt/m/n/10 g
 .............\TU/lmtt/m/n/10 i
 .............\TU/lmtt/m/n/10 t
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10876,8 +11204,10 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -10903,7 +11233,9 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\TU/lmtt/m/n/10 E
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10992,8 +11324,10 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -11019,7 +11353,9 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\TU/lmtt/m/n/10 +
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11094,8 +11430,10 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -11121,7 +11459,9 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\TU/lmtt/m/n/10 -
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11253,8 +11593,10 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -11273,6 +11615,7 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x70.67004, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/it/10 u
 .............\TU/lmr/m/it/10 n
 .............\discretionary (penalty 50)
@@ -11297,6 +11640,7 @@ TEST 19: pgfmanual-en-tutorial-chains-22
 .............\TU/lmr/m/it/10 g
 .............\TU/lmr/m/it/10 e
 .............\TU/lmr/m/it/10 r
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11494,8 +11838,10 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -11514,6 +11860,7 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x70.67004, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmr/m/it/10 u
 .............\TU/lmr/m/it/10 n
@@ -11540,6 +11887,7 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 .............\TU/lmr/m/it/10 e
 .............\TU/lmr/m/it/10 r
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11676,8 +12024,10 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -11703,9 +12053,11 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 .
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11845,8 +12197,10 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -11872,6 +12226,7 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x26.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 d
 .............\TU/lmtt/m/n/10 i
@@ -11879,6 +12234,7 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 .............\TU/lmtt/m/n/10 i
 .............\TU/lmtt/m/n/10 t
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12176,8 +12532,10 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -12203,9 +12561,11 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 E
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12397,8 +12757,10 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -12424,9 +12786,11 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 +
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12497,8 +12861,10 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -12524,9 +12890,11 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 -
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12831,8 +13199,10 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -12851,6 +13221,7 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x70.67004, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmr/m/it/10 u
 .............\TU/lmr/m/it/10 n
@@ -12877,6 +13248,7 @@ TEST 20: pgfmanual-en-tutorial-chains-23
 .............\TU/lmr/m/it/10 e
 .............\TU/lmr/m/it/10 r
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13454,8 +13826,10 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -13474,6 +13848,7 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x70.67004, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmr/m/it/10 u
 .............\TU/lmr/m/it/10 n
@@ -13500,6 +13875,7 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 .............\TU/lmr/m/it/10 e
 .............\TU/lmr/m/it/10 r
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13608,8 +13984,10 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -13635,9 +14013,11 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 .
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13756,8 +14136,10 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -13783,6 +14165,7 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x26.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 d
 .............\TU/lmtt/m/n/10 i
@@ -13790,6 +14173,7 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 .............\TU/lmtt/m/n/10 i
 .............\TU/lmtt/m/n/10 t
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14046,8 +14430,10 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -14073,9 +14459,11 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 E
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14246,8 +14634,10 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -14273,9 +14663,11 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 +
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14345,8 +14737,10 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -14372,9 +14766,11 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x5.25, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmtt/m/n/10 -
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14595,8 +14991,10 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
@@ -14615,6 +15013,7 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.465+1.0775)x70.67004, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {0 g 0 G}
 .............\TU/lmr/m/it/10 u
 .............\TU/lmr/m/it/10 n
@@ -14641,6 +15040,7 @@ TEST 21: pgfmanual-en-tutorial-chains-24
 .............\TU/lmr/m/it/10 e
 .............\TU/lmr/m/it/10 r
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tutorial-map.tlg
+++ b/testfiles-examples/pgfmanual-en-tutorial-map.tlg
@@ -37,6 +37,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+2.05)x119.18, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 C
 ...........\TU/lmr/m/n/10 o
 ...........\TU/lmr/m/n/10 m
@@ -72,6 +73,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...........\TU/lmr/m/n/10 t
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -102,6 +104,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+1.94)x109.68, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 C
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 m
@@ -132,6 +135,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 s
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -174,6 +178,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x80.58, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 P
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 o
@@ -194,6 +199,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -236,6 +242,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.16+1.94)x74.16, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 P
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 o
@@ -256,6 +263,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 c
 ...............\TU/lmr/m/n/10 t
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -298,6 +306,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x78.42, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 P
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 o
@@ -317,6 +326,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 n
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -359,6 +369,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+2.05)x61.61, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 K
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 y
@@ -373,6 +384,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 m
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -417,6 +429,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+1.94)x100.06999, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 C
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 m
@@ -446,6 +459,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 l
 .............\TU/lmr/m/n/10 s
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -488,6 +502,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+2.06)x73.15, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 T
 ...............\kern-0.83 (font)
 ...............\TU/lmr/m/n/10 u
@@ -509,6 +524,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 n
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -551,6 +567,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.16+0.22)x112.50002, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 R
 ...............\TU/lmr/m/n/10 a
 ...............\TU/lmr/m/n/10 n
@@ -579,6 +596,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 n
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -621,6 +639,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.22)x34.53, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 C
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 r
@@ -631,6 +650,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 t
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -673,6 +693,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+2.06)x114.47, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 B
 ...............\TU/lmr/m/n/10 i
 ...............\discretionary (penalty 50)
@@ -707,6 +728,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 a
 ...............\TU/lmr/m/n/10 m
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -749,6 +771,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.22)x72.3, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 O
 ...............\TU/lmr/m/n/10 r
 ...............\discretionary (penalty 50)
@@ -771,6 +794,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 n
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -813,6 +837,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.83+2.06)x98.12, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 P
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 o
@@ -837,6 +862,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 g
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -881,6 +907,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+2.06)x98.98, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 M
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 a
@@ -910,6 +937,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 .............\TU/lmr/m/n/10 t
 .............\kern-0.28 (font)
 .............\TU/lmr/m/n/10 y
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -952,6 +980,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+2.05)x94.02, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 C
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 m
@@ -978,6 +1007,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 r
 ...............\TU/lmr/m/n/10 e
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1020,6 +1050,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+2.06)x100.95, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 C
 ...............\TU/lmr/m/n/10 l
 ...............\TU/lmr/m/n/10 a
@@ -1053,6 +1084,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 t
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1095,6 +1127,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+2.06)x101.98, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 C
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 m
@@ -1124,6 +1157,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 t
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1166,6 +1200,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+2.06)x99.67, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 D
 ...............\TU/lmr/m/n/10 e
 ...............\discretionary (penalty 50)
@@ -1196,6 +1231,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 t
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1240,6 +1276,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+2.06)x76.06999, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 S
 .............\TU/lmr/m/n/10 o
 .............\TU/lmr/m/n/10 l
@@ -1260,6 +1297,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 .............\TU/lmr/m/n/10 e
 .............\TU/lmr/m/n/10 m
 .............\TU/lmr/m/n/10 s
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1302,6 +1340,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.16+2.06)x77.45, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 E
 ...............\TU/lmr/m/n/10 x
 ...............\discretionary (penalty 50)
@@ -1324,6 +1363,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 m
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1366,6 +1406,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.22)x66.26, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 R
 ...............\TU/lmr/m/n/10 a
 ...............\TU/lmr/m/n/10 n
@@ -1385,6 +1426,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1427,6 +1469,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.16+2.06)x125.42, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 F
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 x
@@ -1460,6 +1503,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 h
 ...............\TU/lmr/m/n/10 m
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1502,6 +1546,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+1.94)x94.34999, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 P
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 a
@@ -1533,6 +1578,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1575,6 +1621,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.22)x73.29999, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 P
 ...............\kern-0.28 (font)
 ...............\TU/lmr/m/n/10 a
@@ -1599,6 +1646,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 n
 ...............\TU/lmr/m/n/10 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1641,6 +1689,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.16+1.94)x65.87999, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 A
 ...............\TU/lmr/m/n/10 p
 ...............\discretionary (penalty 50)
@@ -1663,6 +1712,7 @@ TEST 1: pgfmanual-en-tutorial-map-1
 ...............\TU/lmr/m/n/10 i
 ...............\TU/lmr/m/n/10 o
 ...............\TU/lmr/m/n/10 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1734,6 +1784,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(5.632+1.632)x101.24803, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/8 C
 ...........\TU/lmr/m/n/8 o
 ...........\TU/lmr/m/n/8 m
@@ -1769,6 +1820,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...........\TU/lmr/m/n/8 t
 ...........\kern-0.24 (font)
 ...........\TU/lmr/m/n/8 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1799,6 +1851,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.632+1.552)x93.16002, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 C
 .............\TU/lmr/m/n/8 o
 .............\TU/lmr/m/n/8 m
@@ -1829,6 +1882,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 .............\TU/lmr/m/n/8 e
 .............\TU/lmr/m/n/8 m
 .............\TU/lmr/m/n/8 s
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -1871,6 +1925,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+0.08)x68.432, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 P
 ...............\TU/lmr/m/n/8 r
 ...............\TU/lmr/m/n/8 o
@@ -1891,6 +1946,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 r
 ...............\TU/lmr/m/n/8 e
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1933,6 +1989,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.712+1.552)x63.00002, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 P
 ...............\TU/lmr/m/n/8 r
 ...............\TU/lmr/m/n/8 o
@@ -1953,6 +2010,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 c
 ...............\TU/lmr/m/n/8 t
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -1995,6 +2053,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+0.08)x66.60802, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 P
 ...............\TU/lmr/m/n/8 r
 ...............\TU/lmr/m/n/8 o
@@ -2014,6 +2073,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 i
 ...............\TU/lmr/m/n/8 n
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2056,6 +2116,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+1.632)x52.32802, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 K
 ...............\TU/lmr/m/n/8 e
 ...............\TU/lmr/m/n/8 y
@@ -2070,6 +2131,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 e
 ...............\TU/lmr/m/n/8 m
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2114,6 +2176,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.632+1.552)x85.00803, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 C
 .............\TU/lmr/m/n/8 o
 .............\TU/lmr/m/n/8 m
@@ -2143,6 +2206,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 .............\TU/lmr/m/n/8 e
 .............\TU/lmr/m/n/8 l
 .............\TU/lmr/m/n/8 s
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2185,6 +2249,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+1.64)x62.112, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 T
 ...............\kern-0.712 (font)
 ...............\TU/lmr/m/n/8 u
@@ -2206,6 +2271,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 n
 ...............\TU/lmr/m/n/8 e
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2248,6 +2314,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.712+0.168)x95.59201, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 R
 ...............\TU/lmr/m/n/8 a
 ...............\TU/lmr/m/n/8 n
@@ -2276,6 +2343,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 n
 ...............\TU/lmr/m/n/8 e
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2318,6 +2386,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+0.168)x29.32, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 C
 ...............\TU/lmr/m/n/8 i
 ...............\TU/lmr/m/n/8 r
@@ -2328,6 +2397,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 i
 ...............\TU/lmr/m/n/8 t
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2370,6 +2440,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+1.64)x97.22404, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 B
 ...............\TU/lmr/m/n/8 i
 ...............\discretionary (penalty 50)
@@ -2404,6 +2475,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 a
 ...............\TU/lmr/m/n/8 m
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2446,6 +2518,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+0.168)x61.408, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 O
 ...............\TU/lmr/m/n/8 r
 ...............\discretionary (penalty 50)
@@ -2468,6 +2541,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 n
 ...............\TU/lmr/m/n/8 e
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2510,6 +2584,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+1.64)x83.328, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 P
 ...............\TU/lmr/m/n/8 r
 ...............\TU/lmr/m/n/8 o
@@ -2534,6 +2609,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 g
 ...............\TU/lmr/m/n/8 i
 ...............\TU/lmr/m/n/8 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2578,6 +2654,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.632+1.64)x84.07202, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 M
 .............\TU/lmr/m/n/8 e
 .............\TU/lmr/m/n/8 a
@@ -2607,6 +2684,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 .............\TU/lmr/m/n/8 t
 .............\kern-0.24 (font)
 .............\TU/lmr/m/n/8 y
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2649,6 +2727,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+1.632)x79.87202, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 C
 ...............\TU/lmr/m/n/8 o
 ...............\TU/lmr/m/n/8 m
@@ -2675,6 +2754,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 r
 ...............\TU/lmr/m/n/8 e
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2717,6 +2797,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+1.64)x85.77605, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 C
 ...............\TU/lmr/m/n/8 l
 ...............\TU/lmr/m/n/8 a
@@ -2750,6 +2831,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 t
 ...............\kern-0.24 (font)
 ...............\TU/lmr/m/n/8 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2792,6 +2874,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+1.64)x86.62402, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 C
 ...............\TU/lmr/m/n/8 o
 ...............\TU/lmr/m/n/8 m
@@ -2821,6 +2904,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 t
 ...............\kern-0.24 (font)
 ...............\TU/lmr/m/n/8 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2863,6 +2947,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+1.64)x84.66403, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 D
 ...............\TU/lmr/m/n/8 e
 ...............\discretionary (penalty 50)
@@ -2893,6 +2978,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 t
 ...............\kern-0.24 (font)
 ...............\TU/lmr/m/n/8 y
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -2937,6 +3023,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(5.632+1.64)x64.60802, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/8 S
 .............\TU/lmr/m/n/8 o
 .............\TU/lmr/m/n/8 l
@@ -2957,6 +3044,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 .............\TU/lmr/m/n/8 e
 .............\TU/lmr/m/n/8 m
 .............\TU/lmr/m/n/8 s
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -2999,6 +3087,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.712+1.64)x65.78401, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 E
 ...............\TU/lmr/m/n/8 x
 ...............\discretionary (penalty 50)
@@ -3021,6 +3110,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 h
 ...............\TU/lmr/m/n/8 m
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3063,6 +3153,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+0.168)x56.28801, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 R
 ...............\TU/lmr/m/n/8 a
 ...............\TU/lmr/m/n/8 n
@@ -3082,6 +3173,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 i
 ...............\TU/lmr/m/n/8 o
 ...............\TU/lmr/m/n/8 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3124,6 +3216,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.712+1.64)x106.50401, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 F
 ...............\TU/lmr/m/n/8 i
 ...............\TU/lmr/m/n/8 x
@@ -3157,6 +3250,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 h
 ...............\TU/lmr/m/n/8 m
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3199,6 +3293,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+1.552)x80.128, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 P
 ...............\kern-0.24 (font)
 ...............\TU/lmr/m/n/8 a
@@ -3230,6 +3325,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 i
 ...............\TU/lmr/m/n/8 o
 ...............\TU/lmr/m/n/8 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3272,6 +3368,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+0.168)x62.24, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 P
 ...............\kern-0.24 (font)
 ...............\TU/lmr/m/n/8 a
@@ -3296,6 +3393,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 o
 ...............\TU/lmr/m/n/8 n
 ...............\TU/lmr/m/n/8 s
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3338,6 +3436,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.712+1.552)x55.936, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/8 A
 ...............\TU/lmr/m/n/8 p
 ...............\discretionary (penalty 50)
@@ -3360,6 +3459,7 @@ TEST 2: pgfmanual-en-tutorial-map-2
 ...............\TU/lmr/m/n/8 i
 ...............\TU/lmr/m/n/8 o
 ...............\TU/lmr/m/n/8 n
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3431,6 +3531,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.97+14.0)x76.82234, direction TLT
+...........\begindir TLT
 ...........\vbox(6.97+14.0)x76.82234, direction TLT
 ............\hbox(6.97+1.94)x76.82234, glue set 0.88118fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -3483,6 +3584,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3513,6 +3615,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+12.11)x76.82234, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+12.11)x76.82234, direction TLT
 ..............\hbox(7.05+1.94)x76.82234, glue set 5.62617fil, direction TLT
 ...............\glue(\leftskip) 0.0 plus 1.0fil
@@ -3560,6 +3663,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 1.0fil
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3602,6 +3706,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.58)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x56.9055, direction TLT
 ................\hbox(5.552+0.08)x56.9055, glue set 12.81276fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -3639,6 +3744,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3681,6 +3787,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+11.052)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+11.052)x56.9055, direction TLT
 ................\hbox(5.552+0.08)x56.9055, glue set 12.81276fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -3718,6 +3825,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3760,6 +3868,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.58)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x56.9055, direction TLT
 ................\hbox(5.552+0.08)x56.9055, glue set 12.81276fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -3796,6 +3905,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3838,6 +3948,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+1.632)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+1.632)x56.9055, direction TLT
 ................\hbox(5.552+1.632)x56.9055, glue set 2.28874fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -3865,6 +3976,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -3909,6 +4021,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+12.11)x76.82234, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+12.11)x76.82234, direction TLT
 ..............\hbox(7.05+1.94)x76.82234, glue set 5.62617fil, direction TLT
 ...............\glue(\leftskip) 0.0 plus 1.0fil
@@ -3955,6 +4068,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 1.0fil
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -3997,6 +4111,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.408+9.58)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.408+9.58)x56.9055, direction TLT
 ................\hbox(5.408+1.64)x56.9055, glue set 16.06076fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4035,6 +4150,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4077,6 +4193,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+19.08)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+19.08)x56.9055, direction TLT
 ................\hbox(5.552+0.168)x56.9055, glue set 11.40076fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4126,6 +4243,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4168,6 +4286,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+0.168)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+0.168)x56.9055, direction TLT
 ................\hbox(5.632+0.168)x56.9055, glue set 13.79276fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4191,6 +4310,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4233,6 +4353,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+20.64)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+20.64)x56.9055, direction TLT
 ................\hbox(5.464+1.632)x56.9055, glue set 15.88075fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4288,6 +4409,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4330,6 +4452,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+9.58)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+9.58)x56.9055, direction TLT
 ................\hbox(5.632+0.168)x56.9055, glue set 16.41275fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4369,6 +4492,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4411,6 +4535,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+11.14)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+11.14)x56.9055, direction TLT
 ................\hbox(5.464+1.64)x56.9055, glue set 3.13275fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4452,6 +4577,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4496,6 +4622,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.83+14.05)x76.82234, direction TLT
+.............\begindir TLT
 .............\vbox(6.83+14.05)x76.82234, direction TLT
 ..............\hbox(6.83+2.06)x76.82234, glue set 15.72618fil, direction TLT
 ...............\glue(\leftskip) 0.0 plus 1.0fil
@@ -4542,6 +4669,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 1.0fil
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -4584,6 +4712,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+9.58)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+9.58)x56.9055, direction TLT
 ................\hbox(5.632+1.632)x56.9055, glue set 7.09274fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4627,6 +4756,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4669,6 +4799,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+11.132)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+11.132)x56.9055, direction TLT
 ................\hbox(5.632+1.64)x56.9055, glue set 8.34074fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4719,6 +4850,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4761,6 +4893,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+11.132)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+11.132)x56.9055, direction TLT
 ................\hbox(5.632+1.64)x56.9055, glue set 7.91675fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4807,6 +4940,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4849,6 +4983,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+11.132)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+11.132)x56.9055, direction TLT
 ................\hbox(5.552+1.64)x56.9055, glue set 8.89674fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -4896,6 +5031,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -4940,6 +5076,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(7.05+2.06)x76.82234, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+2.06)x76.82234, direction TLT
 ..............\hbox(7.05+2.06)x76.82234, glue set 0.37617fil, direction TLT
 ...............\glue(\leftskip) 0.0 plus 1.0fil
@@ -4973,6 +5110,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 1.0fil
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5015,6 +5153,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.44+11.14)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.44+11.14)x56.9055, direction TLT
 ................\hbox(5.44+0.08)x56.9055, glue set 17.65276fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -5054,6 +5193,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5096,6 +5236,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+0.168)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+0.168)x56.9055, direction TLT
 ................\hbox(5.552+0.168)x56.9055, glue set 0.30875fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -5128,6 +5269,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5170,6 +5312,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+20.64)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+20.64)x56.9055, direction TLT
 ................\hbox(5.552+0.08)x56.9055, glue set 16.59274fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -5224,6 +5367,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5266,6 +5410,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+11.052)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+11.052)x56.9055, direction TLT
 ................\hbox(5.552+0.08)x56.9055, glue set 14.34875fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -5314,6 +5459,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5356,6 +5502,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.668)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.668)x56.9055, direction TLT
 ................\hbox(5.552+0.08)x56.9055, glue set 15.76476fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -5397,6 +5544,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5439,6 +5587,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.712+1.552)x56.9055, direction TLT
+...............\begindir TLT
 ...............\vbox(5.712+1.552)x56.9055, direction TLT
 ................\hbox(5.712+1.552)x56.9055, glue set 0.48476fil, direction TLT
 .................\glue(\leftskip) 0.0 plus 1.0fil
@@ -5474,6 +5623,7 @@ TEST 3: pgfmanual-en-tutorial-map-3
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 1.0fil
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5556,6 +5706,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.448+16.448)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.448+16.448)x99.58464, direction TLT
 ............\hbox(8.448+2.328)x99.58464, glue set 0.46944, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -5608,6 +5759,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5648,6 +5800,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+11.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+11.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -5697,6 +5850,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5783,6 +5937,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -5820,6 +5975,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -5908,6 +6064,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+11.052)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+11.052)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -5945,6 +6102,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6033,6 +6191,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -6069,6 +6228,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6157,6 +6317,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+9.58)x42.67912, direction TLT
 ................\hbox(5.464+1.632)x42.67912, glue set 0.86922, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -6188,6 +6349,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6279,6 +6441,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+11.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+11.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -6327,6 +6490,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6413,6 +6577,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.408+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.408+9.58)x42.67912, direction TLT
 ................\hbox(5.408+1.64)x42.67912, glue set 0.55922, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -6451,6 +6616,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6539,6 +6705,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+19.08)x42.67912, direction TLT
 ................\hbox(5.552+0.168)x42.67912, glue set 0.26797, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -6588,6 +6755,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6676,6 +6844,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+0.168)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+0.168)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.41747, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -6699,6 +6868,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6787,6 +6957,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+20.64)x42.67912, direction TLT
 ................\hbox(5.464+1.632)x42.67912, glue set 0.54797, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -6842,6 +7013,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -6930,6 +7102,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+9.58)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.58122, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -6969,6 +7142,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -7057,6 +7231,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+11.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+11.14)x42.67912, direction TLT
 ................\hbox(5.464+1.64)x42.67912, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -7100,6 +7275,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -7191,6 +7367,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.147+12.845)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.147+12.845)x56.9055, direction TLT
 ..............\hbox(6.147+1.854)x56.9055, glue set 0.4152, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -7237,6 +7414,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7323,6 +7501,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+19.08)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.69948, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -7371,6 +7550,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -7459,6 +7639,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+20.632)x42.67912, direction TLT
 ................\hbox(5.632+1.64)x42.67912, glue set 0.07672, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -7514,6 +7695,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -7602,6 +7784,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+20.632)x42.67912, direction TLT
 ................\hbox(5.632+1.64)x42.67912, glue set 0.05022, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -7653,6 +7836,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -7741,6 +7925,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+20.632)x42.67912, direction TLT
 ................\hbox(5.552+1.64)x42.67912, glue set 0.11147, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -7793,6 +7978,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -7884,6 +8070,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+11.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+11.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.854)x56.9055, glue set 0.7597, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -7921,6 +8108,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8007,6 +8195,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.44+11.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.44+11.14)x42.67912, direction TLT
 ................\hbox(5.44+0.08)x42.67912, glue set 0.65872, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -8046,6 +8235,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -8134,6 +8324,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+0.168)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+0.168)x42.67912, direction TLT
 ................\hbox(5.552+0.168)x42.67912, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -8168,6 +8359,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -8256,6 +8448,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+20.64)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.59247, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -8310,6 +8503,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -8398,6 +8592,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+19.08)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.45222, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -8451,6 +8646,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -8539,6 +8735,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.668)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.668)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.54073, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -8580,6 +8777,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -8668,6 +8866,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.712+1.552)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.712+1.552)x42.67912, direction TLT
 ................\hbox(5.712+1.552)x42.67912, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -8705,6 +8904,7 @@ TEST 4: pgfmanual-en-tutorial-map-4
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -8835,6 +9035,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.448+16.448)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.448+16.448)x99.58464, direction TLT
 ............\hbox(8.448+2.328)x99.58464, glue set 0.46944, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -8888,6 +9089,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8928,6 +9130,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+22.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+22.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, glue set 0.68146, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -8981,6 +9184,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9067,6 +9271,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -9105,6 +9310,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9193,6 +9399,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+11.052)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+11.052)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -9231,6 +9438,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9319,6 +9527,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -9356,6 +9565,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9444,6 +9654,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+9.58)x42.67912, direction TLT
 ................\hbox(5.464+1.632)x42.67912, glue set 0.86922, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -9476,6 +9687,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9567,6 +9779,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+11.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+11.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, glue set 0.45296, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -9615,6 +9828,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -9701,6 +9915,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.408+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.408+9.58)x42.67912, direction TLT
 ................\hbox(5.408+1.64)x42.67912, glue set 0.55922, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -9740,6 +9955,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9828,6 +10044,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+19.08)x42.67912, direction TLT
 ................\hbox(5.552+0.168)x42.67912, glue set 0.26797, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -9878,6 +10095,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -9966,6 +10184,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+0.168)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+0.168)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.41747, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -9990,6 +10209,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10078,6 +10298,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+20.64)x42.67912, direction TLT
 ................\hbox(5.464+1.632)x42.67912, glue set 0.54797, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -10134,6 +10355,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10222,6 +10444,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+9.58)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.58122, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -10262,6 +10485,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10350,6 +10574,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.464+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+20.64)x42.67912, direction TLT
 ................\hbox(5.464+1.64)x42.67912, glue set 0.23798, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -10397,6 +10622,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10488,6 +10714,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.147+12.845)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.147+12.845)x56.9055, direction TLT
 ..............\hbox(6.147+1.854)x56.9055, glue set 0.4152, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -10535,6 +10762,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -10621,6 +10849,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+19.08)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.69948, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -10670,6 +10899,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10758,6 +10988,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+20.632)x42.67912, direction TLT
 ................\hbox(5.632+1.64)x42.67912, glue set 0.07672, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -10814,6 +11045,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -10902,6 +11134,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.632+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+20.632)x42.67912, direction TLT
 ................\hbox(5.632+1.64)x42.67912, glue set 0.05022, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -10954,6 +11187,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11042,6 +11276,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+20.632)x42.67912, direction TLT
 ................\hbox(5.552+1.64)x42.67912, glue set 0.11147, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -11095,6 +11330,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11186,6 +11422,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.345+11.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+11.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.854)x56.9055, glue set 0.7597, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -11224,6 +11461,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -11310,6 +11548,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.44+11.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.44+11.14)x42.67912, direction TLT
 ................\hbox(5.44+0.08)x42.67912, glue set 0.65872, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -11350,6 +11589,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11438,6 +11678,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.168)x42.67912, glue set 0.26797, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -11476,6 +11717,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11564,6 +11806,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+20.64)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.59247, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -11619,6 +11862,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11707,6 +11951,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+19.08)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.45222, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -11761,6 +12006,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11849,6 +12095,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.552+9.668)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.668)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.54073, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -11891,6 +12138,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -11979,6 +12227,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(5.712+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.712+9.58)x42.67912, direction TLT
 ................\hbox(5.712+1.552)x42.67912, glue set 0.38222, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -12020,6 +12269,7 @@ TEST 5: pgfmanual-en-tutorial-map-5
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -12158,6 +12408,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.448+16.448)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.448+16.448)x99.58464, direction TLT
 ............\hbox(8.448+2.328)x99.58464, glue set 0.46944, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -12213,6 +12464,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -12253,6 +12505,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.345+22.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+22.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, glue set 0.68146, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -12308,6 +12561,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -12402,8 +12656,10 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -12443,6 +12699,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -12483,6 +12740,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -12571,6 +12829,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+11.052)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+11.052)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -12611,6 +12870,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -12699,6 +12959,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.35622, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -12738,6 +12999,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -12826,6 +13088,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.464+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+9.58)x42.67912, direction TLT
 ................\hbox(5.464+1.632)x42.67912, glue set 0.86922, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -12860,6 +13123,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -12950,6 +13214,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.345+11.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+11.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.746)x56.9055, glue set 0.45296, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -13000,6 +13265,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -13094,8 +13360,10 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -13135,6 +13403,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.408+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.408+9.58)x42.67912, direction TLT
 ................\hbox(5.408+1.64)x42.67912, glue set 0.55922, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -13176,6 +13445,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -13264,6 +13534,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+19.08)x42.67912, direction TLT
 ................\hbox(5.552+0.168)x42.67912, glue set 0.26797, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -13316,6 +13587,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -13404,6 +13676,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.632+0.168)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+0.168)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.41747, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -13430,6 +13703,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -13518,6 +13792,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.464+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+20.64)x42.67912, direction TLT
 ................\hbox(5.464+1.632)x42.67912, glue set 0.54797, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -13576,6 +13851,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -13664,6 +13940,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.632+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+9.58)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.58122, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -13706,6 +13983,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -13794,6 +14072,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.464+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.464+20.64)x42.67912, direction TLT
 ................\hbox(5.464+1.64)x42.67912, glue set 0.23798, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -13843,6 +14122,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -13933,6 +14213,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.147+12.845)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.147+12.845)x56.9055, direction TLT
 ..............\hbox(6.147+1.854)x56.9055, glue set 0.4152, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -13982,6 +14263,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14076,8 +14358,10 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -14117,6 +14401,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.632+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+19.08)x42.67912, direction TLT
 ................\hbox(5.632+0.168)x42.67912, glue set 0.69948, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -14168,6 +14453,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -14256,6 +14542,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.632+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+20.632)x42.67912, direction TLT
 ................\hbox(5.632+1.64)x42.67912, glue set 0.07672, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -14314,6 +14601,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -14402,6 +14690,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.632+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.632+20.632)x42.67912, direction TLT
 ................\hbox(5.632+1.64)x42.67912, glue set 0.05022, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -14456,6 +14745,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -14544,6 +14834,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+20.632)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+20.632)x42.67912, direction TLT
 ................\hbox(5.552+1.64)x42.67912, glue set 0.11147, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -14599,6 +14890,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -14689,6 +14981,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.345+11.099)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.345+11.099)x56.9055, direction TLT
 ..............\hbox(6.345+1.854)x56.9055, glue set 0.7597, direction TLT
 ...............\glue(\leftskip) 0.0 plus 18.0
@@ -14729,6 +15022,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 18.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -14823,8 +15117,10 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -14864,6 +15160,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.44+11.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.44+11.14)x42.67912, direction TLT
 ................\hbox(5.44+0.08)x42.67912, glue set 0.65872, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -14906,6 +15203,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -14994,6 +15292,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.58)x42.67912, direction TLT
 ................\hbox(5.552+0.168)x42.67912, glue set 0.26797, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -15034,6 +15333,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -15122,6 +15422,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+20.64)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+20.64)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.59247, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -15179,6 +15480,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -15267,6 +15569,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+19.08)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+19.08)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.45222, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -15323,6 +15626,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -15411,6 +15715,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.552+9.668)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.552+9.668)x42.67912, direction TLT
 ................\hbox(5.552+0.08)x42.67912, glue set 0.54073, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -15455,6 +15760,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -15543,6 +15849,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(5.712+9.58)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(5.712+9.58)x42.67912, direction TLT
 ................\hbox(5.712+1.552)x42.67912, glue set 0.38222, direction TLT
 .................\glue(\leftskip) 0.0 plus 16.0
@@ -15586,6 +15893,7 @@ TEST 6: pgfmanual-en-tutorial-map-6
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 16.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -15736,6 +16044,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.46+14.264)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.46+14.264)x99.58464, direction TLT
 ............\hbox(8.46+0.264)x99.58464, glue set 0.15518, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -15792,6 +16101,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -15851,6 +16161,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+24.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+24.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.49313, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -15909,6 +16220,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16004,8 +16316,10 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -16064,6 +16378,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -16104,6 +16419,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -16211,6 +16527,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+9.358)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+9.358)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -16251,6 +16568,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -16358,6 +16676,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -16397,6 +16716,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -16491,8 +16811,10 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -16552,6 +16874,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+1.428)x42.67912, glue set 0.24568, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -16587,6 +16910,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -16696,6 +17020,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+24.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+24.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.49313, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -16751,6 +17076,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -16847,8 +17173,10 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -16907,6 +17235,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.732+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.732+8.07)x42.67912, direction TLT
 ................\hbox(4.732+1.435)x42.67912, glue set 0.69325, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -16948,6 +17277,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17055,6 +17385,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+16.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+16.07)x42.67912, direction TLT
 ................\hbox(4.858+0.14)x42.67912, glue set 0.386, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -17107,6 +17438,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17201,8 +17533,10 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -17262,6 +17596,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+0.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+0.14)x42.67912, direction TLT
 ................\hbox(4.921+0.14)x42.67912, glue set 0.53775, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -17288,6 +17623,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17395,6 +17731,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.781+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.781+17.435)x42.67912, direction TLT
 ................\hbox(4.781+1.428)x42.67912, glue set 0.68225, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -17453,6 +17790,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17547,8 +17885,10 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -17608,6 +17948,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+8.07)x42.67912, direction TLT
 ................\hbox(4.921+0.14)x42.67912, glue set 0.7165, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -17650,6 +17991,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17757,6 +18099,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.781+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.781+17.435)x42.67912, direction TLT
 ................\hbox(4.781+1.435)x42.67912, glue set 0.3515, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -17806,6 +18149,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -17915,6 +18259,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.83+24.0)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.83+24.0)x56.9055, direction TLT
 ..............\hbox(6.83+0.14)x56.9055, glue set 0.0754, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -17968,6 +18313,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18063,8 +18409,10 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -18123,6 +18471,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+8.07)x42.67912, direction TLT
 ................\hbox(4.921+1.428)x42.67912, glue set 0.09326, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -18169,6 +18518,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18276,6 +18626,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.928+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.928+9.428)x42.67912, direction TLT
 ................\hbox(4.928+1.435)x42.67912, glue set 0.17076, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -18329,6 +18680,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18436,6 +18788,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+9.428)x42.67912, direction TLT
 ................\hbox(4.921+1.435)x42.67912, glue set 0.151, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -18485,6 +18838,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18592,6 +18946,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+9.428)x42.67912, direction TLT
 ................\hbox(4.858+1.435)x42.67912, glue set 0.21126, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -18642,6 +18997,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -18736,8 +19092,10 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -18799,6 +19157,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+12.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+12.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.46263, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -18841,6 +19200,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -18935,8 +19295,10 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -18995,6 +19357,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.753+9.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.753+9.435)x42.67912, direction TLT
 ................\hbox(4.753+0.07)x42.67912, glue set 0.8015, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -19037,6 +19400,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -19144,6 +19508,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.14)x42.67912, glue set 0.386, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -19184,6 +19549,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -19291,6 +19657,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+17.435)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.72826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -19348,6 +19715,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -19455,6 +19823,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+16.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+16.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.57475, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -19511,6 +19880,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -19618,6 +19988,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.14)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.671, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -19662,6 +20033,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -19769,6 +20141,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.991+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.991+8.07)x42.67912, direction TLT
 ................\hbox(4.991+1.358)x42.67912, glue set 0.50575, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -19812,6 +20185,7 @@ TEST 7: pgfmanual-en-tutorial-map-7
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -19973,6 +20347,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.46+14.264)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.46+14.264)x99.58464, direction TLT
 ............\hbox(8.46+0.264)x99.58464, glue set 0.15518, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -20029,6 +20404,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -20089,6 +20465,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+24.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+24.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.49313, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -20147,6 +20524,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -20242,8 +20620,10 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -20303,6 +20683,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -20343,6 +20724,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -20451,6 +20833,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+9.358)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+9.358)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -20491,6 +20874,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -20599,6 +20983,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -20638,6 +21023,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -20732,8 +21118,10 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -20794,6 +21182,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+1.428)x42.67912, glue set 0.24568, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -20829,6 +21218,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -20939,6 +21329,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+24.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+24.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.49313, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -20994,6 +21385,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -21090,8 +21482,10 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -21151,6 +21545,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.732+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.732+8.07)x42.67912, direction TLT
 ................\hbox(4.732+1.435)x42.67912, glue set 0.69325, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -21192,6 +21587,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -21300,6 +21696,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+16.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+16.07)x42.67912, direction TLT
 ................\hbox(4.858+0.14)x42.67912, glue set 0.386, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -21352,6 +21749,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -21446,8 +21844,10 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -21508,6 +21908,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+0.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+0.14)x42.67912, direction TLT
 ................\hbox(4.921+0.14)x42.67912, glue set 0.53775, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -21534,6 +21935,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -21642,6 +22044,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.781+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.781+17.435)x42.67912, direction TLT
 ................\hbox(4.781+1.428)x42.67912, glue set 0.68225, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -21700,6 +22103,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -21794,8 +22198,10 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -21856,6 +22262,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+8.07)x42.67912, direction TLT
 ................\hbox(4.921+0.14)x42.67912, glue set 0.7165, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -21898,6 +22305,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -22006,6 +22414,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.781+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.781+17.435)x42.67912, direction TLT
 ................\hbox(4.781+1.435)x42.67912, glue set 0.3515, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -22055,6 +22464,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -22165,6 +22575,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.83+24.0)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.83+24.0)x56.9055, direction TLT
 ..............\hbox(6.83+0.14)x56.9055, glue set 0.0754, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -22218,6 +22629,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -22313,8 +22725,10 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -22374,6 +22788,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+8.07)x42.67912, direction TLT
 ................\hbox(4.921+1.428)x42.67912, glue set 0.09326, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -22420,6 +22835,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -22528,6 +22944,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.928+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.928+9.428)x42.67912, direction TLT
 ................\hbox(4.928+1.435)x42.67912, glue set 0.17076, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -22581,6 +22998,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -22689,6 +23107,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+9.428)x42.67912, direction TLT
 ................\hbox(4.921+1.435)x42.67912, glue set 0.151, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -22738,6 +23157,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -22846,6 +23266,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+9.428)x42.67912, direction TLT
 ................\hbox(4.858+1.435)x42.67912, glue set 0.21126, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -22896,6 +23317,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -22990,8 +23412,10 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -23054,6 +23478,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+12.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+12.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.46263, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -23096,6 +23521,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -23190,8 +23616,10 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -23251,6 +23679,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.753+9.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.753+9.435)x42.67912, direction TLT
 ................\hbox(4.753+0.07)x42.67912, glue set 0.8015, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -23293,6 +23722,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -23401,6 +23831,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.14)x42.67912, glue set 0.386, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -23441,6 +23872,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -23549,6 +23981,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+17.435)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.72826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -23606,6 +24039,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -23714,6 +24148,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+16.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+16.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.57475, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -23770,6 +24205,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -23878,6 +24314,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.14)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.671, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -23922,6 +24359,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -24030,6 +24468,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.991+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.991+8.07)x42.67912, direction TLT
 ................\hbox(4.991+1.358)x42.67912, glue set 0.50575, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -24073,6 +24512,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -24171,6 +24611,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.525+66.97)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(3.525+66.97)x99.58464, direction TLT
 ............\hbox(3.525+0.97)x99.58464, glue set 21.57298fil, direction TLT
 .............\localpar
@@ -24444,6 +24885,7 @@ TEST 8: pgfmanual-en-tutorial-map-9
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 1.0fil
 ............\penalty -51
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24556,6 +24998,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.46+14.264)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.46+14.264)x99.58464, direction TLT
 ............\hbox(8.46+0.264)x99.58464, glue set 0.15518, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -24612,6 +25055,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -24672,6 +25116,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+24.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+24.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.49313, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -24730,6 +25175,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -24825,8 +25271,10 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -24886,6 +25334,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -24926,6 +25375,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -25034,6 +25484,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+9.358)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+9.358)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -25074,6 +25525,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -25182,6 +25634,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.47826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -25221,6 +25674,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -25315,8 +25769,10 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -25377,6 +25833,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+1.428)x42.67912, glue set 0.24568, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -25412,6 +25869,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -25522,6 +25980,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+24.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+24.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.49313, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -25577,6 +26036,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -25673,8 +26133,10 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -25734,6 +26196,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.732+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.732+8.07)x42.67912, direction TLT
 ................\hbox(4.732+1.435)x42.67912, glue set 0.69325, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -25775,6 +26238,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -25883,6 +26347,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+16.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+16.07)x42.67912, direction TLT
 ................\hbox(4.858+0.14)x42.67912, glue set 0.386, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -25935,6 +26400,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -26029,8 +26495,10 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -26091,6 +26559,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+0.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+0.14)x42.67912, direction TLT
 ................\hbox(4.921+0.14)x42.67912, glue set 0.53775, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -26117,6 +26586,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -26225,6 +26695,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.781+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.781+17.435)x42.67912, direction TLT
 ................\hbox(4.781+1.428)x42.67912, glue set 0.68225, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -26283,6 +26754,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -26377,8 +26849,10 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -26439,6 +26913,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+8.07)x42.67912, direction TLT
 ................\hbox(4.921+0.14)x42.67912, glue set 0.7165, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -26481,6 +26956,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -26589,6 +27065,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.781+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.781+17.435)x42.67912, direction TLT
 ................\hbox(4.781+1.435)x42.67912, glue set 0.3515, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -26638,6 +27115,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -26748,6 +27226,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(6.83+24.0)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(6.83+24.0)x56.9055, direction TLT
 ..............\hbox(6.83+0.14)x56.9055, glue set 0.0754, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -26801,6 +27280,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -26896,8 +27376,10 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -26957,6 +27439,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+8.07)x42.67912, direction TLT
 ................\hbox(4.921+1.428)x42.67912, glue set 0.09326, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -27003,6 +27486,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -27111,6 +27595,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.928+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.928+9.428)x42.67912, direction TLT
 ................\hbox(4.928+1.435)x42.67912, glue set 0.17076, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -27164,6 +27649,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -27272,6 +27758,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.921+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.921+9.428)x42.67912, direction TLT
 ................\hbox(4.921+1.435)x42.67912, glue set 0.151, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -27321,6 +27808,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -27429,6 +27917,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+9.428)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+9.428)x42.67912, direction TLT
 ................\hbox(4.858+1.435)x42.67912, glue set 0.21126, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -27479,6 +27968,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -27573,8 +28063,10 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..........\glue -50.1875
 ..........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 ...........\hbox(100.375+0.0)x100.375, direction TLT
+............\begindir TLT
 ............\hbox(100.375+0.0)x100.375, direction TLT
 .............\box(100.375+0.0)x100.375
+............\enddir TLT
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
 ........\glue(\spaceskip) 0.0
@@ -27637,6 +28129,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(7.05+12.14)x56.9055, direction TLT
+.............\begindir TLT
 .............\vbox(7.05+12.14)x56.9055, direction TLT
 ..............\hbox(7.05+0.22)x56.9055, glue set 0.46263, direction TLT
 ...............\glue(\leftskip) 0.0 plus 20.0
@@ -27679,6 +28172,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0
 ...............\glue(\rightskip) 0.0 plus 20.0
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -27773,8 +28267,10 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ........\glue -50.1875
 ........\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .........\hbox(100.375+0.0)x100.375, direction TLT
+..........\begindir TLT
 ..........\hbox(100.375+0.0)x100.375, direction TLT
 ...........\box(100.375+0.0)x100.375
+..........\enddir TLT
 ......\pdfliteral origin{Q }
 ......\glue(\spaceskip) 0.0
 ......\glue(\spaceskip) 0.0
@@ -27834,6 +28330,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.753+9.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.753+9.435)x42.67912, direction TLT
 ................\hbox(4.753+0.07)x42.67912, glue set 0.8015, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -27876,6 +28373,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -27984,6 +28482,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.07)x42.67912, direction TLT
 ................\hbox(4.858+0.14)x42.67912, glue set 0.386, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -28024,6 +28523,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -28132,6 +28632,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+17.435)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+17.435)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.72826, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -28189,6 +28690,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -28297,6 +28799,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+16.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+16.07)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.57475, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -28353,6 +28856,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -28461,6 +28965,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.858+8.14)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.858+8.14)x42.67912, direction TLT
 ................\hbox(4.858+0.07)x42.67912, glue set 0.671, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -28505,6 +29010,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -28613,6 +29119,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..............\pdfliteral origin{1 G }
 ..............\pdfliteral origin{1 g }
 ..............\hbox(4.991+8.07)x42.67912, direction TLT
+...............\begindir TLT
 ...............\vbox(4.991+8.07)x42.67912, direction TLT
 ................\hbox(4.991+1.358)x42.67912, glue set 0.50575, direction TLT
 .................\glue(\leftskip) 0.0 plus 14.0
@@ -28656,6 +29163,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .................\penalty 10000
 .................\glue(\parfillskip) 0.0
 .................\glue(\rightskip) 0.0 plus 14.0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -28752,6 +29260,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.515+27.03)x113.81102, direction TLT
+...........\begindir TLT
 ...........\vbox(3.515+27.03)x113.81102, direction TLT
 ............\hbox(3.515+0.97)x113.81102, glue set 30.90436fil, direction TLT
 .............\localpar
@@ -29011,6 +29520,7 @@ TEST 9: pgfmanual-en-tutorial-map-11
 .............\glue(\parfillskip) 0.0 plus 1.0fil
 .............\glue(\rightskip) 0.0 plus 1.0fil
 ............\penalty -51
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29138,8 +29648,10 @@ TEST 10: pgfmanual-en-tutorial-map-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -29163,8 +29675,10 @@ TEST 10: pgfmanual-en-tutorial-map-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -29188,8 +29702,10 @@ TEST 10: pgfmanual-en-tutorial-map-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -29213,8 +29729,10 @@ TEST 10: pgfmanual-en-tutorial-map-12
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -29288,6 +29806,7 @@ TEST 10: pgfmanual-en-tutorial-map-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.46+14.264)x99.58464, direction TLT
+...........\begindir TLT
 ...........\vbox(8.46+14.264)x99.58464, direction TLT
 ............\hbox(8.46+0.264)x99.58464, glue set 0.15518, direction TLT
 .............\glue(\leftskip) 0.0 plus 24.0
@@ -29343,6 +29862,7 @@ TEST 10: pgfmanual-en-tutorial-map-12
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 24.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29401,7 +29921,9 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29430,7 +29952,9 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29459,7 +29983,9 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29488,9 +30014,11 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.385+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29519,9 +30047,11 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29550,7 +30080,9 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29579,7 +30111,9 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.38+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29608,7 +30142,9 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29637,7 +30173,9 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29666,8 +30204,10 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29696,10 +30236,12 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29728,10 +30270,12 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29760,8 +30304,10 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29790,8 +30336,10 @@ TEST 11: pgfmanual-en-tutorial-map-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.385+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29852,7 +30400,9 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29881,7 +30431,9 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29910,7 +30462,9 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29939,9 +30493,11 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.385+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -29970,9 +30526,11 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30001,7 +30559,9 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30030,7 +30590,9 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.38+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30059,7 +30621,9 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30088,7 +30652,9 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30117,8 +30683,10 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30147,10 +30715,12 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30179,10 +30749,12 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30211,8 +30783,10 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30241,8 +30815,10 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.385+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30272,6 +30848,7 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.515+0.97)x83.13002, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\TU/lmr/bx/n/5 C
 ...........\TU/lmr/bx/n/5 o
@@ -30305,6 +30882,7 @@ TEST 12: pgfmanual-en-tutorial-map-15
 ...........\TU/lmr/bx/n/5 s
 ...........\kern0.0 (italic)
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30364,6 +30942,7 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.444+1.746)x42.43504, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 A
 ...........\TU/lmr/m/n/9 p
 ...........\TU/lmr/m/n/9 r
@@ -30374,6 +30953,7 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ...........\TU/lmr/m/n/9 0
 ...........\TU/lmr/m/n/9 0
 ...........\TU/lmr/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30399,7 +30979,9 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30428,7 +31010,9 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30457,7 +31041,9 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30486,9 +31072,11 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.385+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 4
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30517,9 +31105,11 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30548,7 +31138,9 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30577,7 +31169,9 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.38+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30606,7 +31200,9 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30635,7 +31231,9 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30664,8 +31262,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30694,10 +31294,12 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 1
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30726,10 +31328,12 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 2
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30758,8 +31362,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30788,8 +31394,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.385+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30818,8 +31426,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30848,8 +31458,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 6
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30878,8 +31490,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.38+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30908,10 +31522,12 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 8
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30940,10 +31556,12 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 1
 ...........\TU/lmr/m/n/5 9
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -30972,8 +31590,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31002,8 +31622,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31032,8 +31654,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31062,8 +31686,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31092,8 +31718,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.385+0.0)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31122,10 +31750,12 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 5
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31154,10 +31784,12 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0.75 G }
 ..........\pdfliteral origin{0.75 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0.75 g 0.75 G}
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 6
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31186,8 +31818,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.38+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 7
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31216,8 +31850,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 8
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31246,8 +31882,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 2
 ...........\TU/lmr/m/n/5 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31276,8 +31914,10 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.11)x6.81, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 3
 ...........\TU/lmr/m/n/5 0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31308,6 +31948,7 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.147+1.845)x39.31204, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/9 M
 ...........\TU/lmr/m/n/9 a
 ...........\kern-0.261 (font)
@@ -31317,6 +31958,7 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ...........\TU/lmr/m/n/9 0
 ...........\TU/lmr/m/n/9 0
 ...........\TU/lmr/m/n/9 9
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31342,7 +31984,9 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.33+0.0)x3.405, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/5 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31372,6 +32016,7 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.515+0.97)x83.13002, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\TU/lmr/bx/n/5 C
 ...........\TU/lmr/bx/n/5 o
@@ -31405,6 +32050,7 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ...........\TU/lmr/bx/n/5 s
 ...........\kern0.0 (italic)
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -31432,6 +32078,7 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(3.515+0.97)x75.895, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\TU/lmr/bx/n/5 C
 ...........\TU/lmr/bx/n/5 o
@@ -31464,6 +32111,7 @@ TEST 13: pgfmanual-en-tutorial-map-16
 ...........\TU/lmr/bx/n/5 s
 ...........\kern0.0 (italic)
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tutorial-nodes.tlg
+++ b/testfiles-examples/pgfmanual-en-tutorial-nodes.tlg
@@ -40,6 +40,8 @@ TEST 1: pgfmanual-en-tutorial-nodes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -69,6 +71,8 @@ TEST 1: pgfmanual-en-tutorial-nodes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -98,6 +102,8 @@ TEST 1: pgfmanual-en-tutorial-nodes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -125,6 +131,8 @@ TEST 1: pgfmanual-en-tutorial-nodes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -152,6 +160,8 @@ TEST 1: pgfmanual-en-tutorial-nodes-4
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -212,6 +222,8 @@ TEST 2: pgfmanual-en-tutorial-nodes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -241,6 +253,8 @@ TEST 2: pgfmanual-en-tutorial-nodes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -270,6 +284,8 @@ TEST 2: pgfmanual-en-tutorial-nodes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -297,6 +313,8 @@ TEST 2: pgfmanual-en-tutorial-nodes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -324,6 +342,8 @@ TEST 2: pgfmanual-en-tutorial-nodes-5
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -384,6 +404,8 @@ TEST 3: pgfmanual-en-tutorial-nodes-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -415,6 +437,8 @@ TEST 3: pgfmanual-en-tutorial-nodes-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -446,6 +470,8 @@ TEST 3: pgfmanual-en-tutorial-nodes-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -475,6 +501,8 @@ TEST 3: pgfmanual-en-tutorial-nodes-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -504,6 +532,8 @@ TEST 3: pgfmanual-en-tutorial-nodes-6
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -572,6 +602,8 @@ TEST 4: pgfmanual-en-tutorial-nodes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -609,6 +641,8 @@ TEST 4: pgfmanual-en-tutorial-nodes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -646,6 +680,8 @@ TEST 4: pgfmanual-en-tutorial-nodes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -681,6 +717,8 @@ TEST 4: pgfmanual-en-tutorial-nodes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -716,6 +754,8 @@ TEST 4: pgfmanual-en-tutorial-nodes-7
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -785,6 +825,8 @@ TEST 5: pgfmanual-en-tutorial-nodes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -824,6 +866,8 @@ TEST 5: pgfmanual-en-tutorial-nodes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -863,6 +907,8 @@ TEST 5: pgfmanual-en-tutorial-nodes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -900,6 +946,8 @@ TEST 5: pgfmanual-en-tutorial-nodes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -937,6 +985,8 @@ TEST 5: pgfmanual-en-tutorial-nodes-8
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1006,6 +1056,8 @@ TEST 6: pgfmanual-en-tutorial-nodes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1045,6 +1097,8 @@ TEST 6: pgfmanual-en-tutorial-nodes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1084,6 +1138,8 @@ TEST 6: pgfmanual-en-tutorial-nodes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1121,6 +1177,8 @@ TEST 6: pgfmanual-en-tutorial-nodes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1158,6 +1216,8 @@ TEST 6: pgfmanual-en-tutorial-nodes-9
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1227,6 +1287,8 @@ TEST 7: pgfmanual-en-tutorial-nodes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1266,6 +1328,8 @@ TEST 7: pgfmanual-en-tutorial-nodes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1305,6 +1369,8 @@ TEST 7: pgfmanual-en-tutorial-nodes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1342,6 +1408,8 @@ TEST 7: pgfmanual-en-tutorial-nodes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1379,6 +1447,8 @@ TEST 7: pgfmanual-en-tutorial-nodes-10
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1447,6 +1517,8 @@ TEST 8: pgfmanual-en-tutorial-nodes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1486,6 +1558,8 @@ TEST 8: pgfmanual-en-tutorial-nodes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1525,6 +1599,8 @@ TEST 8: pgfmanual-en-tutorial-nodes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1562,6 +1638,8 @@ TEST 8: pgfmanual-en-tutorial-nodes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1599,6 +1677,8 @@ TEST 8: pgfmanual-en-tutorial-nodes-12
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1667,6 +1747,8 @@ TEST 9: pgfmanual-en-tutorial-nodes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1706,6 +1788,8 @@ TEST 9: pgfmanual-en-tutorial-nodes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1745,6 +1829,8 @@ TEST 9: pgfmanual-en-tutorial-nodes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1782,6 +1868,8 @@ TEST 9: pgfmanual-en-tutorial-nodes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1819,6 +1907,8 @@ TEST 9: pgfmanual-en-tutorial-nodes-13
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1887,6 +1977,8 @@ TEST 10: pgfmanual-en-tutorial-nodes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1926,6 +2018,8 @@ TEST 10: pgfmanual-en-tutorial-nodes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -1965,6 +2059,8 @@ TEST 10: pgfmanual-en-tutorial-nodes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2002,6 +2098,8 @@ TEST 10: pgfmanual-en-tutorial-nodes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2037,6 +2135,8 @@ TEST 10: pgfmanual-en-tutorial-nodes-14
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2107,6 +2207,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2146,6 +2248,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2185,6 +2289,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2222,6 +2328,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2257,6 +2365,8 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2289,6 +2399,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.44444+1.35971)x23.02074, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 s
@@ -2298,6 +2409,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2367,6 +2479,8 @@ TEST 12: pgfmanual-en-tutorial-nodes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2406,6 +2520,8 @@ TEST 12: pgfmanual-en-tutorial-nodes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2447,6 +2563,8 @@ TEST 12: pgfmanual-en-tutorial-nodes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2472,6 +2590,7 @@ TEST 12: pgfmanual-en-tutorial-nodes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+1.35971)x23.02074, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OML/cmm/m/it/10 s
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
@@ -2479,6 +2598,7 @@ TEST 12: pgfmanual-en-tutorial-nodes-16
 ...........\glue(\thickmuskip) 2.77771 plus 2.77771
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2516,6 +2636,8 @@ TEST 12: pgfmanual-en-tutorial-nodes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2551,6 +2673,8 @@ TEST 12: pgfmanual-en-tutorial-nodes-16
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2615,6 +2739,7 @@ TEST 13: pgfmanual-en-tutorial-nodes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x39.46, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
@@ -2627,6 +2752,7 @@ TEST 13: pgfmanual-en-tutorial-nodes-17
 ...........\TU/lmr/m/n/10 c
 ...........\TU/lmr/m/n/10 l
 ...........\TU/lmr/m/n/10 e
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2650,12 +2776,14 @@ TEST 13: pgfmanual-en-tutorial-nodes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x14.59726, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 6
 ...........\OT1/cmr/m/n/10 0
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2681,6 +2809,7 @@ TEST 13: pgfmanual-en-tutorial-nodes-17
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.83333)x22.37506, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 9
@@ -2688,6 +2817,7 @@ TEST 13: pgfmanual-en-tutorial-nodes-17
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2757,6 +2887,8 @@ TEST 14: pgfmanual-en-tutorial-nodes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2796,6 +2928,8 @@ TEST 14: pgfmanual-en-tutorial-nodes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2837,6 +2971,8 @@ TEST 14: pgfmanual-en-tutorial-nodes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2867,6 +3003,7 @@ TEST 14: pgfmanual-en-tutorial-nodes-18
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.44444+1.35971)x23.02074, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 s
@@ -2876,6 +3013,7 @@ TEST 14: pgfmanual-en-tutorial-nodes-18
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2914,6 +3052,8 @@ TEST 14: pgfmanual-en-tutorial-nodes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -2949,6 +3089,8 @@ TEST 14: pgfmanual-en-tutorial-nodes-18
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3017,6 +3159,8 @@ TEST 15: pgfmanual-en-tutorial-nodes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3056,6 +3200,8 @@ TEST 15: pgfmanual-en-tutorial-nodes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3095,6 +3241,8 @@ TEST 15: pgfmanual-en-tutorial-nodes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3132,6 +3280,8 @@ TEST 15: pgfmanual-en-tutorial-nodes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3167,6 +3317,8 @@ TEST 15: pgfmanual-en-tutorial-nodes-19
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3251,6 +3403,8 @@ TEST 16: pgfmanual-en-tutorial-nodes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3290,6 +3444,8 @@ TEST 16: pgfmanual-en-tutorial-nodes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3329,6 +3485,8 @@ TEST 16: pgfmanual-en-tutorial-nodes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3366,6 +3524,8 @@ TEST 16: pgfmanual-en-tutorial-nodes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3401,6 +3561,8 @@ TEST 16: pgfmanual-en-tutorial-nodes-20
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3487,6 +3649,8 @@ TEST 17: pgfmanual-en-tutorial-nodes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3526,6 +3690,8 @@ TEST 17: pgfmanual-en-tutorial-nodes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3565,6 +3731,8 @@ TEST 17: pgfmanual-en-tutorial-nodes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3602,6 +3770,8 @@ TEST 17: pgfmanual-en-tutorial-nodes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3637,6 +3807,8 @@ TEST 17: pgfmanual-en-tutorial-nodes-21
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3726,6 +3898,8 @@ TEST 18: pgfmanual-en-tutorial-nodes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3765,6 +3939,8 @@ TEST 18: pgfmanual-en-tutorial-nodes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3804,6 +3980,8 @@ TEST 18: pgfmanual-en-tutorial-nodes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3841,6 +4019,8 @@ TEST 18: pgfmanual-en-tutorial-nodes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3876,6 +4056,8 @@ TEST 18: pgfmanual-en-tutorial-nodes-22
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3968,6 +4150,8 @@ TEST 19: pgfmanual-en-tutorial-nodes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4007,6 +4191,8 @@ TEST 19: pgfmanual-en-tutorial-nodes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4046,6 +4232,8 @@ TEST 19: pgfmanual-en-tutorial-nodes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4083,6 +4271,8 @@ TEST 19: pgfmanual-en-tutorial-nodes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4118,6 +4308,8 @@ TEST 19: pgfmanual-en-tutorial-nodes-23
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4230,6 +4422,8 @@ TEST 20: pgfmanual-en-tutorial-nodes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4269,6 +4463,8 @@ TEST 20: pgfmanual-en-tutorial-nodes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4308,6 +4504,8 @@ TEST 20: pgfmanual-en-tutorial-nodes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4345,6 +4543,8 @@ TEST 20: pgfmanual-en-tutorial-nodes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4380,6 +4580,8 @@ TEST 20: pgfmanual-en-tutorial-nodes-24
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4501,6 +4703,8 @@ TEST 21: pgfmanual-en-tutorial-nodes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4540,6 +4744,8 @@ TEST 21: pgfmanual-en-tutorial-nodes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4579,6 +4785,8 @@ TEST 21: pgfmanual-en-tutorial-nodes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4616,6 +4824,8 @@ TEST 21: pgfmanual-en-tutorial-nodes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4727,6 +4937,8 @@ TEST 21: pgfmanual-en-tutorial-nodes-25
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4847,11 +5059,13 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x9.59724, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 0
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4879,6 +5093,7 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x19.59727, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\OT1/cmr/m/n/10 2
@@ -4886,6 +5101,7 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4913,6 +5129,7 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.88586+0.0)x19.59727, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 2
 ...........\OT1/cmr/m/n/10 4
@@ -4920,6 +5137,7 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ...........\hbox(3.25694+0.0)x4.59723, shifted -3.62892, direction TLT
 ............\OMS/cmsy/m/n/7 ^^N
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4979,7 +5197,9 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5003,8 +5223,10 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x7.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ’
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5030,7 +5252,9 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.0)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5054,8 +5278,10 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.0)x7.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ’
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5081,7 +5307,9 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+0.22)x5.0, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5107,8 +5335,10 @@ TEST 22: pgfmanual-en-tutorial-nodes-26
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+0.22)x7.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ’
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5179,6 +5409,8 @@ TEST 23: pgfmanual-en-tutorial-nodes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5218,6 +5450,8 @@ TEST 23: pgfmanual-en-tutorial-nodes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5257,6 +5491,8 @@ TEST 23: pgfmanual-en-tutorial-nodes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5294,6 +5530,8 @@ TEST 23: pgfmanual-en-tutorial-nodes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5355,7 +5593,9 @@ TEST 23: pgfmanual-en-tutorial-nodes-27
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -5415,6 +5655,8 @@ TEST 23: pgfmanual-en-tutorial-nodes-27
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5933,6 +6175,7 @@ TEST 26: pgfmanual-en-tutorial-nodes-30
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(31.05+2.05)x63.91, direction TLT
+...........\begindir TLT
 ...........\vbox(31.05+2.05)x63.91, direction TLT
 ............\hbox(19.05+2.05)x63.91, direction TLT
 .............\glue(\tabskip) 0.0
@@ -6020,6 +6263,7 @@ TEST 26: pgfmanual-en-tutorial-nodes-30
 ..............\pdfcolorstack 0 pop
 ..............\glue 0.0 plus 1.0fil
 .............\glue(\tabskip) 0.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6217,6 +6461,7 @@ TEST 27: pgfmanual-en-tutorial-nodes-31
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(7.05+26.05)x85.35826, direction TLT
+...........\begindir TLT
 ...........\vbox(7.05+26.05)x85.35826, direction TLT
 ............\hbox(7.05+1.94)x85.35826, glue set 0.53613, direction TLT
 .............\glue(\leftskip) 0.0 plus 20.0
@@ -6296,6 +6541,7 @@ TEST 27: pgfmanual-en-tutorial-nodes-31
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6367,6 +6613,7 @@ TEST 28: pgfmanual-en-tutorial-nodes-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(55.26016+55.26016)x99.13922, direction TLT
+...........\begindir TLT
 ...........\vbox(0.0+0.0)x99.13922, direction TLT
 ............\hbox(0.0+0.0)x99.13922, glue set 49.56961fil, direction TLT
 .............\glue(\leftskip) 0.0 plus 1.0fil
@@ -6380,6 +6627,7 @@ TEST 28: pgfmanual-en-tutorial-nodes-32
 .............\penalty 10000
 .............\glue(\parfillskip) 0.0
 .............\glue(\rightskip) 0.0 plus 1.0fil
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6424,6 +6672,8 @@ TEST 28: pgfmanual-en-tutorial-nodes-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6463,6 +6713,8 @@ TEST 28: pgfmanual-en-tutorial-nodes-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6502,6 +6754,8 @@ TEST 28: pgfmanual-en-tutorial-nodes-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6539,6 +6793,8 @@ TEST 28: pgfmanual-en-tutorial-nodes-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6600,7 +6856,9 @@ TEST 28: pgfmanual-en-tutorial-nodes-32
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6660,6 +6918,8 @@ TEST 28: pgfmanual-en-tutorial-nodes-32
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6794,6 +7054,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6833,8 +7095,10 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -6879,6 +7143,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6920,6 +7186,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6950,6 +7218,7 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.44444+1.35971)x23.02074, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 s
@@ -6959,6 +7228,7 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ...........\OT1/cmr/m/n/10 3
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6999,6 +7269,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7038,6 +7310,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7077,8 +7351,10 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7121,6 +7397,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7225,6 +7503,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7314,6 +7594,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7388,7 +7670,9 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7428,6 +7712,8 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7504,7 +7790,9 @@ TEST 29: pgfmanual-en-tutorial-nodes-34
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7577,6 +7865,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7616,8 +7906,10 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7662,6 +7954,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7706,6 +8000,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7734,11 +8030,13 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(4.30554+0.0)x4.6875, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\OML/cmm/m/it/10 s
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7784,6 +8082,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7823,8 +8123,10 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7869,8 +8171,10 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7915,8 +8219,10 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -7952,6 +8258,7 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(5.67776+0.0)x4.6875, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\vbox(5.67776+0.0)x4.6875, direction TLT
@@ -7962,6 +8269,7 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 .............\OML/cmm/m/it/10 s
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8001,6 +8309,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8040,6 +8350,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8079,8 +8391,10 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ............\pdfliteral origin{1 G }
 ............\pdfliteral origin{1 g }
 ............\hbox(0.0+0.0)x0.0, direction TLT
+.............\begindir TLT
 .............\pdfcolorstack 0 push {1 g 1 G}
 .............\pdfcolorstack 0 pop
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8123,6 +8437,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8220,6 +8536,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8319,6 +8637,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8403,7 +8723,9 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0
@@ -8443,6 +8765,8 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -8527,7 +8851,9 @@ TEST 30: pgfmanual-en-tutorial-nodes-35
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(6.66+0.0)x5.0, direction TLT
+.............\begindir TLT
 .............\TU/lmr/m/n/10 2
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-examples/pgfmanual-en-tutorial.tlg
+++ b/testfiles-examples/pgfmanual-en-tutorial.tlg
@@ -1595,8 +1595,10 @@ TEST 23: pgfmanual-en-tutorial-31
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1655,8 +1657,10 @@ TEST 24: pgfmanual-en-tutorial-32
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1686,8 +1690,10 @@ TEST 24: pgfmanual-en-tutorial-32
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1719,8 +1725,10 @@ TEST 24: pgfmanual-en-tutorial-32
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1759,8 +1767,10 @@ TEST 24: pgfmanual-en-tutorial-32
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -1899,8 +1909,10 @@ TEST 25: pgfmanual-en-tutorial-33
 ......\glue -50.1875
 ......\hbox(100.375+0.0)x100.375, shifted 50.1875, direction TLT
 .......\hbox(100.375+0.0)x100.375, direction TLT
+........\begindir TLT
 ........\hbox(100.375+0.0)x100.375, direction TLT
 .........\box(100.375+0.0)x100.375
+........\enddir TLT
 ....\pdfliteral origin{Q }
 ....\glue(\spaceskip) 0.0
 ....\pdfliteral origin{Q }
@@ -3346,9 +3358,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3390,9 +3404,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3434,9 +3450,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3478,9 +3496,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3522,9 +3542,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3566,9 +3588,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3610,9 +3634,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3654,9 +3680,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3698,9 +3726,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3742,9 +3772,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3786,9 +3818,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3830,9 +3864,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3874,9 +3910,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3918,9 +3956,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -3962,9 +4002,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 3
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4006,9 +4048,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4050,9 +4094,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4094,9 +4140,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4138,9 +4186,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4182,9 +4232,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 4
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4226,9 +4278,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4270,9 +4324,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4314,9 +4370,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4358,9 +4416,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4402,9 +4462,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 5
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4446,9 +4508,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4490,9 +4554,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4534,9 +4600,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4578,9 +4646,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4622,9 +4692,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.76+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 7
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4666,9 +4738,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4710,9 +4784,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4754,9 +4830,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4798,9 +4876,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4842,9 +4922,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 8
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4886,9 +4968,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4930,9 +5014,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -4974,9 +5060,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5018,9 +5106,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5062,9 +5152,11 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x12.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 9
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5106,10 +5198,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5151,10 +5245,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5196,10 +5292,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5241,10 +5339,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5286,10 +5386,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 0
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5331,10 +5433,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5376,10 +5480,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5421,10 +5527,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5466,10 +5574,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5511,10 +5621,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5556,10 +5668,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5601,10 +5715,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5646,10 +5762,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 3
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5691,10 +5809,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 4
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5736,10 +5856,12 @@ TEST 41: pgfmanual-en-tutorial-51
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.66+1.93)x17.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 1
 ...........\TU/lmr/m/n/10 2
 ...........\TU/lmr/m/n/10 ,
 ...........\TU/lmr/m/n/10 5
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5815,6 +5937,7 @@ TEST 42: pgfmanual-en-tutorial-52
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.11)x67.05, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 T
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -5832,6 +5955,7 @@ TEST 42: pgfmanual-en-tutorial-52
 ...........\penalty 10000
 ...........\glue(\spaceskip) 5.25
 ...........\TU/lmtt/m/n/10 1
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -5857,6 +5981,7 @@ TEST 42: pgfmanual-en-tutorial-52
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.77+0.11)x67.05, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 T
 ...........\kern-0.83 (font)
 ...........\TU/lmr/m/n/10 e
@@ -5874,6 +5999,7 @@ TEST 42: pgfmanual-en-tutorial-52
 ...........\penalty 10000
 ...........\glue(\spaceskip) 5.25
 ...........\TU/lmtt/m/n/10 2
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6039,10 +6165,12 @@ TEST 43: pgfmanual-en-tutorial-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6074,12 +6202,14 @@ TEST 43: pgfmanual-en-tutorial-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x20.55562, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 0
 ...........\OML/cmm/m/it/10 :
 ...........\OT1/cmr/m/n/10 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6111,9 +6241,11 @@ TEST 43: pgfmanual-en-tutorial-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6144,10 +6276,12 @@ TEST 43: pgfmanual-en-tutorial-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6177,12 +6311,14 @@ TEST 43: pgfmanual-en-tutorial-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x20.55562, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 0
 ...........\OML/cmm/m/it/10 :
 ...........\OT1/cmr/m/n/10 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6212,11 +6348,13 @@ TEST 43: pgfmanual-en-tutorial-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 0
 ...........\OML/cmm/m/it/10 :
 ...........\OT1/cmr/m/n/10 5
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6246,9 +6384,11 @@ TEST 43: pgfmanual-en-tutorial-53
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6415,10 +6555,12 @@ TEST 44: pgfmanual-en-tutorial-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6450,6 +6592,7 @@ TEST 44: pgfmanual-en-tutorial-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.44843+3.44841)x14.16393, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\hbox(8.44843+3.44841)x6.38612, direction TLT
@@ -6465,6 +6608,7 @@ TEST 44: pgfmanual-en-tutorial-54
 ...............\OT1/cmr/m/n/7 2
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6496,9 +6640,11 @@ TEST 44: pgfmanual-en-tutorial-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6529,10 +6675,12 @@ TEST 44: pgfmanual-en-tutorial-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6562,6 +6710,7 @@ TEST 44: pgfmanual-en-tutorial-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.44843+3.44841)x14.16393, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\hbox(8.44843+3.44841)x6.38612, direction TLT
@@ -6577,6 +6726,7 @@ TEST 44: pgfmanual-en-tutorial-54
 ...............\OT1/cmr/m/n/7 2
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6606,6 +6756,7 @@ TEST 44: pgfmanual-en-tutorial-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.44843+3.44841)x6.38612, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(8.44843+3.44841)x6.38612, direction TLT
 ............\hbox(8.44843+3.44841)x6.38612, direction TLT
@@ -6620,6 +6771,7 @@ TEST 44: pgfmanual-en-tutorial-54
 ...............\OT1/cmr/m/n/7 2
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6649,9 +6801,11 @@ TEST 44: pgfmanual-en-tutorial-54
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6834,6 +6988,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{1 0 0 RG }
 ..........\pdfliteral origin{1 0 0 rg }
 ..........\hbox(6.67859+0.0)x20.37846, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 ...........\mathon
 ...........\hbox(6.67859+0.0)x12.2778, direction TLT
@@ -6846,6 +7001,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ...........\kern0.03702 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6887,6 +7043,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{0 0 1 RG }
 ..........\pdfliteral origin{0 0 1 rg }
 ..........\hbox(4.30554+0.0)x21.48956, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {0 0 1 rg 0 0 1 RG}
 ...........\mathon
 ...........\hbox(4.30554+0.0)x13.3889, direction TLT
@@ -6899,6 +7056,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ...........\kern0.03702 (italic)
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -6960,6 +7118,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{1 0.5 0 RG }
 ..........\pdfliteral origin{1 0.5 0 rg }
 ..........\hbox(13.44366+6.85951)x59.76793, direction TLT
+...........\begindir TLT
 ...........\pdfcolorstack 0 push {1 0.5 0 rg 1 0.5 0 RG}
 ...........\mathon
 ...........\hbox(6.15079+0.0)x14.44449, direction TLT
@@ -7011,6 +7170,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ...........\mathoff
 ...........\pdfcolorstack 0 pop
 ...........\pdfcolorstack 0 pop
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7057,10 +7217,12 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7098,6 +7260,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.44843+3.44841)x14.16393, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\hbox(8.44843+3.44841)x6.38612, direction TLT
@@ -7113,6 +7276,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ...............\OT1/cmr/m/n/7 2
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7150,9 +7314,11 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7189,10 +7355,12 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.83333)x12.77782, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7228,6 +7396,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.44843+3.44841)x14.16393, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OMS/cmsy/m/n/10 ^^@
 ...........\hbox(8.44843+3.44841)x6.38612, direction TLT
@@ -7243,6 +7412,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ...............\OT1/cmr/m/n/7 2
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7278,6 +7448,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(8.44843+3.44841)x6.38612, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\hbox(8.44843+3.44841)x6.38612, direction TLT
 ............\hbox(8.44843+3.44841)x6.38612, direction TLT
@@ -7292,6 +7463,7 @@ TEST 45: pgfmanual-en-tutorial-55
 ...............\OT1/cmr/m/n/7 2
 .............\hbox(0.0+0.0)x1.2, shifted -2.5, direction TLT
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7327,9 +7499,11 @@ TEST 45: pgfmanual-en-tutorial-55
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.44444+0.0)x5.00002, direction TLT
+...........\begindir TLT
 ...........\mathon
 ...........\OT1/cmr/m/n/10 1
 ...........\mathoff
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7388,6 +7562,7 @@ TEST 46: pgfmanual-en-tutorial-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.15+0.11)x42.89, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 a
@@ -7398,6 +7573,7 @@ TEST 46: pgfmanual-en-tutorial-56
 ...........\TU/lmr/m/n/10 a
 ...........\TU/lmr/m/n/10 r
 ...........\TU/lmr/m/n/10 t
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7423,6 +7599,7 @@ TEST 46: pgfmanual-en-tutorial-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x33.61, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 m
 ...........\TU/lmr/m/n/10 i
 ...........\TU/lmr/m/n/10 d
@@ -7433,6 +7610,7 @@ TEST 46: pgfmanual-en-tutorial-56
 ...........\TU/lmr/m/n/10 a
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 y
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7458,6 +7636,7 @@ TEST 46: pgfmanual-en-tutorial-56
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(6.94+2.05)x59.78, direction TLT
+...........\begindir TLT
 ...........\TU/lmr/m/n/10 v
 ...........\kern-0.28 (font)
 ...........\TU/lmr/m/n/10 e
@@ -7472,6 +7651,7 @@ TEST 46: pgfmanual-en-tutorial-56
 ...........\TU/lmr/m/n/10 e
 ...........\TU/lmr/m/n/10 n
 ...........\TU/lmr/m/n/10 d
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -7594,10 +7774,12 @@ TEST 47: pgfmanual-en-tutorial-58
 ............\pdfliteral origin{0 G }
 ............\pdfliteral origin{0 g }
 ............\hbox(4.30554+0.0)x6.43404, direction TLT
+.............\begindir TLT
 .............\mathon
 .............\OML/cmm/m/it/10 ^^K
 .............\kern0.03702 (italic)
 .............\mathoff
+.............\enddir TLT
 ............\glue(\spaceskip) 0.0
 ..........\pdfliteral origin{Q }
 ..........\glue(\spaceskip) 0.0

--- a/testfiles-regression-luatex/gd-examples.tlg
+++ b/testfiles-regression-luatex/gd-examples.tlg
@@ -369,7 +369,9 @@ TEST 1: gd-examples-SimpleEdgeDemo-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -415,7 +417,9 @@ TEST 1: gd-examples-SimpleEdgeDemo-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -461,7 +465,9 @@ TEST 1: gd-examples-SimpleEdgeDemo-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -507,7 +513,9 @@ TEST 1: gd-examples-SimpleEdgeDemo-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -553,7 +561,9 @@ TEST 1: gd-examples-SimpleEdgeDemo-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 e
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -599,7 +609,9 @@ TEST 1: gd-examples-SimpleEdgeDemo-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.0)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -985,7 +997,9 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1021,9 +1035,11 @@ TEST 2: gd-examples-SimpleHuffman-1
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(6.66+0.22)x12.78, direction TLT
+..............\begindir TLT
 ..............\TU/lmr/m/n/10 0
 ..............\TU/lmr/m/n/10 .
 ..............\TU/lmr/m/n/10 5
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0
@@ -1064,7 +1080,9 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1100,10 +1118,12 @@ TEST 2: gd-examples-SimpleHuffman-1
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(6.66+0.22)x17.78, direction TLT
+..............\begindir TLT
 ..............\TU/lmr/m/n/10 0
 ..............\TU/lmr/m/n/10 .
 ..............\TU/lmr/m/n/10 1
 ..............\TU/lmr/m/n/10 2
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0
@@ -1144,7 +1164,9 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1180,9 +1202,11 @@ TEST 2: gd-examples-SimpleHuffman-1
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(6.66+0.22)x12.78, direction TLT
+..............\begindir TLT
 ..............\TU/lmr/m/n/10 0
 ..............\TU/lmr/m/n/10 .
 ..............\TU/lmr/m/n/10 2
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0
@@ -1223,7 +1247,9 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1259,9 +1285,11 @@ TEST 2: gd-examples-SimpleHuffman-1
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(6.66+0.22)x12.78, direction TLT
+..............\begindir TLT
 ..............\TU/lmr/m/n/10 0
 ..............\TU/lmr/m/n/10 .
 ..............\TU/lmr/m/n/10 1
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0
@@ -1302,7 +1330,9 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1338,10 +1368,12 @@ TEST 2: gd-examples-SimpleHuffman-1
 .............\pdfliteral origin{0 G }
 .............\pdfliteral origin{0 g }
 .............\hbox(6.66+0.22)x17.78, direction TLT
+..............\begindir TLT
 ..............\TU/lmr/m/n/10 0
 ..............\TU/lmr/m/n/10 .
 ..............\TU/lmr/m/n/10 1
 ..............\TU/lmr/m/n/10 1
+..............\enddir TLT
 .............\glue(\spaceskip) 0.0
 ...........\pdfliteral origin{Q }
 ...........\glue(\spaceskip) 0.0
@@ -1382,6 +1414,8 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1427,6 +1461,8 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1472,6 +1508,8 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -1517,6 +1555,8 @@ TEST 2: gd-examples-SimpleHuffman-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2180,11 +2220,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.30554+1.49998)x10.2014, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\OML/cmm/m/it/10 x
 .................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..................\OT1/cmr/m/n/7 1
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2236,11 +2278,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.30554+1.49998)x10.2014, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\OML/cmm/m/it/10 x
 .................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..................\OT1/cmr/m/n/7 2
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2292,11 +2336,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.30554+1.49998)x10.2014, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\OML/cmm/m/it/10 x
 .................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..................\OT1/cmr/m/n/7 3
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2348,11 +2394,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.30554+1.49998)x10.2014, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\OML/cmm/m/it/10 x
 .................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..................\OT1/cmr/m/n/7 4
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2404,11 +2452,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.30554+1.49998)x10.2014, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\OML/cmm/m/it/10 x
 .................\hbox(4.51111+0.0)x4.48613, shifted 1.49998, direction TLT
 ..................\OT1/cmr/m/n/7 5
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2452,6 +2502,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.05554+0.0)x13.33324, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\hbox(1.05554+0.0)x11.66661, direction TLT
 ..................\OML/cmm/m/it/10 :
@@ -2461,6 +2512,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\OML/cmm/m/it/10 :
 .................\glue 1.66663
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2512,6 +2564,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.30554+2.33333)x21.39474, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\OML/cmm/m/it/10 x
 .................\hbox(4.51111+0.83334)x15.67947, shifted 1.49998, direction TLT
@@ -2519,6 +2572,7 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ..................\OMS/cmsy/m/n/7 ^^@
 ..................\OT1/cmr/m/n/7 1
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -2570,11 +2624,13 @@ LaTeX Font Info:    Trying to load font information for U+msb on input line ....
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.30554+1.49998)x11.1586, direction TLT
+.................\begindir TLT
 .................\mathon
 .................\OML/cmm/m/it/10 x
 .................\hbox(3.01389+0.0)x5.44333, shifted 1.49998, direction TLT
 ..................\OML/cmm/m/it/7 n
 .................\mathoff
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3095,7 +3151,9 @@ TEST 4: gd-circular-Tantau2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3141,7 +3199,9 @@ TEST 4: gd-circular-Tantau2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3187,7 +3247,9 @@ TEST 4: gd-circular-Tantau2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3233,7 +3295,9 @@ TEST 4: gd-circular-Tantau2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3279,7 +3343,9 @@ TEST 4: gd-circular-Tantau2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3325,7 +3391,9 @@ TEST 4: gd-circular-Tantau2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3371,7 +3439,9 @@ TEST 4: gd-circular-Tantau2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3892,7 +3962,9 @@ TEST 5: gd-circular-Tantau2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3938,7 +4010,9 @@ TEST 5: gd-circular-Tantau2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -3984,7 +4058,9 @@ TEST 5: gd-circular-Tantau2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4030,7 +4106,9 @@ TEST 5: gd-circular-Tantau2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4076,7 +4154,9 @@ TEST 5: gd-circular-Tantau2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4122,7 +4202,9 @@ TEST 5: gd-circular-Tantau2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4168,7 +4250,9 @@ TEST 5: gd-circular-Tantau2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4645,7 +4729,9 @@ TEST 6: gd-circular-Tantau2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4697,7 +4783,9 @@ TEST 6: gd-circular-Tantau2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4749,7 +4837,9 @@ TEST 6: gd-circular-Tantau2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4801,7 +4891,9 @@ TEST 6: gd-circular-Tantau2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4853,7 +4945,9 @@ TEST 6: gd-circular-Tantau2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4905,7 +4999,9 @@ TEST 6: gd-circular-Tantau2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -4957,7 +5053,9 @@ TEST 6: gd-circular-Tantau2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5435,7 +5533,9 @@ TEST 7: gd-circular-Tantau2012-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5487,7 +5587,9 @@ TEST 7: gd-circular-Tantau2012-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5539,7 +5641,9 @@ TEST 7: gd-circular-Tantau2012-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5591,7 +5695,9 @@ TEST 7: gd-circular-Tantau2012-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5643,7 +5749,9 @@ TEST 7: gd-circular-Tantau2012-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5695,7 +5803,9 @@ TEST 7: gd-circular-Tantau2012-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -5747,7 +5857,9 @@ TEST 7: gd-circular-Tantau2012-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6240,7 +6352,9 @@ TEST 8: gd-circular-Tantau2012-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6292,7 +6406,9 @@ TEST 8: gd-circular-Tantau2012-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6344,7 +6460,9 @@ TEST 8: gd-circular-Tantau2012-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6396,7 +6514,9 @@ TEST 8: gd-circular-Tantau2012-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6448,7 +6568,9 @@ TEST 8: gd-circular-Tantau2012-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6500,7 +6622,9 @@ TEST 8: gd-circular-Tantau2012-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -6552,7 +6676,9 @@ TEST 8: gd-circular-Tantau2012-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7029,7 +7155,9 @@ TEST 9: gd-circular-Tantau2012-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7081,7 +7209,9 @@ TEST 9: gd-circular-Tantau2012-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7133,7 +7263,9 @@ TEST 9: gd-circular-Tantau2012-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7185,7 +7317,9 @@ TEST 9: gd-circular-Tantau2012-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7237,7 +7371,9 @@ TEST 9: gd-circular-Tantau2012-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7289,7 +7425,9 @@ TEST 9: gd-circular-Tantau2012-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7341,7 +7479,9 @@ TEST 9: gd-circular-Tantau2012-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7847,7 +7987,9 @@ TEST 10: gd-circular-Tantau2012-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7895,7 +8037,9 @@ TEST 10: gd-circular-Tantau2012-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7943,7 +8087,9 @@ TEST 10: gd-circular-Tantau2012-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -7991,7 +8137,9 @@ TEST 10: gd-circular-Tantau2012-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8039,7 +8187,9 @@ TEST 10: gd-circular-Tantau2012-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8087,7 +8237,9 @@ TEST 10: gd-circular-Tantau2012-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8135,7 +8287,9 @@ TEST 10: gd-circular-Tantau2012-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -8957,7 +9111,9 @@ TEST 11: gd-routing-NecklaceRouting-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9009,7 +9165,9 @@ TEST 11: gd-routing-NecklaceRouting-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9061,7 +9219,9 @@ TEST 11: gd-routing-NecklaceRouting-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9113,7 +9273,9 @@ TEST 11: gd-routing-NecklaceRouting-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9165,7 +9327,9 @@ TEST 11: gd-routing-NecklaceRouting-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9217,7 +9381,9 @@ TEST 11: gd-routing-NecklaceRouting-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9269,7 +9435,9 @@ TEST 11: gd-routing-NecklaceRouting-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -9973,7 +10141,9 @@ TEST 12: gd-force-ControlStart-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10019,7 +10189,9 @@ TEST 12: gd-force-ControlStart-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10065,7 +10237,9 @@ TEST 12: gd-force-ControlStart-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10111,7 +10285,9 @@ TEST 12: gd-force-ControlStart-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10157,7 +10333,9 @@ TEST 12: gd-force-ControlStart-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10203,7 +10381,9 @@ TEST 12: gd-force-ControlStart-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10249,7 +10429,9 @@ TEST 12: gd-force-ControlStart-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10295,7 +10477,9 @@ TEST 12: gd-force-ControlStart-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -10999,7 +11183,9 @@ TEST 13: gd-force-ControlStart-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11045,7 +11231,9 @@ TEST 13: gd-force-ControlStart-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11091,7 +11279,9 @@ TEST 13: gd-force-ControlStart-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11137,7 +11327,9 @@ TEST 13: gd-force-ControlStart-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11183,7 +11375,9 @@ TEST 13: gd-force-ControlStart-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11229,7 +11423,9 @@ TEST 13: gd-force-ControlStart-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11275,7 +11471,9 @@ TEST 13: gd-force-ControlStart-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11321,7 +11519,9 @@ TEST 13: gd-force-ControlStart-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11694,7 +11894,9 @@ TEST 14: gd-force-ControlIteration-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11740,7 +11942,9 @@ TEST 14: gd-force-ControlIteration-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11786,7 +11990,9 @@ TEST 14: gd-force-ControlIteration-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -11832,7 +12038,9 @@ TEST 14: gd-force-ControlIteration-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12205,7 +12413,9 @@ TEST 15: gd-force-ControlIteration-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12251,7 +12461,9 @@ TEST 15: gd-force-ControlIteration-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12297,7 +12509,9 @@ TEST 15: gd-force-ControlIteration-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12343,7 +12557,9 @@ TEST 15: gd-force-ControlIteration-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12716,7 +12932,9 @@ TEST 16: gd-force-ControlIteration-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12762,7 +12980,9 @@ TEST 16: gd-force-ControlIteration-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12808,7 +13028,9 @@ TEST 16: gd-force-ControlIteration-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -12854,7 +13076,9 @@ TEST 16: gd-force-ControlIteration-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13227,7 +13451,9 @@ TEST 17: gd-force-ControlIteration-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13273,7 +13499,9 @@ TEST 17: gd-force-ControlIteration-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13319,7 +13547,9 @@ TEST 17: gd-force-ControlIteration-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13365,7 +13595,9 @@ TEST 17: gd-force-ControlIteration-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13655,7 +13887,9 @@ TEST 18: gd-force-ControlIteration-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13701,7 +13935,9 @@ TEST 18: gd-force-ControlIteration-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -13747,7 +13983,9 @@ TEST 18: gd-force-ControlIteration-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14037,7 +14275,9 @@ TEST 19: gd-force-ControlIteration-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14083,7 +14323,9 @@ TEST 19: gd-force-ControlIteration-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14129,7 +14371,9 @@ TEST 19: gd-force-ControlIteration-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14618,7 +14862,9 @@ TEST 20: gd-force-ControlIteration-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14664,7 +14910,9 @@ TEST 20: gd-force-ControlIteration-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14710,7 +14958,9 @@ TEST 20: gd-force-ControlIteration-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14756,7 +15006,9 @@ TEST 20: gd-force-ControlIteration-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14802,7 +15054,9 @@ TEST 20: gd-force-ControlIteration-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14848,7 +15102,9 @@ TEST 20: gd-force-ControlIteration-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -14894,7 +15150,9 @@ TEST 20: gd-force-ControlIteration-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15383,7 +15641,9 @@ TEST 21: gd-force-ControlIteration-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15429,7 +15689,9 @@ TEST 21: gd-force-ControlIteration-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15475,7 +15737,9 @@ TEST 21: gd-force-ControlIteration-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15521,7 +15785,9 @@ TEST 21: gd-force-ControlIteration-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15567,7 +15833,9 @@ TEST 21: gd-force-ControlIteration-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15613,7 +15881,9 @@ TEST 21: gd-force-ControlIteration-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15659,7 +15929,9 @@ TEST 21: gd-force-ControlIteration-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15947,7 +16219,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -15993,7 +16267,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -16039,7 +16315,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -16315,7 +16593,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -16361,7 +16641,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -16407,7 +16689,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -16684,7 +16968,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -16730,7 +17016,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -16776,7 +17064,9 @@ TEST 22: gd-force-ControlSprings-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17064,7 +17354,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17110,7 +17402,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17156,7 +17450,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17432,7 +17728,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17478,7 +17776,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17524,7 +17824,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17801,7 +18103,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17847,7 +18151,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -17893,7 +18199,9 @@ TEST 23: gd-force-ControlSprings-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -18791,7 +19099,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -18837,7 +19147,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -18883,7 +19195,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -18929,7 +19243,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -18975,7 +19291,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -19021,7 +19339,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -19067,7 +19387,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -19113,7 +19435,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -19159,7 +19483,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -19205,7 +19531,9 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 9
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -19251,8 +19579,10 @@ TEST 24: gd-force-ControlElectric-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x10.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20150,7 +20480,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20196,7 +20528,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20242,7 +20576,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20288,7 +20624,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20334,7 +20672,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20380,7 +20720,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20426,7 +20768,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20472,7 +20816,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20518,7 +20864,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20564,7 +20912,9 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 9
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20610,8 +20960,10 @@ TEST 25: gd-force-ControlElectric-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x10.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20915,7 +21267,9 @@ TEST 26: gd-force-ControlElectric-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -20961,7 +21315,9 @@ TEST 26: gd-force-ControlElectric-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21007,7 +21363,9 @@ TEST 26: gd-force-ControlElectric-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21053,7 +21411,9 @@ TEST 26: gd-force-ControlElectric-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21542,7 +21902,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21588,7 +21950,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21634,7 +21998,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21680,7 +22046,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21726,7 +22094,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21772,7 +22142,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -21818,7 +22190,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -22296,7 +22670,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -22342,7 +22718,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -22388,7 +22766,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -22434,7 +22814,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -22480,7 +22862,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -22526,7 +22910,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -22572,7 +22958,9 @@ TEST 27: gd-force-ControlCoarsening-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23129,7 +23517,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23175,7 +23565,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23221,7 +23613,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23267,7 +23661,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23313,7 +23709,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23359,7 +23757,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23405,7 +23805,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23451,7 +23853,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -23997,7 +24401,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24043,7 +24449,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24089,7 +24497,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24135,7 +24545,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24181,7 +24593,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24227,7 +24641,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24273,7 +24689,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24319,7 +24737,9 @@ TEST 28: gd-force-ControlCoarsening-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24809,7 +25229,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24855,7 +25277,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24901,7 +25325,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24947,7 +25373,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -24993,7 +25421,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25039,7 +25469,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25085,7 +25517,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25564,7 +25998,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25610,7 +26046,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25656,7 +26094,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25702,7 +26142,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25748,7 +26190,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25794,7 +26238,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -25840,7 +26286,9 @@ TEST 29: gd-force-ControlCoarsening-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -26464,7 +26912,9 @@ TEST 30: gd-layered-Sugiyama-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -26510,7 +26960,9 @@ TEST 30: gd-layered-Sugiyama-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -26556,7 +27008,9 @@ TEST 30: gd-layered-Sugiyama-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -26602,7 +27056,9 @@ TEST 30: gd-layered-Sugiyama-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -26648,7 +27104,9 @@ TEST 30: gd-layered-Sugiyama-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -26694,7 +27152,9 @@ TEST 30: gd-layered-Sugiyama-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -26740,7 +27200,9 @@ TEST 30: gd-layered-Sugiyama-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -27367,7 +27829,9 @@ TEST 31: gd-layered-Sugiyama-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -27413,7 +27877,9 @@ TEST 31: gd-layered-Sugiyama-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -27459,7 +27925,9 @@ TEST 31: gd-layered-Sugiyama-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -27505,7 +27973,9 @@ TEST 31: gd-layered-Sugiyama-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -27551,7 +28021,9 @@ TEST 31: gd-layered-Sugiyama-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -27597,7 +28069,9 @@ TEST 31: gd-layered-Sugiyama-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -27643,7 +28117,9 @@ TEST 31: gd-layered-Sugiyama-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28093,7 +28569,9 @@ TEST 32: gd-layered-Sugiyama-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28139,7 +28617,9 @@ TEST 32: gd-layered-Sugiyama-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28185,7 +28665,9 @@ TEST 32: gd-layered-Sugiyama-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28231,7 +28713,9 @@ TEST 32: gd-layered-Sugiyama-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28277,7 +28761,9 @@ TEST 32: gd-layered-Sugiyama-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28707,7 +29193,9 @@ TEST 33: gd-layered-Sugiyama-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28753,7 +29241,9 @@ TEST 33: gd-layered-Sugiyama-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28799,7 +29289,9 @@ TEST 33: gd-layered-Sugiyama-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28845,7 +29337,9 @@ TEST 33: gd-layered-Sugiyama-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -28891,7 +29385,9 @@ TEST 33: gd-layered-Sugiyama-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31646,10 +32142,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 7
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31695,10 +32193,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 7
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31744,10 +32244,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 7
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31793,10 +32295,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 8
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31842,10 +32346,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 8
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31891,10 +32397,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 8
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31940,10 +32448,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 8
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -31989,10 +32499,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 8
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32038,10 +32550,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x20.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32087,6 +32601,7 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.11)x26.43, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
 .................\TU/lmr/m/n/10 u
 .................\discretionary (penalty 50)
@@ -32095,6 +32610,7 @@ TEST 34: gd-layered-Sugiyama-5
 .................\TU/lmr/m/n/10 u
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32140,6 +32656,7 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+1.94)x46.17, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 T
 .................\TU/lmr/m/n/10 h
 .................\TU/lmr/m/n/10 o
@@ -32150,6 +32667,7 @@ TEST 34: gd-layered-Sugiyama-5
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32195,12 +32713,14 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.05)x33.39, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 M
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 y
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32246,12 +32766,14 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.83+0.11)x31.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 B
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 u
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 n
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32297,6 +32819,7 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x42.45, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 F
 .................\kern-0.83 (font)
 .................\TU/lmr/m/n/10 o
@@ -32307,6 +32830,7 @@ TEST 34: gd-layered-Sugiyama-5
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 l
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32352,9 +32876,11 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x13.94, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32400,9 +32926,11 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x13.94, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32448,9 +32976,11 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x14.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 v
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32496,9 +33026,11 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x14.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 k
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32544,6 +33076,7 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+2.05)x42.27, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 S
 .................\TU/lmr/m/n/10 y
 .................\TU/lmr/m/n/10 s
@@ -32554,6 +33087,7 @@ TEST 34: gd-layered-Sugiyama-5
 ..................< \TU/lmr/m/n/10 -
 ..................= \TU/lmr/m/n/10 -
 .................\TU/lmr/m/n/10 V
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32599,10 +33133,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.22)x19.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 v
 .................\TU/lmr/m/n/10 9
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32648,10 +33184,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x17.83, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 t
 .................\TU/lmr/m/n/10 c
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32697,6 +33235,7 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x20.89, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 k
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
@@ -32704,6 +33243,7 @@ TEST 34: gd-layered-Sugiyama-5
 ..................< \TU/lmr/m/n/10 -
 ..................= \TU/lmr/m/n/10 -
 .................\TU/lmr/m/n/10 i
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32749,6 +33289,7 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.22)x43.09999, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 K
 .................\kern-0.28 (font)
 .................\TU/lmr/m/n/10 o
@@ -32763,6 +33304,7 @@ TEST 34: gd-layered-Sugiyama-5
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 l
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32808,11 +33350,13 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x17.67, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 P
 .................\kern-0.28 (font)
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 l
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32858,8 +33402,10 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x8.36, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32905,9 +33451,11 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x11.11, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 t
 .................\TU/lmr/m/n/10 c
 .................\TU/lmr/m/n/10 l
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -32953,10 +33501,12 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x21.58, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 B
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33002,11 +33552,13 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.22)x31.26, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 P
 .................\TU/lmr/m/n/10 O
 .................\TU/lmr/m/n/10 S
 .................\TU/lmr/m/n/10 I
 .................\TU/lmr/m/n/10 X
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33052,6 +33604,7 @@ TEST 34: gd-layered-Sugiyama-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.22)x49.37, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 k
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 h
@@ -33063,6 +33616,7 @@ TEST 34: gd-layered-Sugiyama-5
 .................\TU/lmr/m/n/10 S
 .................\TU/lmr/m/n/10 I
 .................\TU/lmr/m/n/10 X
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33607,7 +34161,9 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33653,7 +34209,9 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33699,7 +34257,9 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33745,7 +34305,9 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33791,7 +34353,9 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33837,7 +34401,9 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33883,7 +34449,9 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33929,6 +34497,8 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -33974,6 +34544,8 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34019,6 +34591,8 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34064,6 +34638,8 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34109,6 +34685,8 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34154,6 +34732,8 @@ TEST 35: gd-phylogenetics-PhylogeneticTree-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34512,7 +35092,9 @@ TEST 36: gd-phylogenetics-AuthorDefinedPhylogeny-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34558,7 +35140,9 @@ TEST 36: gd-phylogenetics-AuthorDefinedPhylogeny-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34604,7 +35188,9 @@ TEST 36: gd-phylogenetics-AuthorDefinedPhylogeny-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34650,7 +35236,9 @@ TEST 36: gd-phylogenetics-AuthorDefinedPhylogeny-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -34696,7 +35284,9 @@ TEST 36: gd-phylogenetics-AuthorDefinedPhylogeny-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35241,7 +35831,9 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35287,7 +35879,9 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35333,7 +35927,9 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35379,7 +35975,9 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35425,7 +36023,9 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35471,7 +36071,9 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35517,7 +36119,9 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35563,6 +36167,8 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35608,6 +36214,8 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35653,6 +36261,8 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35698,6 +36308,8 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35743,6 +36355,8 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -35788,6 +36402,8 @@ TEST 37: gd-phylogenetics-SokalMichener1958-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36301,7 +36917,9 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36347,7 +36965,9 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36393,7 +37013,9 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36439,7 +37061,9 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36485,7 +37109,9 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36531,7 +37157,9 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36577,7 +37205,9 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36623,6 +37253,8 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36668,6 +37300,8 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36713,6 +37347,8 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36758,6 +37394,8 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -36803,6 +37441,8 @@ TEST 38: gd-phylogenetics-BalancedMinimumEvolution-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37316,7 +37956,9 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37362,7 +38004,9 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37408,7 +38052,9 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37454,7 +38100,9 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37500,7 +38148,9 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37546,7 +38196,9 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37592,7 +38244,9 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37638,6 +38292,8 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37683,6 +38339,8 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37728,6 +38386,8 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37773,6 +38433,8 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -37818,6 +38480,8 @@ TEST 39: gd-phylogenetics-Maeusle2012-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38311,7 +38975,9 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38357,7 +39023,9 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38403,7 +39071,9 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38449,7 +39119,9 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38495,7 +39167,9 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38541,7 +39215,9 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38587,7 +39263,9 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38633,6 +39311,8 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38678,6 +39358,8 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38723,6 +39405,8 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38768,6 +39452,8 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -38813,6 +39499,8 @@ TEST 40: gd-phylogenetics-Maeusle2012-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39326,7 +40014,9 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39372,7 +40062,9 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39418,7 +40110,9 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39464,7 +40158,9 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39510,7 +40206,9 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39556,7 +40254,9 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39602,7 +40302,9 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39648,6 +40350,8 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39693,6 +40397,8 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39738,6 +40444,8 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39783,6 +40491,8 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -39828,6 +40538,8 @@ TEST 41: gd-phylogenetics-Maeusle2012-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40321,7 +41033,9 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40367,7 +41081,9 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40413,7 +41129,9 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40459,7 +41177,9 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40505,7 +41225,9 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40551,7 +41273,9 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40597,7 +41321,9 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40643,6 +41369,8 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40688,6 +41416,8 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40733,6 +41463,8 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40778,6 +41510,8 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40823,6 +41557,8 @@ TEST 42: gd-phylogenetics-Maeusle2012-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -40989,7 +41725,9 @@ TEST 43: gd-trees-ReingoldTilford1981-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.42+0.0)x3.92, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 r
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -41041,7 +41779,9 @@ TEST 43: gd-trees-ReingoldTilford1981-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -41093,7 +41833,9 @@ TEST 43: gd-trees-ReingoldTilford1981-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -41356,7 +42098,9 @@ TEST 44: gd-trees-ReingoldTilford1981-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.42+0.0)x3.92, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 r
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -41408,7 +42152,9 @@ TEST 44: gd-trees-ReingoldTilford1981-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -41460,7 +42206,9 @@ TEST 44: gd-trees-ReingoldTilford1981-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -41867,7 +42615,9 @@ TEST 45: gd-trees-ReingoldTilford1981-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.42+0.0)x3.92, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 r
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -41919,7 +42669,9 @@ TEST 45: gd-trees-ReingoldTilford1981-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -41971,7 +42723,9 @@ TEST 45: gd-trees-ReingoldTilford1981-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42023,7 +42777,9 @@ TEST 45: gd-trees-ReingoldTilford1981-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42075,7 +42831,9 @@ TEST 45: gd-trees-ReingoldTilford1981-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42127,7 +42885,9 @@ TEST 45: gd-trees-ReingoldTilford1981-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42593,7 +43353,9 @@ TEST 46: gd-trees-ReingoldTilford1981-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42645,7 +43407,9 @@ TEST 46: gd-trees-ReingoldTilford1981-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42697,7 +43461,9 @@ TEST 46: gd-trees-ReingoldTilford1981-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42749,7 +43515,9 @@ TEST 46: gd-trees-ReingoldTilford1981-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42801,7 +43569,9 @@ TEST 46: gd-trees-ReingoldTilford1981-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42853,7 +43623,9 @@ TEST 46: gd-trees-ReingoldTilford1981-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -42905,7 +43677,9 @@ TEST 46: gd-trees-ReingoldTilford1981-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -43574,6 +44348,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -43625,6 +44401,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -43676,6 +44454,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -43727,6 +44507,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -43778,6 +44560,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -43829,6 +44613,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -43880,6 +44666,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -43931,6 +44719,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -43982,6 +44772,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -44033,6 +44825,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -44084,6 +44878,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -44742,6 +45538,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -44793,6 +45591,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -44844,6 +45644,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -44895,6 +45697,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -44946,6 +45750,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -44997,6 +45803,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -45048,6 +45856,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -45099,6 +45909,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -45150,6 +45962,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -45201,6 +46015,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -45252,6 +46068,8 @@ TEST 47: gd-trees-ReingoldTilford1981-5
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -45719,6 +46537,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -45770,7 +46590,9 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -45822,6 +46644,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -45873,6 +46697,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -45924,7 +46750,9 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -45976,6 +46804,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -46027,6 +46857,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -46487,6 +47319,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -46538,7 +47372,9 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -46590,6 +47426,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -46641,6 +47479,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -46692,7 +47532,9 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -46744,6 +47586,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -46795,6 +47639,8 @@ TEST 48: gd-trees-ReingoldTilford1981-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(0.0+0.0)x0.0, direction TLT
+.................\begindir TLT
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -47565,7 +48411,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -47617,7 +48465,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 2
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -47669,7 +48519,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 3
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -47721,7 +48573,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.77+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 4
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -47773,7 +48627,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 5
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -47825,7 +48681,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 6
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -47877,7 +48735,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.76+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 7
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -47929,7 +48789,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 8
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -47981,7 +48843,9 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 9
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -48033,8 +48897,10 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -48086,8 +48952,10 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 1
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -48139,8 +49007,10 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 2
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -48192,8 +49062,10 @@ TEST 49: gd-trees-ReingoldTilford1981-7
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 3
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -48961,7 +49833,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49013,7 +49887,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 2
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49065,7 +49941,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 3
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49117,7 +49995,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.77+0.0)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 4
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49169,7 +50049,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 5
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49221,7 +50103,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 6
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49273,7 +50157,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.76+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 7
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49325,7 +50211,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 8
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49377,7 +50265,9 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 9
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49429,8 +50319,10 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 0
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49482,8 +50374,10 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 1
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49535,8 +50429,10 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.0)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 2
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -49588,8 +50484,10 @@ TEST 50: gd-trees-ReingoldTilford1981-8
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.66+0.22)x10.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 1
 ...............\TU/lmr/m/n/10 3
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -50052,7 +50950,9 @@ TEST 51: gd-trees-ReingoldTilford1981-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -50104,7 +51004,9 @@ TEST 51: gd-trees-ReingoldTilford1981-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -50156,7 +51058,9 @@ TEST 51: gd-trees-ReingoldTilford1981-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -50208,7 +51112,9 @@ TEST 51: gd-trees-ReingoldTilford1981-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -50260,7 +51166,9 @@ TEST 51: gd-trees-ReingoldTilford1981-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -50312,7 +51220,9 @@ TEST 51: gd-trees-ReingoldTilford1981-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -50364,7 +51274,9 @@ TEST 51: gd-trees-ReingoldTilford1981-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -51033,6 +51945,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51084,6 +51998,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51135,6 +52051,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51186,6 +52104,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51237,6 +52157,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51288,6 +52210,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51339,6 +52263,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51390,6 +52316,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51441,6 +52369,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51492,6 +52422,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -51543,6 +52475,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52201,6 +53135,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52252,6 +53188,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52303,6 +53241,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52354,6 +53294,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52405,6 +53347,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52456,6 +53400,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52507,6 +53453,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52558,6 +53506,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52609,6 +53559,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52660,6 +53612,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -52711,6 +53665,8 @@ TEST 52: gd-trees-ReingoldTilford1981-10
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(0.0+0.0)x0.0, direction TLT
+...............\begindir TLT
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53423,7 +54379,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53469,7 +54427,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53515,7 +54475,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53561,7 +54523,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53607,7 +54571,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 e
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53653,7 +54619,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.0)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53699,7 +54667,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53745,7 +54715,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.0)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 h
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53791,7 +54763,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+0.0)x2.78, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 i
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53837,7 +54811,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+2.05)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 j
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -53883,7 +54859,9 @@ TEST 53: gd-trees-ReingoldTilford1981-11
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 k
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -54436,12 +55414,14 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x28.06999, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 K
 .................\TU/lmr/m/n/10 n
 .................\kern-0.28 (font)
 .................\TU/lmr/m/n/10 u
 .................\TU/lmr/m/n/10 t
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -54487,6 +55467,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.83+0.11)x30.41, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 B
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 e
@@ -54495,6 +55476,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 t
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -54540,6 +55522,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x45.03, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 K
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 l
@@ -54551,6 +55534,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 m
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -54596,12 +55580,14 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.22)x30.08, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 C
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 n
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 s
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -54647,6 +55633,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x25.29, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 T
 .................\kern-0.83 (font)
 .................\TU/lmr/m/n/10 o
@@ -54655,6 +55642,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 b
 .................\TU/lmr/m/n/10 i
 .................\TU/lmr/m/n/10 n
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -54700,11 +55688,13 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x22.47, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 P
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 s
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -54750,6 +55740,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.83+1.94)x38.23, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 L
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 m
@@ -54760,6 +55751,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -54805,6 +55797,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+1.94)x28.9, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 S
 .................\TU/lmr/m/n/10 p
 .................\TU/lmr/m/n/10 i
@@ -54814,6 +55807,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\kern-0.56 (font)
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 k
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -55598,6 +56592,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{1 G }
 ................\pdfliteral origin{1 g }
 ................\hbox(6.94+0.11)x28.06999, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 g 1 G}
 .................\TU/lmr/m/n/10 K
 .................\TU/lmr/m/n/10 n
@@ -55606,6 +56601,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 t
 .................\TU/lmr/m/n/10 h
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -55666,6 +56662,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{1 G }
 ................\pdfliteral origin{1 g }
 ................\hbox(6.83+0.11)x30.41, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 g 1 G}
 .................\TU/lmr/m/n/10 B
 .................\TU/lmr/m/n/10 e
@@ -55676,6 +56673,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -55736,6 +56734,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{1 G }
 ................\pdfliteral origin{1 g }
 ................\hbox(6.94+0.11)x45.03, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 g 1 G}
 .................\TU/lmr/m/n/10 K
 .................\TU/lmr/m/n/10 e
@@ -55749,6 +56748,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 n
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -55809,6 +56809,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{1 G }
 ................\pdfliteral origin{1 g }
 ................\hbox(7.05+0.22)x30.08, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 g 1 G}
 .................\TU/lmr/m/n/10 C
 .................\TU/lmr/m/n/10 a
@@ -55817,6 +56818,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 s
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -55877,6 +56879,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{1 G }
 ................\pdfliteral origin{1 g }
 ................\hbox(6.94+0.11)x25.29, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 g 1 G}
 .................\TU/lmr/m/n/10 T
 .................\kern-0.83 (font)
@@ -55887,6 +56890,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 i
 .................\TU/lmr/m/n/10 n
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -55947,6 +56951,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{1 G }
 ................\pdfliteral origin{1 g }
 ................\hbox(6.94+0.11)x22.47, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 g 1 G}
 .................\TU/lmr/m/n/10 P
 .................\TU/lmr/m/n/10 l
@@ -55954,6 +56959,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 s
 .................\TU/lmr/m/n/10 s
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -56014,6 +57020,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{1 G }
 ................\pdfliteral origin{1 g }
 ................\hbox(6.83+1.94)x38.23, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 g 1 G}
 .................\TU/lmr/m/n/10 L
 .................\TU/lmr/m/n/10 a
@@ -56026,6 +57033,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 r
 .................\TU/lmr/m/n/10 t
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -56086,6 +57094,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 ................\pdfliteral origin{1 G }
 ................\pdfliteral origin{1 g }
 ................\hbox(7.05+1.94)x28.9, direction TLT
+.................\begindir TLT
 .................\pdfcolorstack 0 push {1 g 1 G}
 .................\TU/lmr/m/n/10 S
 .................\TU/lmr/m/n/10 p
@@ -56097,6 +57106,7 @@ TEST 54: gd-trees-ReingoldTilford1981-12
 .................\TU/lmr/m/n/10 a
 .................\TU/lmr/m/n/10 k
 .................\pdfcolorstack 0 pop
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -56812,7 +57822,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -56858,7 +57870,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -56904,7 +57918,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -56950,7 +57966,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -56996,7 +58014,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 e
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57042,7 +58062,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.0)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57088,7 +58110,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57134,7 +58158,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.0)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 h
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57180,7 +58206,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+0.0)x2.78, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 i
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57226,7 +58254,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.57+2.05)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 j
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57272,7 +58302,9 @@ TEST 55: gd-trees-ReingoldTilford1981-13
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.0)x5.28, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 k
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57582,7 +58614,9 @@ TEST 56: gd-trees-ChildSpec-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57628,7 +58662,9 @@ TEST 56: gd-trees-ChildSpec-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57674,7 +58710,9 @@ TEST 56: gd-trees-ChildSpec-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57720,7 +58758,9 @@ TEST 56: gd-trees-ChildSpec-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57766,7 +58806,9 @@ TEST 56: gd-trees-ChildSpec-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 e
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57812,7 +58854,9 @@ TEST 56: gd-trees-ChildSpec-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.0)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -57858,7 +58902,9 @@ TEST 56: gd-trees-ChildSpec-1
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -58381,7 +59427,9 @@ TEST 57: gd-trees-ChildSpec-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 a
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -58427,7 +59475,9 @@ TEST 57: gd-trees-ChildSpec-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 b
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -58473,7 +59523,9 @@ TEST 57: gd-trees-ChildSpec-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 c
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -58519,7 +59571,9 @@ TEST 57: gd-trees-ChildSpec-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(6.94+0.11)x5.56, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 d
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -58565,7 +59619,9 @@ TEST 57: gd-trees-ChildSpec-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.48+0.11)x4.44, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 e
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -58611,7 +59667,9 @@ TEST 57: gd-trees-ChildSpec-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(7.05+0.0)x3.06, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 f
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -58657,7 +59715,9 @@ TEST 57: gd-trees-ChildSpec-2
 ..............\pdfliteral origin{0 G }
 ..............\pdfliteral origin{0 g }
 ..............\hbox(4.53+2.06)x5.0, direction TLT
+...............\begindir TLT
 ...............\TU/lmr/m/n/10 g
+...............\enddir TLT
 ..............\glue(\spaceskip) 0.0
 ............\pdfliteral origin{Q }
 ............\glue(\spaceskip) 0.0
@@ -59147,7 +60207,9 @@ TEST 58: gd-trees-ChildSpec-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59193,7 +60255,9 @@ TEST 58: gd-trees-ChildSpec-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59239,7 +60303,9 @@ TEST 58: gd-trees-ChildSpec-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59285,7 +60351,9 @@ TEST 58: gd-trees-ChildSpec-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59331,7 +60399,9 @@ TEST 58: gd-trees-ChildSpec-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59377,7 +60447,9 @@ TEST 58: gd-trees-ChildSpec-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59423,7 +60495,9 @@ TEST 58: gd-trees-ChildSpec-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59605,7 +60679,9 @@ TEST 59: gd-trees-ChildSpec-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59651,7 +60727,9 @@ TEST 59: gd-trees-ChildSpec-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59892,7 +60970,9 @@ TEST 60: gd-trees-ChildSpec-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59938,7 +61018,9 @@ TEST 60: gd-trees-ChildSpec-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -59984,7 +61066,9 @@ TEST 60: gd-trees-ChildSpec-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -60225,7 +61309,9 @@ TEST 61: gd-trees-ChildSpec-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -60271,7 +61357,9 @@ TEST 61: gd-trees-ChildSpec-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -60317,7 +61405,9 @@ TEST 61: gd-trees-ChildSpec-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -60558,7 +61648,9 @@ TEST 62: gd-trees-ChildSpec-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -60604,7 +61696,9 @@ TEST 62: gd-trees-ChildSpec-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -60650,7 +61744,9 @@ TEST 62: gd-trees-ChildSpec-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -60940,7 +62036,9 @@ TEST 63: gd-trees-ChildSpec-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -60986,7 +62084,9 @@ TEST 63: gd-trees-ChildSpec-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -61032,7 +62132,9 @@ TEST 63: gd-trees-ChildSpec-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -61078,7 +62180,9 @@ TEST 63: gd-trees-ChildSpec-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -61523,7 +62627,9 @@ TEST 64: gd-trees-SpanningTreeComputation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -61569,7 +62675,9 @@ TEST 64: gd-trees-SpanningTreeComputation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -61615,7 +62723,9 @@ TEST 64: gd-trees-SpanningTreeComputation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -61661,7 +62771,9 @@ TEST 64: gd-trees-SpanningTreeComputation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -61707,7 +62819,9 @@ TEST 64: gd-trees-SpanningTreeComputation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -61753,7 +62867,9 @@ TEST 64: gd-trees-SpanningTreeComputation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -62237,7 +63353,9 @@ TEST 65: gd-trees-SpanningTreeComputation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -62283,7 +63401,9 @@ TEST 65: gd-trees-SpanningTreeComputation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -62329,7 +63449,9 @@ TEST 65: gd-trees-SpanningTreeComputation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -62375,7 +63497,9 @@ TEST 65: gd-trees-SpanningTreeComputation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -62421,7 +63545,9 @@ TEST 65: gd-trees-SpanningTreeComputation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -62467,7 +63593,9 @@ TEST 65: gd-trees-SpanningTreeComputation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63311,7 +64439,9 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63359,9 +64489,11 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+1.93)x12.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 ,
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63409,7 +64541,9 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63457,7 +64591,9 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63505,7 +64641,9 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63553,8 +64691,10 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x10.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63602,9 +64742,11 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+1.93)x12.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
 .................\TU/lmr/m/n/10 ,
 .................\TU/lmr/m/n/10 9
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63652,7 +64794,9 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63700,7 +64844,9 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -63748,8 +64894,10 @@ TEST 66: gd-trees-SpanningTreeComputation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x10.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
 .................\TU/lmr/m/n/10 0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -64392,7 +65540,9 @@ TEST 67: gd-trees-SpanningTreeComputation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -64440,7 +65590,9 @@ TEST 67: gd-trees-SpanningTreeComputation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -64488,7 +65640,9 @@ TEST 67: gd-trees-SpanningTreeComputation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 8
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -64536,7 +65690,9 @@ TEST 67: gd-trees-SpanningTreeComputation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -64584,7 +65740,9 @@ TEST 67: gd-trees-SpanningTreeComputation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -64632,7 +65790,9 @@ TEST 67: gd-trees-SpanningTreeComputation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -64680,7 +65840,9 @@ TEST 67: gd-trees-SpanningTreeComputation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 9
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -65229,7 +66391,9 @@ TEST 68: gd-control-Distances-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.06+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 .
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -65281,7 +66445,9 @@ TEST 68: gd-control-Distances-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.06+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 .
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -65333,7 +66499,9 @@ TEST 68: gd-control-Distances-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.06+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 .
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -65385,7 +66553,9 @@ TEST 68: gd-control-Distances-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.06+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 .
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -65437,7 +66607,9 @@ TEST 68: gd-control-Distances-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.06+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 .
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -65489,7 +66661,9 @@ TEST 68: gd-control-Distances-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.06+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 .
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -65541,7 +66715,9 @@ TEST 68: gd-control-Distances-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.06+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 .
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -65593,7 +66769,9 @@ TEST 68: gd-control-Distances-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(1.06+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 .
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66031,7 +67209,9 @@ TEST 69: gd-control-Distances-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66083,7 +67263,9 @@ TEST 69: gd-control-Distances-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66135,7 +67317,9 @@ TEST 69: gd-control-Distances-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66187,7 +67371,9 @@ TEST 69: gd-control-Distances-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66239,7 +67425,9 @@ TEST 69: gd-control-Distances-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66633,7 +67821,9 @@ TEST 70: gd-control-Distances-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66685,7 +67875,9 @@ TEST 70: gd-control-Distances-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66737,7 +67929,9 @@ TEST 70: gd-control-Distances-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66789,7 +67983,9 @@ TEST 70: gd-control-Distances-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -66841,7 +68037,9 @@ TEST 70: gd-control-Distances-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67166,7 +68364,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67212,7 +68412,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67258,7 +68460,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67762,7 +68966,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67808,7 +69014,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67854,7 +69062,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67900,7 +69110,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67946,7 +69158,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -67992,7 +69206,9 @@ TEST 71: gd-control-Distances-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -68414,7 +69630,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -68462,7 +69680,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -68510,7 +69730,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -68558,7 +69780,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -68606,7 +69830,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -68962,7 +70188,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69010,7 +70238,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69058,7 +70288,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69106,7 +70338,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69154,7 +70388,9 @@ TEST 72: gd-control-Distances-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69460,7 +70696,9 @@ TEST 73: gd-control-Distances-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69512,7 +70750,9 @@ TEST 73: gd-control-Distances-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69564,7 +70804,9 @@ TEST 73: gd-control-Distances-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69616,7 +70858,9 @@ TEST 73: gd-control-Distances-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69668,7 +70912,9 @@ TEST 73: gd-control-Distances-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -69974,7 +71220,9 @@ TEST 74: gd-control-Distances-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70026,7 +71274,9 @@ TEST 74: gd-control-Distances-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70078,7 +71328,9 @@ TEST 74: gd-control-Distances-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70130,7 +71382,9 @@ TEST 74: gd-control-Distances-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70182,7 +71436,9 @@ TEST 74: gd-control-Distances-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70488,7 +71744,9 @@ TEST 75: gd-control-Distances-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70540,7 +71798,9 @@ TEST 75: gd-control-Distances-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70592,7 +71852,9 @@ TEST 75: gd-control-Distances-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70644,7 +71906,9 @@ TEST 75: gd-control-Distances-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -70696,7 +71960,9 @@ TEST 75: gd-control-Distances-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -71002,7 +72268,9 @@ TEST 76: gd-control-Distances-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -71054,7 +72322,9 @@ TEST 76: gd-control-Distances-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -71106,7 +72376,9 @@ TEST 76: gd-control-Distances-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -71158,7 +72430,9 @@ TEST 76: gd-control-Distances-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -71210,7 +72484,9 @@ TEST 76: gd-control-Distances-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72248,7 +73524,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72296,7 +73574,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72344,7 +73624,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72392,7 +73674,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72440,7 +73724,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72488,7 +73774,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72536,7 +73824,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72584,7 +73874,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72632,7 +73924,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72680,7 +73974,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72728,7 +74024,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72776,7 +74074,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72824,7 +74124,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.0)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 x
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72872,7 +74174,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+2.05)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 y
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72920,7 +74224,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.0)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 z
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -72968,7 +74274,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.42+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 u
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -73016,7 +74324,9 @@ TEST 77: gd-control-Distances-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.11)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 v
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74054,7 +75364,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74102,7 +75414,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74150,7 +75464,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74198,7 +75514,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74246,7 +75564,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74294,7 +75614,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74342,7 +75664,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74390,7 +75714,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74438,7 +75764,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74486,7 +75814,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74534,7 +75864,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74582,7 +75914,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74630,7 +75964,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.0)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 x
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74678,7 +76014,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+2.05)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 y
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74726,7 +76064,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.0)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 z
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74774,7 +76114,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.42+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 u
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -74822,7 +76164,9 @@ TEST 78: gd-control-Distances-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.11)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 v
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -75146,7 +76490,9 @@ TEST 79: gd-control-Anchoring-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -75192,7 +76538,9 @@ TEST 79: gd-control-Anchoring-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -75238,7 +76586,9 @@ TEST 79: gd-control-Anchoring-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -75562,7 +76912,9 @@ TEST 80: gd-control-Anchoring-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -75608,7 +76960,9 @@ TEST 80: gd-control-Anchoring-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -75654,7 +77008,9 @@ TEST 80: gd-control-Anchoring-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -75981,7 +77337,9 @@ TEST 81: gd-control-Anchoring-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -76027,7 +77385,9 @@ TEST 81: gd-control-Anchoring-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -76073,7 +77433,9 @@ TEST 81: gd-control-Anchoring-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -76537,7 +77899,9 @@ TEST 82: gd-control-Anchoring-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -76583,7 +77947,9 @@ TEST 82: gd-control-Anchoring-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -76629,7 +77995,9 @@ TEST 82: gd-control-Anchoring-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -76675,7 +78043,9 @@ TEST 82: gd-control-Anchoring-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -76721,7 +78091,9 @@ TEST 82: gd-control-Anchoring-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -77356,7 +78728,9 @@ TEST 83: gd-control-Anchoring-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -77402,7 +78776,9 @@ TEST 83: gd-control-Anchoring-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -77448,7 +78824,9 @@ TEST 83: gd-control-Anchoring-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -77494,7 +78872,9 @@ TEST 83: gd-control-Anchoring-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -77540,7 +78920,9 @@ TEST 83: gd-control-Anchoring-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -77586,7 +78968,9 @@ TEST 83: gd-control-Anchoring-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -77632,7 +79016,9 @@ TEST 83: gd-control-Anchoring-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -77678,7 +79064,9 @@ TEST 83: gd-control-Anchoring-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -78319,7 +79707,9 @@ TEST 84: gd-control-Anchoring-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -78365,7 +79755,9 @@ TEST 84: gd-control-Anchoring-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -78411,7 +79803,9 @@ TEST 84: gd-control-Anchoring-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -78457,7 +79851,9 @@ TEST 84: gd-control-Anchoring-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -78503,7 +79899,9 @@ TEST 84: gd-control-Anchoring-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -78549,7 +79947,9 @@ TEST 84: gd-control-Anchoring-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -78595,7 +79995,9 @@ TEST 84: gd-control-Anchoring-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -78641,7 +80043,9 @@ TEST 84: gd-control-Anchoring-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79285,7 +80689,9 @@ TEST 85: gd-control-Anchoring-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79331,7 +80737,9 @@ TEST 85: gd-control-Anchoring-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79377,7 +80785,9 @@ TEST 85: gd-control-Anchoring-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79423,7 +80833,9 @@ TEST 85: gd-control-Anchoring-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79469,7 +80881,9 @@ TEST 85: gd-control-Anchoring-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79515,7 +80929,9 @@ TEST 85: gd-control-Anchoring-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79561,7 +80977,9 @@ TEST 85: gd-control-Anchoring-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79607,7 +81025,9 @@ TEST 85: gd-control-Anchoring-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79862,7 +81282,9 @@ TEST 86: gd-control-Anchoring-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79908,7 +81330,9 @@ TEST 86: gd-control-Anchoring-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -79954,7 +81378,9 @@ TEST 86: gd-control-Anchoring-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -80176,7 +81602,9 @@ TEST 86: gd-control-Anchoring-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.0)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 x
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -80222,7 +81650,9 @@ TEST 86: gd-control-Anchoring-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+2.05)x5.28, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 y
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -80268,7 +81698,9 @@ TEST 86: gd-control-Anchoring-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.31+0.0)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 z
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -80678,7 +82110,9 @@ TEST 87: gd-control-Anchoring-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -80724,7 +82158,9 @@ TEST 87: gd-control-Anchoring-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -80770,7 +82206,9 @@ TEST 87: gd-control-Anchoring-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -80816,7 +82254,9 @@ TEST 87: gd-control-Anchoring-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -81212,7 +82652,9 @@ TEST 88: gd-control-Anchoring-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -81258,7 +82700,9 @@ TEST 88: gd-control-Anchoring-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -81304,7 +82748,9 @@ TEST 88: gd-control-Anchoring-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -81350,7 +82796,9 @@ TEST 88: gd-control-Anchoring-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -81744,7 +83192,9 @@ TEST 89: gd-control-Anchoring-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -81790,7 +83240,9 @@ TEST 89: gd-control-Anchoring-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -81836,7 +83288,9 @@ TEST 89: gd-control-Anchoring-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -81882,7 +83336,9 @@ TEST 89: gd-control-Anchoring-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -82425,7 +83881,9 @@ TEST 90: gd-control-Orientation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -82471,7 +83929,9 @@ TEST 90: gd-control-Orientation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -82517,7 +83977,9 @@ TEST 90: gd-control-Orientation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -82563,7 +84025,9 @@ TEST 90: gd-control-Orientation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -82609,7 +84073,9 @@ TEST 90: gd-control-Orientation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -82655,7 +84121,9 @@ TEST 90: gd-control-Orientation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -82701,7 +84169,9 @@ TEST 90: gd-control-Orientation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -82747,7 +84217,9 @@ TEST 90: gd-control-Orientation-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -83291,7 +84763,9 @@ TEST 91: gd-control-Orientation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -83337,7 +84811,9 @@ TEST 91: gd-control-Orientation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -83383,7 +84859,9 @@ TEST 91: gd-control-Orientation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -83429,7 +84907,9 @@ TEST 91: gd-control-Orientation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -83475,7 +84955,9 @@ TEST 91: gd-control-Orientation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -83521,7 +85003,9 @@ TEST 91: gd-control-Orientation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -83567,7 +85051,9 @@ TEST 91: gd-control-Orientation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -83613,7 +85099,9 @@ TEST 91: gd-control-Orientation-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -84157,7 +85645,9 @@ TEST 92: gd-control-Orientation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -84203,7 +85693,9 @@ TEST 92: gd-control-Orientation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -84249,7 +85741,9 @@ TEST 92: gd-control-Orientation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -84295,7 +85789,9 @@ TEST 92: gd-control-Orientation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -84341,7 +85837,9 @@ TEST 92: gd-control-Orientation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -84387,7 +85885,9 @@ TEST 92: gd-control-Orientation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -84433,7 +85933,9 @@ TEST 92: gd-control-Orientation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -84479,7 +85981,9 @@ TEST 92: gd-control-Orientation-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85073,7 +86577,9 @@ TEST 93: gd-control-Orientation-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85119,7 +86625,9 @@ TEST 93: gd-control-Orientation-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85165,7 +86673,9 @@ TEST 93: gd-control-Orientation-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85211,7 +86721,9 @@ TEST 93: gd-control-Orientation-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85257,7 +86769,9 @@ TEST 93: gd-control-Orientation-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85303,7 +86817,9 @@ TEST 93: gd-control-Orientation-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85349,7 +86865,9 @@ TEST 93: gd-control-Orientation-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85395,7 +86913,9 @@ TEST 93: gd-control-Orientation-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -85989,7 +87509,9 @@ TEST 94: gd-control-Orientation-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86035,7 +87557,9 @@ TEST 94: gd-control-Orientation-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86081,7 +87605,9 @@ TEST 94: gd-control-Orientation-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86127,7 +87653,9 @@ TEST 94: gd-control-Orientation-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86173,7 +87701,9 @@ TEST 94: gd-control-Orientation-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86219,7 +87749,9 @@ TEST 94: gd-control-Orientation-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86265,7 +87797,9 @@ TEST 94: gd-control-Orientation-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86311,7 +87845,9 @@ TEST 94: gd-control-Orientation-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86905,7 +88441,9 @@ TEST 95: gd-control-Orientation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86951,7 +88489,9 @@ TEST 95: gd-control-Orientation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -86997,7 +88537,9 @@ TEST 95: gd-control-Orientation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87043,7 +88585,9 @@ TEST 95: gd-control-Orientation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87089,7 +88633,9 @@ TEST 95: gd-control-Orientation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87135,7 +88681,9 @@ TEST 95: gd-control-Orientation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87181,7 +88729,9 @@ TEST 95: gd-control-Orientation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87227,7 +88777,9 @@ TEST 95: gd-control-Orientation-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87505,7 +89057,9 @@ TEST 96: gd-control-Orientation-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87551,7 +89105,9 @@ TEST 96: gd-control-Orientation-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87597,7 +89153,9 @@ TEST 96: gd-control-Orientation-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87864,7 +89422,9 @@ TEST 96: gd-control-Orientation-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87910,7 +89470,9 @@ TEST 96: gd-control-Orientation-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -87956,7 +89518,9 @@ TEST 96: gd-control-Orientation-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -88234,7 +89798,9 @@ TEST 97: gd-control-Orientation-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -88280,7 +89846,9 @@ TEST 97: gd-control-Orientation-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -88326,7 +89894,9 @@ TEST 97: gd-control-Orientation-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -88593,7 +90163,9 @@ TEST 97: gd-control-Orientation-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -88639,7 +90211,9 @@ TEST 97: gd-control-Orientation-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -88685,7 +90259,9 @@ TEST 97: gd-control-Orientation-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -88963,7 +90539,9 @@ TEST 98: gd-control-Orientation-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -89009,7 +90587,9 @@ TEST 98: gd-control-Orientation-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -89055,7 +90635,9 @@ TEST 98: gd-control-Orientation-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -89322,7 +90904,9 @@ TEST 98: gd-control-Orientation-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -89368,7 +90952,9 @@ TEST 98: gd-control-Orientation-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -89414,7 +91000,9 @@ TEST 98: gd-control-Orientation-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90012,7 +91600,9 @@ TEST 99: gd-control-Orientation-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90058,7 +91648,9 @@ TEST 99: gd-control-Orientation-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90104,7 +91696,9 @@ TEST 99: gd-control-Orientation-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90150,7 +91744,9 @@ TEST 99: gd-control-Orientation-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90196,7 +91792,9 @@ TEST 99: gd-control-Orientation-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90242,7 +91840,9 @@ TEST 99: gd-control-Orientation-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90288,7 +91888,9 @@ TEST 99: gd-control-Orientation-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90334,7 +91936,9 @@ TEST 99: gd-control-Orientation-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90932,7 +92536,9 @@ TEST 100: gd-control-Orientation-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -90978,7 +92584,9 @@ TEST 100: gd-control-Orientation-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -91024,7 +92632,9 @@ TEST 100: gd-control-Orientation-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -91070,7 +92680,9 @@ TEST 100: gd-control-Orientation-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -91116,7 +92728,9 @@ TEST 100: gd-control-Orientation-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -91162,7 +92776,9 @@ TEST 100: gd-control-Orientation-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -91208,7 +92824,9 @@ TEST 100: gd-control-Orientation-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -91254,7 +92872,9 @@ TEST 100: gd-control-Orientation-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92038,7 +93658,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92084,7 +93706,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92130,7 +93754,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92176,7 +93802,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92222,7 +93850,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92268,7 +93898,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92314,7 +93946,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92360,7 +93994,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -92406,7 +94042,9 @@ TEST 101: gd-control-Orientation-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.57+0.0)x2.78, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 i
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93004,7 +94642,9 @@ TEST 102: gd-control-Orientation-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93050,7 +94690,9 @@ TEST 102: gd-control-Orientation-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93096,7 +94738,9 @@ TEST 102: gd-control-Orientation-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93142,7 +94786,9 @@ TEST 102: gd-control-Orientation-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93188,7 +94834,9 @@ TEST 102: gd-control-Orientation-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93234,7 +94882,9 @@ TEST 102: gd-control-Orientation-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93280,7 +94930,9 @@ TEST 102: gd-control-Orientation-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93326,7 +94978,9 @@ TEST 102: gd-control-Orientation-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.0)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 h
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93764,7 +95418,9 @@ TEST 103: gd-control-FineTune-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93812,7 +95468,9 @@ TEST 103: gd-control-FineTune-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93860,7 +95518,9 @@ TEST 103: gd-control-FineTune-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93908,7 +95568,9 @@ TEST 103: gd-control-FineTune-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -93956,7 +95618,9 @@ TEST 103: gd-control-FineTune-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -94392,7 +96056,9 @@ TEST 104: gd-control-FineTune-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -94440,7 +96106,9 @@ TEST 104: gd-control-FineTune-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -94488,7 +96156,9 @@ TEST 104: gd-control-FineTune-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -94536,7 +96206,9 @@ TEST 104: gd-control-FineTune-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -94584,7 +96256,9 @@ TEST 104: gd-control-FineTune-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95020,7 +96694,9 @@ TEST 105: gd-control-FineTune-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95068,7 +96744,9 @@ TEST 105: gd-control-FineTune-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95116,7 +96794,9 @@ TEST 105: gd-control-FineTune-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95164,7 +96844,9 @@ TEST 105: gd-control-FineTune-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95212,7 +96894,9 @@ TEST 105: gd-control-FineTune-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95650,7 +97334,9 @@ TEST 106: gd-control-FineTune-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95698,7 +97384,9 @@ TEST 106: gd-control-FineTune-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95746,7 +97434,9 @@ TEST 106: gd-control-FineTune-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95794,7 +97484,9 @@ TEST 106: gd-control-FineTune-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -95842,7 +97534,9 @@ TEST 106: gd-control-FineTune-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -96282,7 +97976,9 @@ TEST 107: gd-control-FineTune-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -96330,7 +98026,9 @@ TEST 107: gd-control-FineTune-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -96378,7 +98076,9 @@ TEST 107: gd-control-FineTune-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -96426,7 +98126,9 @@ TEST 107: gd-control-FineTune-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -96474,7 +98176,9 @@ TEST 107: gd-control-FineTune-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -96995,7 +98699,9 @@ TEST 108: gd-control-Components-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97041,7 +98747,9 @@ TEST 108: gd-control-Components-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97087,7 +98795,9 @@ TEST 108: gd-control-Components-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97133,7 +98843,9 @@ TEST 108: gd-control-Components-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97179,7 +98891,9 @@ TEST 108: gd-control-Components-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97225,7 +98939,9 @@ TEST 108: gd-control-Components-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97271,7 +98987,9 @@ TEST 108: gd-control-Components-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97792,7 +99510,9 @@ TEST 109: gd-control-Components-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97838,7 +99558,9 @@ TEST 109: gd-control-Components-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97884,7 +99606,9 @@ TEST 109: gd-control-Components-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97930,7 +99654,9 @@ TEST 109: gd-control-Components-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -97976,7 +99702,9 @@ TEST 109: gd-control-Components-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98022,7 +99750,9 @@ TEST 109: gd-control-Components-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98068,7 +99798,9 @@ TEST 109: gd-control-Components-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98421,7 +100153,9 @@ TEST 110: gd-control-ComponentOrder-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98473,7 +100207,9 @@ TEST 110: gd-control-ComponentOrder-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98525,7 +100261,9 @@ TEST 110: gd-control-ComponentOrder-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98577,7 +100315,9 @@ TEST 110: gd-control-ComponentOrder-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98629,7 +100369,9 @@ TEST 110: gd-control-ComponentOrder-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98681,7 +100423,9 @@ TEST 110: gd-control-ComponentOrder-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -98733,7 +100477,9 @@ TEST 110: gd-control-ComponentOrder-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99075,7 +100821,9 @@ TEST 111: gd-control-ComponentOrder-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99127,7 +100875,9 @@ TEST 111: gd-control-ComponentOrder-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99179,7 +100929,9 @@ TEST 111: gd-control-ComponentOrder-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99231,7 +100983,9 @@ TEST 111: gd-control-ComponentOrder-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99283,7 +101037,9 @@ TEST 111: gd-control-ComponentOrder-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99335,7 +101091,9 @@ TEST 111: gd-control-ComponentOrder-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99387,7 +101145,9 @@ TEST 111: gd-control-ComponentOrder-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99729,7 +101489,9 @@ TEST 112: gd-control-ComponentOrder-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99781,7 +101543,9 @@ TEST 112: gd-control-ComponentOrder-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99833,7 +101597,9 @@ TEST 112: gd-control-ComponentOrder-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99885,7 +101651,9 @@ TEST 112: gd-control-ComponentOrder-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99937,7 +101705,9 @@ TEST 112: gd-control-ComponentOrder-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -99989,7 +101759,9 @@ TEST 112: gd-control-ComponentOrder-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -100041,7 +101813,9 @@ TEST 112: gd-control-ComponentOrder-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -100383,7 +102157,9 @@ TEST 113: gd-control-ComponentDirection-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -100435,7 +102211,9 @@ TEST 113: gd-control-ComponentDirection-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -100487,7 +102265,9 @@ TEST 113: gd-control-ComponentDirection-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -100539,7 +102319,9 @@ TEST 113: gd-control-ComponentDirection-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -100591,7 +102373,9 @@ TEST 113: gd-control-ComponentDirection-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -100643,7 +102427,9 @@ TEST 113: gd-control-ComponentDirection-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -100695,7 +102481,9 @@ TEST 113: gd-control-ComponentDirection-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101037,7 +102825,9 @@ TEST 114: gd-control-ComponentDirection-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101089,7 +102879,9 @@ TEST 114: gd-control-ComponentDirection-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101141,7 +102933,9 @@ TEST 114: gd-control-ComponentDirection-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101193,7 +102987,9 @@ TEST 114: gd-control-ComponentDirection-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101245,7 +103041,9 @@ TEST 114: gd-control-ComponentDirection-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101297,7 +103095,9 @@ TEST 114: gd-control-ComponentDirection-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101349,7 +103149,9 @@ TEST 114: gd-control-ComponentDirection-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101691,7 +103493,9 @@ TEST 115: gd-control-ComponentDirection-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101743,7 +103547,9 @@ TEST 115: gd-control-ComponentDirection-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101795,7 +103601,9 @@ TEST 115: gd-control-ComponentDirection-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101847,7 +103655,9 @@ TEST 115: gd-control-ComponentDirection-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101899,7 +103709,9 @@ TEST 115: gd-control-ComponentDirection-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -101951,7 +103763,9 @@ TEST 115: gd-control-ComponentDirection-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102003,7 +103817,9 @@ TEST 115: gd-control-ComponentDirection-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.53+2.06)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 g
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102343,7 +104159,9 @@ TEST 116: gd-control-ComponentAlign-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102391,7 +104209,9 @@ TEST 116: gd-control-ComponentAlign-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102439,7 +104259,9 @@ TEST 116: gd-control-ComponentAlign-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102487,7 +104309,9 @@ TEST 116: gd-control-ComponentAlign-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102535,7 +104359,9 @@ TEST 116: gd-control-ComponentAlign-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102583,7 +104409,9 @@ TEST 116: gd-control-ComponentAlign-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102923,7 +104751,9 @@ TEST 117: gd-control-ComponentAlign-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -102971,7 +104801,9 @@ TEST 117: gd-control-ComponentAlign-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103019,7 +104851,9 @@ TEST 117: gd-control-ComponentAlign-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103067,7 +104901,9 @@ TEST 117: gd-control-ComponentAlign-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103115,7 +104951,9 @@ TEST 117: gd-control-ComponentAlign-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103163,7 +105001,9 @@ TEST 117: gd-control-ComponentAlign-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103503,7 +105343,9 @@ TEST 118: gd-control-ComponentAlign-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103551,7 +105393,9 @@ TEST 118: gd-control-ComponentAlign-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103599,7 +105443,9 @@ TEST 118: gd-control-ComponentAlign-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103647,7 +105493,9 @@ TEST 118: gd-control-ComponentAlign-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103695,7 +105543,9 @@ TEST 118: gd-control-ComponentAlign-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -103743,7 +105593,9 @@ TEST 118: gd-control-ComponentAlign-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104083,7 +105935,9 @@ TEST 119: gd-control-ComponentAlign-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104131,7 +105985,9 @@ TEST 119: gd-control-ComponentAlign-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104179,7 +106035,9 @@ TEST 119: gd-control-ComponentAlign-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104227,7 +106085,9 @@ TEST 119: gd-control-ComponentAlign-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104275,7 +106135,9 @@ TEST 119: gd-control-ComponentAlign-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104323,7 +106185,9 @@ TEST 119: gd-control-ComponentAlign-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104663,7 +106527,9 @@ TEST 120: gd-control-ComponentAlign-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104711,7 +106577,9 @@ TEST 120: gd-control-ComponentAlign-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104759,7 +106627,9 @@ TEST 120: gd-control-ComponentAlign-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104807,7 +106677,9 @@ TEST 120: gd-control-ComponentAlign-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104855,7 +106727,9 @@ TEST 120: gd-control-ComponentAlign-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -104903,7 +106777,9 @@ TEST 120: gd-control-ComponentAlign-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105243,7 +107119,9 @@ TEST 121: gd-control-ComponentAlign-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105291,7 +107169,9 @@ TEST 121: gd-control-ComponentAlign-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105339,7 +107219,9 @@ TEST 121: gd-control-ComponentAlign-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105387,7 +107269,9 @@ TEST 121: gd-control-ComponentAlign-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105435,7 +107319,9 @@ TEST 121: gd-control-ComponentAlign-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105483,7 +107369,9 @@ TEST 121: gd-control-ComponentAlign-6
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105823,7 +107711,9 @@ TEST 122: gd-control-ComponentAlign-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105871,7 +107761,9 @@ TEST 122: gd-control-ComponentAlign-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105919,7 +107811,9 @@ TEST 122: gd-control-ComponentAlign-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -105967,7 +107861,9 @@ TEST 122: gd-control-ComponentAlign-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106015,7 +107911,9 @@ TEST 122: gd-control-ComponentAlign-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106063,7 +107961,9 @@ TEST 122: gd-control-ComponentAlign-7
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106403,7 +108303,9 @@ TEST 123: gd-control-ComponentAlign-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106451,7 +108353,9 @@ TEST 123: gd-control-ComponentAlign-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106499,7 +108403,9 @@ TEST 123: gd-control-ComponentAlign-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106547,7 +108453,9 @@ TEST 123: gd-control-ComponentAlign-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106595,7 +108503,9 @@ TEST 123: gd-control-ComponentAlign-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106643,7 +108553,9 @@ TEST 123: gd-control-ComponentAlign-8
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(7.05+0.0)x3.06, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 f
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106851,8 +108763,10 @@ TEST 124: gd-control-ComponentAlign-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x5.0, direction TLT
 ..................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106900,6 +108814,7 @@ TEST 124: gd-control-ComponentAlign-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(18.94+0.11)x20.84, direction TLT
+.................\begindir TLT
 .................\vbox(18.94+0.11)x20.84, direction TLT
 ..................\hbox(6.94+2.06)x20.84, direction TLT
 ...................\glue(\tabskip) 0.0
@@ -106925,6 +108840,7 @@ TEST 124: gd-control-ComponentAlign-9
 ....................\TU/lmr/m/n/10 e
 ....................\glue 0.0 plus 1.0fil
 ...................\glue(\tabskip) 0.0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -106972,8 +108888,10 @@ TEST 124: gd-control-ComponentAlign-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x5.56, direction TLT
 ..................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107170,8 +109088,10 @@ TEST 124: gd-control-ComponentAlign-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x5.0, direction TLT
 ..................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107219,6 +109139,7 @@ TEST 124: gd-control-ComponentAlign-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(18.94+0.11)x20.84, direction TLT
+.................\begindir TLT
 .................\vbox(18.94+0.11)x20.84, direction TLT
 ..................\hbox(6.94+2.06)x20.84, direction TLT
 ...................\glue(\tabskip) 0.0
@@ -107244,6 +109165,7 @@ TEST 124: gd-control-ComponentAlign-9
 ....................\TU/lmr/m/n/10 e
 ....................\glue 0.0 plus 1.0fil
 ...................\glue(\tabskip) 0.0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107291,8 +109213,10 @@ TEST 124: gd-control-ComponentAlign-9
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x5.56, direction TLT
 ..................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107500,8 +109424,10 @@ TEST 125: gd-control-ComponentAlign-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x5.0, direction TLT
 ..................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107549,6 +109475,7 @@ TEST 125: gd-control-ComponentAlign-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(18.94+0.11)x20.84, direction TLT
+.................\begindir TLT
 .................\vbox(18.94+0.11)x20.84, direction TLT
 ..................\hbox(6.94+2.06)x20.84, direction TLT
 ...................\glue(\tabskip) 0.0
@@ -107574,6 +109501,7 @@ TEST 125: gd-control-ComponentAlign-10
 ....................\TU/lmr/m/n/10 e
 ....................\glue 0.0 plus 1.0fil
 ...................\glue(\tabskip) 0.0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107621,8 +109549,10 @@ TEST 125: gd-control-ComponentAlign-10
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x5.56, direction TLT
 ..................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107830,8 +109760,10 @@ TEST 126: gd-control-ComponentAlign-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x5.0, direction TLT
 ..................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107879,6 +109811,7 @@ TEST 126: gd-control-ComponentAlign-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(18.94+0.11)x20.84, direction TLT
+.................\begindir TLT
 .................\vbox(18.94+0.11)x20.84, direction TLT
 ..................\hbox(6.94+2.06)x20.84, direction TLT
 ...................\glue(\tabskip) 0.0
@@ -107904,6 +109837,7 @@ TEST 126: gd-control-ComponentAlign-11
 ....................\TU/lmr/m/n/10 e
 ....................\glue 0.0 plus 1.0fil
 ...................\glue(\tabskip) 0.0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -107951,8 +109885,10 @@ TEST 126: gd-control-ComponentAlign-11
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x5.56, direction TLT
 ..................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -108160,8 +110096,10 @@ TEST 127: gd-control-ComponentAlign-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x5.0, direction TLT
 ..................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -108209,6 +110147,7 @@ TEST 127: gd-control-ComponentAlign-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(18.94+0.11)x20.84, direction TLT
+.................\begindir TLT
 .................\vbox(18.94+0.11)x20.84, direction TLT
 ..................\hbox(6.94+2.06)x20.84, direction TLT
 ...................\glue(\tabskip) 0.0
@@ -108234,6 +110173,7 @@ TEST 127: gd-control-ComponentAlign-12
 ....................\TU/lmr/m/n/10 e
 ....................\glue 0.0 plus 1.0fil
 ...................\glue(\tabskip) 0.0
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -108281,8 +110221,10 @@ TEST 127: gd-control-ComponentAlign-12
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x5.56, direction TLT
 ..................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -108542,8 +110484,10 @@ TEST 128: gd-control-ComponentAlign-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x5.0, direction TLT
 ..................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -108591,12 +110535,14 @@ TEST 128: gd-control-ComponentAlign-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x20.56, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x20.56, direction TLT
 ..................\TU/lmr/m/n/10 h
 ..................\TU/lmr/m/n/10 e
 ..................\TU/lmr/m/n/10 l
 ..................\TU/lmr/m/n/10 l
 ..................\TU/lmr/m/n/10 o
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -108644,6 +110590,7 @@ TEST 128: gd-control-ComponentAlign-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x24.2, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x24.2, direction TLT
 ..................\TU/lmr/m/n/10 w
 ..................\kern-0.28 (font)
@@ -108651,6 +110598,7 @@ TEST 128: gd-control-ComponentAlign-13
 ..................\TU/lmr/m/n/10 r
 ..................\TU/lmr/m/n/10 l
 ..................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -108698,8 +110646,10 @@ TEST 128: gd-control-ComponentAlign-13
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x3.94, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x3.94, direction TLT
 ..................\TU/lmr/m/n/10 s
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -108959,8 +110909,10 @@ TEST 129: gd-control-ComponentAlign-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x5.0, direction TLT
 ..................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109008,12 +110960,14 @@ TEST 129: gd-control-ComponentAlign-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x20.56, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x20.56, direction TLT
 ..................\TU/lmr/m/n/10 h
 ..................\TU/lmr/m/n/10 e
 ..................\TU/lmr/m/n/10 l
 ..................\TU/lmr/m/n/10 l
 ..................\TU/lmr/m/n/10 o
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109061,6 +111015,7 @@ TEST 129: gd-control-ComponentAlign-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x24.2, direction TLT
+.................\begindir TLT
 .................\hbox(6.94+0.11)x24.2, direction TLT
 ..................\TU/lmr/m/n/10 w
 ..................\kern-0.28 (font)
@@ -109068,6 +111023,7 @@ TEST 129: gd-control-ComponentAlign-14
 ..................\TU/lmr/m/n/10 r
 ..................\TU/lmr/m/n/10 l
 ..................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109115,8 +111071,10 @@ TEST 129: gd-control-ComponentAlign-14
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x3.94, direction TLT
+.................\begindir TLT
 .................\hbox(4.48+0.11)x3.94, direction TLT
 ..................\TU/lmr/m/n/10 s
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109374,7 +111332,9 @@ TEST 130: gd-control-ComponentDistance-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109422,6 +111382,7 @@ TEST 130: gd-control-ComponentDistance-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.06)x39.17, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
@@ -109431,6 +111392,7 @@ TEST 130: gd-control-ComponentDistance-1
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 x
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109478,6 +111440,7 @@ TEST 130: gd-control-ComponentDistance-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.06)x47.53, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
@@ -109489,6 +111452,7 @@ TEST 130: gd-control-ComponentDistance-1
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 x
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109536,7 +111500,9 @@ TEST 130: gd-control-ComponentDistance-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109794,7 +111760,9 @@ TEST 131: gd-control-ComponentDistance-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109842,6 +111810,7 @@ TEST 131: gd-control-ComponentDistance-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.06)x39.17, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
@@ -109851,6 +111820,7 @@ TEST 131: gd-control-ComponentDistance-2
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 x
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109898,6 +111868,7 @@ TEST 131: gd-control-ComponentDistance-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.06)x47.53, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
@@ -109909,6 +111880,7 @@ TEST 131: gd-control-ComponentDistance-2
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 x
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -109956,7 +111928,9 @@ TEST 131: gd-control-ComponentDistance-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -110214,7 +112188,9 @@ TEST 132: gd-control-ComponentDistance-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -110262,6 +112238,7 @@ TEST 132: gd-control-ComponentDistance-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.06)x39.17, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
@@ -110271,6 +112248,7 @@ TEST 132: gd-control-ComponentDistance-3
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 x
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -110318,6 +112296,7 @@ TEST 132: gd-control-ComponentDistance-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+2.06)x47.53, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 l
 .................\TU/lmr/m/n/10 o
 .................\TU/lmr/m/n/10 n
@@ -110329,6 +112308,7 @@ TEST 132: gd-control-ComponentDistance-3
 .................\TU/lmr/m/n/10 e
 .................\TU/lmr/m/n/10 x
 .................\TU/lmr/m/n/10 t
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -110376,7 +112356,9 @@ TEST 132: gd-control-ComponentDistance-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -110637,7 +112619,9 @@ TEST 133: gd-control-NodeAnchors-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -110685,7 +112669,9 @@ TEST 133: gd-control-NodeAnchors-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -110733,7 +112719,9 @@ TEST 133: gd-control-NodeAnchors-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -110982,7 +112970,9 @@ TEST 134: gd-control-NodeAnchors-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111030,7 +113020,9 @@ TEST 134: gd-control-NodeAnchors-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111078,7 +113070,9 @@ TEST 134: gd-control-NodeAnchors-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111537,7 +113531,9 @@ TEST 135: gd-control-library-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111588,7 +113584,9 @@ TEST 135: gd-control-library-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111639,7 +113637,9 @@ TEST 135: gd-control-library-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111690,7 +113690,9 @@ TEST 135: gd-control-library-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111741,7 +113743,9 @@ TEST 135: gd-control-library-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111792,7 +113796,9 @@ TEST 135: gd-control-library-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -111843,7 +113849,9 @@ TEST 135: gd-control-library-1
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -112892,7 +114900,9 @@ TEST 136: gd-control-library-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 1
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -112943,7 +114953,9 @@ TEST 136: gd-control-library-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 2
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -112994,7 +115006,9 @@ TEST 136: gd-control-library-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 3
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113045,7 +115059,9 @@ TEST 136: gd-control-library-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.77+0.0)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 4
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113096,7 +115112,9 @@ TEST 136: gd-control-library-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 5
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113147,7 +115165,9 @@ TEST 136: gd-control-library-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.66+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 6
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113198,7 +115218,9 @@ TEST 136: gd-control-library-2
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.76+0.22)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 7
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113631,7 +115653,9 @@ TEST 137: gd-control-library-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113677,7 +115701,9 @@ TEST 137: gd-control-library-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113723,7 +115749,9 @@ TEST 137: gd-control-library-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113769,7 +115797,9 @@ TEST 137: gd-control-library-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -113815,7 +115845,9 @@ TEST 137: gd-control-library-3
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114248,7 +116280,9 @@ TEST 138: gd-control-library-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114294,7 +116328,9 @@ TEST 138: gd-control-library-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114340,7 +116376,9 @@ TEST 138: gd-control-library-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114386,7 +116424,9 @@ TEST 138: gd-control-library-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114432,7 +116472,9 @@ TEST 138: gd-control-library-4
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114794,7 +116836,9 @@ TEST 139: gd-control-library-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x5.0, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 a
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114840,7 +116884,9 @@ TEST 139: gd-control-library-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 b
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114886,7 +116932,9 @@ TEST 139: gd-control-library-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 c
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114932,7 +116980,9 @@ TEST 139: gd-control-library-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(6.94+0.11)x5.56, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 d
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0
@@ -114978,7 +117028,9 @@ TEST 139: gd-control-library-5
 ................\pdfliteral origin{0 G }
 ................\pdfliteral origin{0 g }
 ................\hbox(4.48+0.11)x4.44, direction TLT
+.................\begindir TLT
 .................\TU/lmr/m/n/10 e
+.................\enddir TLT
 ................\glue(\spaceskip) 0.0
 ..............\pdfliteral origin{Q }
 ..............\glue(\spaceskip) 0.0

--- a/testfiles-regression-luatex/tikz-RTL.lvt
+++ b/testfiles-regression-luatex/tikz-RTL.lvt
@@ -1,0 +1,27 @@
+\documentclass{article}
+
+\input{pgf-regression-test}
+\usepackage{tikz,fontspec}
+\setmainfont{DavidCLM}[Script=Hebrew]
+\usetikzlibrary{positioning,backgrounds}
+
+\begin{document}
+
+\START
+
+\textdirection=1
+\pardirection=1
+\noindent
+\BEGINBOXTEST{picture embedded in RTL paragraph}
+\tikzpicture[background rectangle/.style={fill=gray!33}, show background rectangle]
+\node [draw,text width=0.75\hsize, align=left, outer sep=0pt,inner sep=0pt](n1) {%
+לורם איפסום דולור סיט אמט.
+};
+\node [draw,below = 0pt of n1.south east,anchor=north east,outer sep=0pt,inner sep=0pt](n2) {%
+שלום עולם
+};
+\filldraw (n2) circle (1pt);
+\endtikzpicture
+\ENDBOXTEST
+
+\END

--- a/testfiles-regression-luatex/tikz-RTL.tlg
+++ b/testfiles-regression-luatex/tikz-RTL.tlg
@@ -1,0 +1,167 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: picture embedded in RTL paragraph
+============================================================
+> \box...=
+\hbox(23.6583+0.0)x270.66666, direction TRT
+.\glue(\spaceskip) 3.5 plus 1.75 minus 1.16667
+.\hbox(23.6583+0.0)x267.16666, direction TLT
+..\glue 133.58333
+..\hbox(0.0+0.0)x0.0, shifted -15.84164, direction TLT
+...\pdfliteral origin{q }
+...\pdfliteral origin{0 G }
+...\pdfliteral origin{0 g }
+...\pdfliteral origin{0.3985 w }
+...\pdfliteral origin{q }
+...\hbox(0.0+0.0)x0.0, direction TLT
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{q }
+....\pdfliteral origin{0.835 g }
+....\pdfliteral origin{-133.08597 -15.78265 m }
+....\pdfliteral origin{-133.08597 -15.78265 m }
+....\pdfliteral origin{-133.08597 7.78754 l }
+....\pdfliteral origin{133.08597 7.78754 l }
+....\pdfliteral origin{133.08597 -15.78265 l }
+....\pdfliteral origin{h }
+....\pdfliteral origin{133.08597 7.78754 m }
+....\pdfliteral origin{f }
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{Q }
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\pdfliteral origin{Q }
+...\hbox(0.0+0.0)x0.0, direction TLT
+....\pdfliteral origin{q }
+....\glue(\spaceskip) 0.0
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{-128.89331 -3.59488 257.78664 7.18977 re }
+......\pdfliteral origin{S }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{q }
+......\hbox(0.0+0.0)x0.0, direction TLT
+.......\glue -129.375
+.......\hbox(0.0+0.0)x0.0, shifted 3.34999, direction TLT
+........\pdfliteral origin{1.0 0.0 0.0 1.0 0.0 0.0 cm }
+........\pdfliteral origin{q }
+........\hbox(0.0+0.0)x0.0, direction TLT
+.........\hbox(6.95833+0.25833)x258.75, direction TLT
+..........\pdfliteral origin{0 G }
+..........\pdfliteral origin{0 g }
+..........\hbox(6.95833+0.25833)x258.75, direction TLT
+...........\begindir TRT
+...........\vbox(6.95833+0.25833)x258.75, direction TRT
+............\hbox(6.95833+0.25833)x258.75, glue set 142.80978fil, direction TRT
+.............\localpar
+..............\localinterlinepenalty=0
+..............\localbrokenpenalty=0
+..............\localleftbox=null
+..............\localrightbox=null
+.............\hbox(0.0+0.0)x0.0, direction TRT
+.............\hbox(0.0+0.0)x0.0, direction TRT
+.............\TU/DavidCLM(0)/m/n/10 ל
+.............\TU/DavidCLM(0)/m/n/10 ו
+.............\TU/DavidCLM(0)/m/n/10 ר
+.............\TU/DavidCLM(0)/m/n/10 ם
+.............\glue(\spaceskip) 3.33298
+.............\TU/DavidCLM(0)/m/n/10 א
+.............\TU/DavidCLM(0)/m/n/10 י
+.............\TU/DavidCLM(0)/m/n/10 פ
+.............\TU/DavidCLM(0)/m/n/10 ס
+.............\TU/DavidCLM(0)/m/n/10 ו
+.............\TU/DavidCLM(0)/m/n/10 ם
+.............\glue(\spaceskip) 3.33298
+.............\TU/DavidCLM(0)/m/n/10 ד
+.............\TU/DavidCLM(0)/m/n/10 ו
+.............\TU/DavidCLM(0)/m/n/10 ל
+.............\TU/DavidCLM(0)/m/n/10 ו
+.............\TU/DavidCLM(0)/m/n/10 ר
+.............\glue(\spaceskip) 3.33298
+.............\TU/DavidCLM(0)/m/n/10 ס
+.............\TU/DavidCLM(0)/m/n/10 י
+.............\TU/DavidCLM(0)/m/n/10 ט
+.............\glue(\spaceskip) 3.33298
+.............\TU/DavidCLM(0)/m/n/10 א
+.............\TU/DavidCLM(0)/m/n/10 מ
+.............\TU/DavidCLM(0)/m/n/10 ט
+.............\TU/DavidCLM(0)/m/n/10 .
+.............\penalty 10000
+.............\glue(\parfillskip) 0.0 plus 1.0fil
+.............\glue(\rightskip) 0.0 plus 20.0
+...........\enddir TRT
+..........\glue(\spaceskip) 0.0
+........\pdfliteral origin{Q }
+........\glue(\spaceskip) 0.0
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\hbox(0.0+0.0)x0.0, direction TLT
+.....\hbox(0.0+0.0)x0.0, direction TLT
+......\pdfliteral origin{q }
+......\glue(\spaceskip) 0.0
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{87.94635 -11.59 40.94695 7.9951 re }
+......\pdfliteral origin{S }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{q }
+......\hbox(0.0+0.0)x0.0, direction TLT
+.......\glue 88.27502
+.......\hbox(0.0+0.0)x0.0, shifted 10.56665, direction TLT
+........\pdfliteral origin{1.0 0.0 0.0 1.0 0.0 0.0 cm }
+........\pdfliteral origin{q }
+........\hbox(0.0+0.0)x0.0, direction TLT
+.........\hbox(6.95833+1.06667)x41.09998, direction TLT
+..........\pdfliteral origin{0 G }
+..........\pdfliteral origin{0 g }
+..........\hbox(6.95833+1.06667)x41.09998, direction TLT
+...........\begindir TRT
+...........\TU/DavidCLM(0)/m/n/10 ש
+...........\TU/DavidCLM(0)/m/n/10 ל
+...........\TU/DavidCLM(0)/m/n/10 ו
+...........\TU/DavidCLM(0)/m/n/10 ם
+...........\glue(\spaceskip) 3.5 plus 1.75 minus 1.16667
+...........\TU/DavidCLM(0)/m/n/10 ע
+...........\TU/DavidCLM(0)/m/n/10 ו
+...........\TU/DavidCLM(0)/m/n/10 ל
+...........\TU/DavidCLM(0)/m/n/10 ם
+...........\enddir TRT
+..........\glue(\spaceskip) 0.0
+........\pdfliteral origin{Q }
+........\glue(\spaceskip) 0.0
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\pdfliteral origin{Q }
+......\glue(\spaceskip) 0.0
+......\pdfliteral origin{Q }
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{108.41983 -7.59244 m }
+....\pdfliteral origin{109.4161 -7.59244 m }
+....\pdfliteral origin{109.4161 -7.0422 108.97006 -6.59616 108.41983 -6.59616 c }
+....\pdfliteral origin{107.8696 -6.59616 107.42355 -7.0422 107.42355 -7.59244 c }
+....\pdfliteral origin{107.42355 -8.14267 107.8696 -8.58871 108.41983 -8.58871 c }
+....\pdfliteral origin{108.97006 -8.58871 109.4161 -8.14267 109.4161 -7.59244 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{108.41983 -7.59244 m }
+....\pdfliteral origin{B }
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{0.3985 w }
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{Q }
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\pdfliteral origin{n }
+...\pdfliteral origin{Q }
+...\glue 0.0 plus 1.0fil minus 1.0fil
+! OK.
+\ENDBOXTEST ...th =\maxdimen \showbox \PGFTESTBOX 
+                                                  \endgroup \ENDTEST 
+l. ...\ENDBOXTEST
+============================================================

--- a/testfiles-regression/gh-1205.luatex.tlg
+++ b/testfiles-regression/gh-1205.luatex.tlg
@@ -171,6 +171,8 @@ TEST 1: gh-1205-old
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0
@@ -371,6 +373,8 @@ TEST 2: gh-1205-new
 ..........\pdfliteral origin{0 G }
 ..........\pdfliteral origin{0 g }
 ..........\hbox(0.0+0.0)x0.0, direction TLT
+...........\begindir TLT
+...........\enddir TLT
 ..........\glue(\spaceskip) 0.0
 ........\pdfliteral origin{Q }
 ........\glue(\spaceskip) 0.0

--- a/testfiles-regression/gh-666-tikz.luatex.tlg
+++ b/testfiles-regression/gh-666-tikz.luatex.tlg
@@ -57,7 +57,9 @@ TEST 1: tikz: matrix
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.48+0.11)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 a
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -110,7 +112,9 @@ TEST 1: tikz: matrix
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(6.83+0.0)x7.5, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 X
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0
@@ -163,7 +167,9 @@ TEST 1: tikz: matrix
 ....................\pdfliteral origin{0 G }
 ....................\pdfliteral origin{0 g }
 ....................\hbox(4.53+2.06)x5.0, direction TLT
+.....................\begindir TLT
 .....................\TU/lmr/m/n/10 g
+.....................\enddir TLT
 ....................\glue(\spaceskip) 0.0
 ..................\pdfliteral origin{Q }
 ..................\glue(\spaceskip) 0.0

--- a/tex/generic/pgf/basiclayer/pgfcorescopes.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcorescopes.code.tex
@@ -225,7 +225,8 @@
   \pgf@picture}
 
 \def\pgf@picture{%
-  \setbox\pgfpic\hbox to0pt\bgroup%
+  \pgfsys@savedirections%
+  \setbox\pgfpic\pgfsys@ltrhbox to0pt\bgroup%
     \begingroup%
     \pgfsys@beginpicture%
       \pgfsys@beginscope%
@@ -756,6 +757,7 @@
         \pgfpicturefalse%
         \let\pgf@positionnodelater@macro\relax%
         \pgf@savelayers%
+        \pgfsys@restoredirections%
 }
 \def\endpgfinterruptpicture
 {%

--- a/tex/generic/pgf/systemlayer/pgfsys-luatex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-luatex.def
@@ -399,8 +399,30 @@
     \pdfextension literal{\csname\string\color@#1\endcsname}%
 }
 
-\endinput
+%
+% Directions
+%
 
+\ifnum\luatexversion<200
+  \def\pgfsys@ltrhbox{\hbox bdir 0}
+  \def\pgfsys@savedirections{%
+    \edef\pgfsys@restoredirections{%
+      \textdirection=\the\textdirection\relax
+      \pardirection=\the\pardirection\relax
+      \bodydirection=\the\bodydirection\relax
+    }%
+  }
+\else
+  \def\pgfsys@ltrhbox{\hbox direction 0}
+  \def\pgfsys@savedirections{%
+    \edef\pgfsys@restoredirections{%
+      \textdirection=\the\textdirection\relax
+      \pardirection=\the\pardirection\relax
+    }%
+  }
+\fi
+
+\endinput
 
 %%% Local Variables:
 %%% mode: latex

--- a/tex/generic/pgf/systemlayer/pgfsys-luatex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-luatex.def
@@ -81,16 +81,11 @@
   \edef\pgf@mask{/SMask \the\lastsavedimageresourceindex\space 0 R}%
 }
 
-\ifnum\luatexversion<200
-  \def\pgfsys@TLT{dir TLT}%
-\else
-  \def\pgfsys@TLT{direction 0}%
-\fi
 \def\pgfsys@horishading#1#2#3{%
   {%
     \pgf@parsefunc{#3}%
     \pgfmathparse{#2}%
-    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgf@max{\vbox to\pgfmathresult pt{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\pgfsys@ltrhbox to\pgf@max{\vbox to\pgfmathresult pt{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{\pgfpoint{\pgf@max}{#2}}%
     \immediate\saveboxresource resources {%
       /Shading << /Sh << /ShadingType 2
@@ -107,7 +102,7 @@
   {%
     \pgf@parsefunc{#3}%
     \pgfmathparse{#2}%
-    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgfmathresult pt{\vbox to\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\pgfsys@ltrhbox to\pgfmathresult pt{\vbox to\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{\pgfpoint{#2}{\pgf@max}}%
     \immediate\saveboxresource resources {%
       /Shading << /Sh << /ShadingType 2
@@ -123,7 +118,7 @@
 \def\pgfsys@radialshading#1#2#3{%
   {%
     \pgf@parsefunc{#3}%
-    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to2\pgf@max{\vbox to2\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\pgfsys@ltrhbox to2\pgf@max{\vbox to2\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{#2}%
     \pgf@xa=\pgf@x%
     \pgf@ya=\pgf@y%
@@ -155,7 +150,7 @@
     \pgf@yb=\pgf@y%
     \advance\pgf@x by-\pgf@xa%
     \advance\pgf@y by-\pgf@ya%
-    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgf@x{\vbox to\pgf@y{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\pgfsys@ltrhbox to\pgf@x{\vbox to\pgf@y{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@sys@bp@correct{\pgf@xa}%
     \pgf@sys@bp@correct{\pgf@ya}%
     \pgf@sys@bp@correct{\pgf@xb}%
@@ -399,8 +394,30 @@
     \pdfextension literal{\csname\string\color@#1\endcsname}%
 }
 
-\endinput
+%
+% Directions
+%
 
+\ifnum\luatexversion<200
+  \def\pgfsys@ltrhbox{\hbox bdir 0}
+  \def\pgfsys@savedirections{%
+    \edef\pgfsys@restoredirections{%
+      \textdirection=\the\textdirection\relax
+      \pardirection=\the\pardirection\relax
+      \bodydirection=\the\bodydirection\relax
+    }%
+  }
+\else
+  \def\pgfsys@ltrhbox{\hbox direction 0}
+  \def\pgfsys@savedirections{%
+    \edef\pgfsys@restoredirections{%
+      \textdirection=\the\textdirection\relax
+      \pardirection=\the\pardirection\relax
+    }%
+  }
+\fi
+
+\endinput
 
 %%% Local Variables:
 %%% mode: latex

--- a/tex/generic/pgf/systemlayer/pgfsys-luatex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-luatex.def
@@ -81,16 +81,11 @@
   \edef\pgf@mask{/SMask \the\lastsavedimageresourceindex\space 0 R}%
 }
 
-\ifnum\luatexversion<200
-  \def\pgfsys@TLT{dir TLT}%
-\else
-  \def\pgfsys@TLT{direction 0}%
-\fi
 \def\pgfsys@horishading#1#2#3{%
   {%
     \pgf@parsefunc{#3}%
     \pgfmathparse{#2}%
-    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgf@max{\vbox to\pgfmathresult pt{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\pgfsys@ltrhbox to\pgf@max{\vbox to\pgfmathresult pt{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{\pgfpoint{\pgf@max}{#2}}%
     \immediate\saveboxresource resources {%
       /Shading << /Sh << /ShadingType 2
@@ -107,7 +102,7 @@
   {%
     \pgf@parsefunc{#3}%
     \pgfmathparse{#2}%
-    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgfmathresult pt{\vbox to\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\pgfsys@ltrhbox to\pgfmathresult pt{\vbox to\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{\pgfpoint{#2}{\pgf@max}}%
     \immediate\saveboxresource resources {%
       /Shading << /Sh << /ShadingType 2
@@ -123,7 +118,7 @@
 \def\pgfsys@radialshading#1#2#3{%
   {%
     \pgf@parsefunc{#3}%
-    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to2\pgf@max{\vbox to2\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\pgfsys@ltrhbox to2\pgf@max{\vbox to2\pgf@max{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@process{#2}%
     \pgf@xa=\pgf@x%
     \pgf@ya=\pgf@y%
@@ -155,7 +150,7 @@
     \pgf@yb=\pgf@y%
     \advance\pgf@x by-\pgf@xa%
     \advance\pgf@y by-\pgf@ya%
-    \setbox\pgfutil@tempboxa=\hbox \pgfsys@TLT to\pgf@x{\vbox to\pgf@y{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
+    \setbox\pgfutil@tempboxa=\pgfsys@ltrhbox to\pgf@x{\vbox to\pgf@y{\vfil\pgfsys@invoke{/Sh sh}}\hfil}%
     \pgf@sys@bp@correct{\pgf@xa}%
     \pgf@sys@bp@correct{\pgf@ya}%
     \pgf@sys@bp@correct{\pgf@xb}%

--- a/tex/generic/pgf/systemlayer/pgfsys.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsys.code.tex
@@ -1567,6 +1567,11 @@
 \def\pgfsys@endpicture{}
 % Called at the end of a pgfpicture.
 
+\def\pgfsys@ltrhbox{\hbox}
+\def\pgfsys@savedirections{}
+\def\pgfsys@restoredirections{}
+% Used to support directions
+
 \def\pgfsys@typesetpicturebox#1{%
   \pgf@ya=\pgf@shift@baseline\relax%
   \advance\pgf@ya by-\pgf@picminy\relax%
@@ -1574,7 +1579,7 @@
   %
   \advance\pgf@picmaxy by-\pgf@picminy\relax% maxy is now the height
   \advance\pgf@picmaxx by-\pgf@picminx\relax% maxx is now the width
-  \setbox#1=\hbox{\hskip-\pgf@picminx\lower\pgf@picminy\box#1}%
+  \setbox#1=\pgfsys@ltrhbox{\hskip-\pgf@picminx\lower\pgf@picminy\box#1}%
   \ht#1=\pgf@picmaxy%
   \wd#1=\pgf@picmaxx%
   \dp#1=0pt%

--- a/tex/generic/pgf/systemlayer/pgfsys.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsys.code.tex
@@ -1567,7 +1567,7 @@
 \def\pgfsys@endpicture{}
 % Called at the end of a pgfpicture.
 
-\let\pgfsys@ltrhbox\hbox
+\def\pgfsys@ltrhbox{\hbox}
 \def\pgfsys@savedirections{}
 \def\pgfsys@restoredirections{}
 % Used to support directions

--- a/tex/generic/pgf/systemlayer/pgfsys.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsys.code.tex
@@ -1567,6 +1567,11 @@
 \def\pgfsys@endpicture{}
 % Called at the end of a pgfpicture.
 
+\let\pgfsys@ltrhbox\hbox
+\def\pgfsys@savedirections{}
+\def\pgfsys@restoredirections{}
+% Used to support directions
+
 \def\pgfsys@typesetpicturebox#1{%
   \pgf@ya=\pgf@shift@baseline\relax%
   \advance\pgf@ya by-\pgf@picminy\relax%
@@ -1574,7 +1579,7 @@
   %
   \advance\pgf@picmaxy by-\pgf@picminy\relax% maxy is now the height
   \advance\pgf@picmaxx by-\pgf@picminx\relax% maxx is now the width
-  \setbox#1=\hbox{\hskip-\pgf@picminx\lower\pgf@picminy\box#1}%
+  \setbox#1=\pgfsys@ltrhbox{\hskip-\pgf@picminx\lower\pgf@picminy\box#1}%
   \ht#1=\pgf@picmaxy%
   \wd#1=\pgf@picmaxx%
   \dp#1=0pt%


### PR DESCRIPTION
It addresses problems as described in
https://tex.stackexchange.com/questions/725922/tcolorbox-gets-cut-off-when-using-hebrew-with-babel and https://tex.stackexchange.com/questions/679730/tikz-sweeps-location-of-text-inside-node-with-hebrew

With this commit the patches babel does (with layout=graphics) are not needed.

<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

Supporting directions in LuaTeX
(not only with babel).

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
