### PR TITLE
Optimize path decoration with redundancy check

### DIFF
--- a/tex/generic/pgf/modules/pgfmoduledecorations.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduledecorations.code.tex
@@ -637,6 +637,12 @@
   \pgfgetpath\pgfdecoratedpath%
   \pgfsetpath\pgfdecorateexistingpath%
   %
+  % Restore the last path coordinates for the automaton's
+  % redundancy check.
+  %
+  \pgf@process{\pgfpoint@decorate@existingpathlast}
+  \global\pgf@path@lastx=\pgf@x
+  \global\pgf@path@lasty=\pgf@y
   \ifx\pgfdecoratedpath\pgfutil@empty%
     \pgferror{I cannot decorate an empty path}%
   \else%
@@ -1238,7 +1244,19 @@
   \pgf@decorate@is@closepath@false%
   \pgf@decorate@currentinputsegmentobject%
   \ifx\pgfdecorationcurrentinputsegment\pgfdecorationinputsegmentmoveto%
-    \pgfpathmoveto{\pgf@decorate@inputsegment@first}%
+    %
+    % Avoid a \pgfpathmoveto if we are already in the exact same
+    % coordinate.
+    %
+    \pgf@process{\pgf@decorate@inputsegment@first}
+    \ifdim\pgf@x=\pgf@path@lastx\relax%
+      \ifdim\pgf@y=\pgf@path@lasty\relax%
+      \else%
+        \pgfpathmoveto{\pgf@decorate@inputsegment@first}%
+      \fi%
+    \else%
+      \pgfpathmoveto{\pgf@decorate@inputsegment@first}%
+    \fi%
     \let\pgfdecorationpreviousinputsegment\pgfdecorationcurrentinputsegment%
     \let\pgf@decorate@currentinputsegmentobject\pgf@decorate@nextinputsegmentobject%
     \pgf@decorate@getnextinputsegmentobject\pgf@decorate@nextinputsegmentobject%


### PR DESCRIPTION
Instruct the decoration automaton to drop any moveto that is purely redundant by updating `\pgf@path@last...` to `\pgfpoint@decorate@existingpathlast` and evaluates the x and y coordinates against `\pgf@path@last...` counterparts to suppress unnecessary moveto operations.

<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**
First reported in https://tex.stackexchange.com/q/761240/399147, nested decorations in the `decorate` subpath disconnect them from the rest of the path. The effect is most visible with `--cycle`.

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html