### PR TITLE
Switch to braced \input syntax

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - PGF/TikZ now requires support for the braced `\input{...}` syntax, i.e. TeX
   built with Web2C 2020 or newer.
+- When using LaTeX the internal functions `\pgfutil@IfFileExists` and
+  `\pgfutil@InputIfFileExists` are now aliases to their counterparts from the
+  LaTeX format. This could potentially change the precedence in file lookup.
+
 ### Fixed
 
 - Resolve parsing ambiguity in general shadow #1435
@@ -25,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Comprehenive testsuite generated from the examples in the manual #666
 - Documentation of `\pgfkeysifassignable` #1423
 - Add a new monotonic interpolation plot handler #1358
 - The keys `actualtext`, `alt`, and `artifact` are now pre-defined as no-ops for usage in tagging #1370

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### BREAKING CHANGES
+
+- PGF/TikZ now requires support for the braced `\input{...}` syntax, i.e. TeX
+  built with Web2C 2020 or newer.
 ### Fixed
 
 - Resolve parsing ambiguity in general shadow #1435

--- a/doc/generic/pgf/pgfmanual-en-base-design.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-design.tex
@@ -39,7 +39,7 @@ provides the most basic commands, and several \emph{modules} like commands for
 plotting (in the |plot| module). Modules are loaded using the |\usepgfmodule|
 command.
 
-If you say |\usepackage{pgf}| or |\input pgf.tex| or |\usemodule[pgf]|, the
+If you say |\usepackage{pgf}| or |\input{pgf.tex}| or |\usemodule[pgf]|, the
 |plot| and |shapes| modules are preloaded (as well as the core and the system
 layer).
 

--- a/doc/generic/pgf/pgfmanual-en-base-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-external.tex
@@ -258,7 +258,7 @@ there is a better way: You input the file |pgfexternal.tex|.
     for |\endpgfgraphicnamed|, it is not necessary to actually include the
     packages necessary for \emph{creating} the graphics. So the idea is that
     you comment out things like |\usepackage{tikz}| and instead say
-    |\input pgfexternal.tex|.
+    |\input{pgfexternal.tex}|.
 
     Indeed, the contents of this file is simply the following line:
     %
@@ -266,7 +266,7 @@ there is a better way: You input the file |pgfexternal.tex|.
 \long\def\beginpgfgraphicnamed#1#2\endpgfgraphicnamed{\includegraphics{#1}}
 \end{codeexample}
 
-    Instead of |\input pgfexternal.tex| you could also include this line in
+    Instead of |\input{pgfexternal.tex}| you could also include this line in
     your main file.
 \end{filedescription}
 
@@ -279,8 +279,8 @@ the baseline information is stored into a separate file. This file is named
 
 So, if you need baseline information, you will have to keep the external
 graphic file together with its~|.dpth| file. Furthermore, the short command in
-|\input pgfexternal.tex| is no longer enough because it ignores any baseline
-information. You will need to use |\input pgfexternalwithdepth.tex| instead (it
+|\input{pgfexternal.tex}| is no longer enough because it ignores any baseline
+information. You will need to use |\input{pgfexternalwithdepth.tex}| instead (it
 is shown below). It is slightly longer, but it can be used in the same way as
 |pgfexternal.tex|.
 
@@ -405,7 +405,7 @@ Thus, we modify the main file |survey.tex| as follows:
 \documentclass{article}
 
 \usepackage{graphics}
-\input pgfexternal.tex
+\input{pgfexternal.tex}
 % \usepackage{tikz}
 % \pgfrealjobname{survey}
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-design.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-design.tex
@@ -13,7 +13,7 @@
 This section describes the design principles behind the \tikzname\ frontend,
 where \tikzname\ means ``\tikzname\ ist \emph{kein} Zeichenprogramm''. To use
 \tikzname, as a \LaTeX\ user say |\usepackage{tikz}| somewhere in the preamble,
-as a plain \TeX\ user say |\input tikz.tex|. \tikzname's job is to make your
+as a plain \TeX\ user say |\input{tikz.tex}|. \tikzname's job is to make your
 life easier by providing an easy-to-learn and easy-to-use syntax for describing
 graphics.
 

--- a/doc/generic/pgf/pgfmanual-en-tutorial-Euclid.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial-Euclid.tex
@@ -119,7 +119,7 @@ following in the preamble:
 
 \begin{codeexample}[code only]
 % For plain TeX:
-\input tikz.tex
+\input{tikz.tex}
 \usetikzlibrary{calc,intersections,through,backgrounds}
 \end{codeexample}
 

--- a/doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
@@ -157,7 +157,7 @@ When using plain \TeX\ use:
 %
 \begin{codeexample}[code only]
 %% Plain TeX file
-\input tikz.tex
+\input{tikz.tex}
 \usetikzlibrary{arrows.meta,decorations.pathmorphing,backgrounds,positioning,fit,petri}
 \baselineskip=12pt
 \hsize=6.3truein

--- a/doc/generic/pgf/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial.tex
@@ -182,14 +182,14 @@ enough space to encompass the picture.
 Karl's wife Gerda, who also happens to be a math teacher, is not a \LaTeX\
 user, but uses plain \TeX\ since she prefers to do things ``the old way''. She
 can also use \tikzname. Instead of |\usepackage{tikz}| she has to write
-|\input tikz.tex| and instead of |\begin{tikzpicture}| she writes
+|\input{tikz.tex}| and instead of |\begin{tikzpicture}| she writes
 |\tikzpicture| and instead of |\end{tikzpicture}| she writes |\endtikzpicture|.
 
 Thus, she would use:
 %
 \begin{codeexample}[code only]
 %% Plain TeX file
-\input tikz.tex
+\input{tikz.tex}
 \baselineskip=12pt
 \hsize=6.3truein
 \vsize=8.7truein

--- a/source/generic/pgf/testsuite/external/tikzexternaltest.tex
+++ b/source/generic/pgf/testsuite/external/tikzexternaltest.tex
@@ -1,4 +1,4 @@
-\input tikzexternaltest.sharedpreamble.tex
+\input{tikzexternaltest.sharedpreamble.tex}
 
 \tikzexternalize{tikzexternaltest}
 

--- a/source/generic/pgf/testsuite/external/tikzexternaltestmakefile.tex
+++ b/source/generic/pgf/testsuite/external/tikzexternaltestmakefile.tex
@@ -1,4 +1,4 @@
-\input tikzexternaltest.sharedpreamble.tex
+\input{tikzexternaltest.sharedpreamble.tex}
 
 \tikzexternalize[mode=list and make]
 

--- a/support/pgf-regression-test.tex
+++ b/support/pgf-regression-test.tex
@@ -1,4 +1,4 @@
-\input regression-test.tex
+\input{regression-test.tex}
 
 \OMIT
 \catcode`\@=11\relax

--- a/testfiles-regression-luatex/support/pgfgd-regression-test.tex
+++ b/testfiles-regression-luatex/support/pgfgd-regression-test.tex
@@ -1,4 +1,4 @@
-\input regression-test.tex
+\input{regression-test.tex}
 
 \ifdefined\directlua
   \AtBeginDocument{\directlua{dofile('pgfgd-debug.lua')}}

--- a/tex/context/third/pgf/basiclayer/t-pgf.tex
+++ b/tex/context/third/pgf/basiclayer/t-pgf.tex
@@ -19,13 +19,13 @@
 \ifx\pgfdefined\undefined
 \let\pgfdefined=\relax
 
-\input t-pgfcor.tex
+\input{t-pgfcor.tex}
 
 \usepgfmodule[shapes,plot]
 
-%\input t-pgfbsn.tex
-%\input t-pgfbde.tex
-%\input t-pgfbma.tex
+%\input{t-pgfbsn.tex}
+%\input{t-pgfbde.tex}
+%\input{t-pgfbma.tex}
 
 \fi
 

--- a/tex/context/third/pgf/basiclayer/t-pgfcor.tex
+++ b/tex/context/third/pgf/basiclayer/t-pgfcor.tex
@@ -19,7 +19,7 @@
 \ifx\pgfcoredefined\undefined
 \let\pgfcoredefined=\relax
 
-\input t-pgfsys.tex
+\input{t-pgfsys.tex}
 
 \edef\pgfcoreatcode{\the\catcode`\@}
 \edef\pgfcorebarcode{\the\catcode`\|}
@@ -29,7 +29,7 @@
 \catcode`\!=12
 
 
-\input pgfcore.code.tex
+\input{pgfcore.code.tex}
 
 \catcode`\@=\pgfcoreatcode
 \catcode`\|=\pgfcorebarcode

--- a/tex/context/third/pgf/frontendlayer/t-tikz.tex
+++ b/tex/context/third/pgf/frontendlayer/t-tikz.tex
@@ -15,10 +15,10 @@
 \startmodule[tikz]
 
 
-% \input xkeyval.tex   % no longer used/needed
+% \input{xkeyval.tex}   % no longer used/needed
 
-\input t-pgf.tex
-\input t-pgffor.tex
+\input{t-pgf.tex}
+\input{t-pgffor.tex}
 
 \edef\tikzatcode{\the\catcode`\@}
 \edef\tikzbarcode{\the\catcode`\|}
@@ -27,7 +27,7 @@
 \catcode`\|=12
 \catcode`\!=12
 
-\input tikz.code.tex
+\input{tikz.code.tex}
 
 \catcode`\@=\tikzatcode
 \catcode`\|=\tikzbarcode

--- a/tex/context/third/pgf/math/t-pgfmat.tex
+++ b/tex/context/third/pgf/math/t-pgfmat.tex
@@ -25,7 +25,7 @@
 \catcode`\|=12
 \catcode`\!=12
 
-\input pgfmath.code.tex
+\input{pgfmath.code.tex}
 
 \catcode`\@=\pgfmathatcode
 \catcode`\|=\pgfmathbarcode

--- a/tex/context/third/pgf/systemlayer/t-pgfsys.tex
+++ b/tex/context/third/pgf/systemlayer/t-pgfsys.tex
@@ -18,7 +18,7 @@
 \ifx\pgfsysdefined\undefined
 \let\pgfsysdefined=\relax
 
-\input t-pgfrcs.tex
+\input{t-pgfrcs.tex}
 
 \edef\pgfsysatcode{\the\catcode`\@}
 \edef\pgfsysbarcode{\the\catcode`\|}
@@ -27,9 +27,9 @@
 \catcode`\|=12
 \catcode`\!=12
 
-\input pgfsys.code.tex
-\input pgfsyssoftpath.code.tex
-\input pgfsysprotocol.code.tex
+\input{pgfsys.code.tex}
+\input{pgfsyssoftpath.code.tex}
+\input{pgfsysprotocol.code.tex}
 
 \catcode`\@=\pgfsysatcode
 \catcode`\|=\pgfsysbarcode

--- a/tex/context/third/pgf/utilities/t-pgfcal.tex
+++ b/tex/context/third/pgf/utilities/t-pgfcal.tex
@@ -17,14 +17,14 @@
 \ifx\pgfcalendardefined\undefined
 \let\pgfcalendardefined=\relax
 
-\input t-pgfrcs.tex
+\input{t-pgfrcs.tex}
 
 \edef\pgfcalendaratcode{\the\catcode`\@}
 \edef\pgfcalendarbarcode{\the\catcode`\|}
 \catcode`\@=11
 \catcode`\|=12
 
-\input pgfcalendar.code.tex
+\input{pgfcalendar.code.tex}
 
 \catcode`\@=\pgfcalendaratcode
 \catcode`\|=\pgfcalendarbarcode

--- a/tex/context/third/pgf/utilities/t-pgffor.tex
+++ b/tex/context/third/pgf/utilities/t-pgffor.tex
@@ -17,15 +17,15 @@
 \ifx\pgffordefined\undefined
 \let\pgffordefined=\relax
 
-\input t-pgfrcs.tex
-\input t-pgfkey.tex
+\input{t-pgfrcs.tex}
+\input{t-pgfkey.tex}
 
 \edef\pgfforatcode{\the\catcode`\@}
 \edef\pgfforbarcode{\the\catcode`\|}
 \catcode`\@=11
 \catcode`\|=12
 
-\input pgffor.code.tex
+\input{pgffor.code.tex}
 
 \catcode`\@=\pgfforatcode
 \catcode`\|=\pgfforbarcode

--- a/tex/context/third/pgf/utilities/t-pgfkey.tex
+++ b/tex/context/third/pgf/utilities/t-pgfkey.tex
@@ -22,7 +22,7 @@
 \catcode`\@=11
 \catcode`\|=12
 
-\input pgfkeys.code.tex
+\input{pgfkeys.code.tex}
 
 \catcode`\@=\pgfkeysatcode
 \catcode`\|=\pgfkeysbarcode

--- a/tex/context/third/pgf/utilities/t-pgfrcs.tex
+++ b/tex/context/third/pgf/utilities/t-pgfrcs.tex
@@ -17,7 +17,7 @@
 \ifx\pgfrcsdefined\undefined
 \let\pgfrcsdefined=\relax
 
-\input t-pgfmod.tex
+\input{t-pgfmod.tex}
 
 \edef\pgfrcsatcode{\the\catcode`\@}
 \edef\pgfrcsbarcode{\the\catcode`\|}
@@ -26,10 +26,10 @@
 \catcode`\|=12
 \catcode`\!=12
 
-\input pgfutil-common.tex
-\input pgfutil-context.def
+\input{pgfutil-common.tex}
+\input{pgfutil-context.def}
 
-\input pgfrcs.code.tex
+\input{pgfrcs.code.tex}
 
 \catcode`\@=\pgfrcsatcode
 \catcode`\|=\pgfrcsbarcode

--- a/tex/generic/pgf/basiclayer/pgfcore.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcore.code.tex
@@ -13,29 +13,29 @@
 \def\pgf@typeout{\immediate\write0}
 
 \ifdefined\pgfmathloaded\else
-  \input pgfmath.code.tex
+  \input{pgfmath.code.tex}
 \fi
 
 \ifdefined\pgfintloaded\else
-  \input pgfint.code.tex
+  \input{pgfint.code.tex}
 \fi
 
-\input pgfcorepoints.code.tex
-\input pgfcorepathconstruct.code.tex
-\input pgfcorepathusage.code.tex
-\input pgfcorescopes.code.tex
-\input pgfcoregraphicstate.code.tex
-\input pgfcoretransformations.code.tex
-\input pgfcorequick.code.tex
-\input pgfcoreobjects.code.tex
-\input pgfcorepathprocessing.code.tex
-\input pgfcorearrows.code.tex
-\input pgfcoreshade.code.tex
-\input pgfcoreimage.code.tex
-\input pgfcoreexternal.code.tex
-\input pgfcorelayers.code.tex
-\input pgfcoretransparency.code.tex
-\input pgfcorepatterns.code.tex
-\input pgfcorerdf.code.tex
+\input{pgfcorepoints.code.tex}
+\input{pgfcorepathconstruct.code.tex}
+\input{pgfcorepathusage.code.tex}
+\input{pgfcorescopes.code.tex}
+\input{pgfcoregraphicstate.code.tex}
+\input{pgfcoretransformations.code.tex}
+\input{pgfcorequick.code.tex}
+\input{pgfcoreobjects.code.tex}
+\input{pgfcorepathprocessing.code.tex}
+\input{pgfcorearrows.code.tex}
+\input{pgfcoreshade.code.tex}
+\input{pgfcoreimage.code.tex}
+\input{pgfcoreexternal.code.tex}
+\input{pgfcorelayers.code.tex}
+\input{pgfcoretransparency.code.tex}
+\input{pgfcorepatterns.code.tex}
+\input{pgfcorerdf.code.tex}
 
 \endinput

--- a/tex/generic/pgf/basiclayer/pgfcoreexternal.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcoreexternal.code.tex
@@ -66,7 +66,7 @@
 % typeset.
 %
 % Finally, once all the graphics have been created, you can also say
-% \input pgfexternal.tex instead of including pgf/TikZ.
+% \input{pgfexternal.tex} instead of including pgf/TikZ.
 
 
 \newif\ifpgfexternalreadmainaux

--- a/tex/generic/pgf/math/pgfmath.code.tex
+++ b/tex/generic/pgf/math/pgfmath.code.tex
@@ -17,21 +17,21 @@
 
 % We need keys:
 \ifx\pgfkeysloaded\pgfutil@undefined
-  \input pgfkeys.code.tex
+  \input{pgfkeys.code.tex}
 \fi
 
-\input pgfmathutil.code.tex
-\input pgfmathparser.code.tex
-\input pgfmathfunctions.code.tex
-\input pgfmathfunctions.basic.code.tex
-\input pgfmathfunctions.trigonometric.code.tex
-\input pgfmathfunctions.random.code.tex
-\input pgfmathfunctions.comparison.code.tex
-\input pgfmathfunctions.base.code.tex
-\input pgfmathfunctions.round.code.tex
-\input pgfmathfunctions.misc.code.tex
-\input pgfmathfunctions.integerarithmetics.code.tex
-\input pgfmathcalc.code.tex
-\input pgfmathfloat.code.tex
+\input{pgfmathutil.code.tex}
+\input{pgfmathparser.code.tex}
+\input{pgfmathfunctions.code.tex}
+\input{pgfmathfunctions.basic.code.tex}
+\input{pgfmathfunctions.trigonometric.code.tex}
+\input{pgfmathfunctions.random.code.tex}
+\input{pgfmathfunctions.comparison.code.tex}
+\input{pgfmathfunctions.base.code.tex}
+\input{pgfmathfunctions.round.code.tex}
+\input{pgfmathfunctions.misc.code.tex}
+\input{pgfmathfunctions.integerarithmetics.code.tex}
+\input{pgfmathcalc.code.tex}
+\input{pgfmathfloat.code.tex}
 
 \endinput

--- a/tex/generic/pgf/modules/pgfmoduleanimations.code.tex
+++ b/tex/generic/pgf/modules/pgfmoduleanimations.code.tex
@@ -12,7 +12,7 @@
 
 % We need the animation system abstraction:
 
-\input pgfsysanimations.code.tex
+\input{pgfsysanimations.code.tex}
 
 
 % Animate an attribute over time

--- a/tex/generic/pgf/systemlayer/pgfsys-dvipdfm.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvipdfm.def
@@ -14,8 +14,8 @@
 %
 % Load common pdf and pdf in dvi commands:
 %
-\input pgfsys-common-pdf.def
-\input pgfsys-common-pdf-via-dvi.def
+\input{pgfsys-common-pdf.def}
+\input{pgfsys-common-pdf-via-dvi.def}
 
 %
 % dvipdfm-specific stuff:

--- a/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvipdfmx.def
@@ -19,7 +19,7 @@
 %
 % Load common pdf and pdf in dvi commands:
 %
-\input pgfsys-common-pdf.def
+\input{pgfsys-common-pdf.def}
 
 
 % For unique object name:

--- a/tex/generic/pgf/systemlayer/pgfsys-dvips.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvips.def
@@ -23,7 +23,7 @@
 %
 % Load common postscript commands:
 %
-\input pgfsys-common-postscript.def
+\input{pgfsys-common-postscript.def}
 
 
 %

--- a/tex/generic/pgf/systemlayer/pgfsys-dvisvgm.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvisvgm.def
@@ -15,7 +15,7 @@
 %
 % Load common pdf commands:
 %
-\input pgfsys-common-svg.def
+\input{pgfsys-common-svg.def}
 
 \newif\ifpgf@sys@svg@inpicture
 

--- a/tex/generic/pgf/systemlayer/pgfsys-dvisvgm4ht.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvisvgm4ht.def
@@ -20,10 +20,10 @@
 % dvips driver is available through the tikz+ option. It doesn't support everything, 
 % but it worked better with nested pictures in the past.
 \ifdefined\ifOption
-\ifOption{tikz+}{\input pgfsys-dvips.def}{\input pgfsys-dvisvgm.def}
+\ifOption{tikz+}{\input{pgfsys-dvips.def}{\input} pgfsys-dvisvgm.def}
 \else
 % load the dvips driver by default
-\input pgfsys-dvisvgm.def
+\input{pgfsys-dvisvgm.def}
 \fi
 
 

--- a/tex/generic/pgf/systemlayer/pgfsys-luatex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-luatex.def
@@ -12,7 +12,7 @@
 
 \ifnum\luatexversion<95
     \immediate\write-1{luatex driver of PGF: detected lua version \the\luatexversion; falling back to old pdftex driver^^J}%
-    \input pgfsys-pdftex.def
+    \input{pgfsys-pdftex.def}
     \expandafter\endinput
 \fi
 
@@ -21,7 +21,7 @@
 %
 % Load common pdf commands:
 %
-\input pgfsys-common-pdf.def
+\input{pgfsys-common-pdf.def}
 
 %
 % pdftex-specific stuff:

--- a/tex/generic/pgf/systemlayer/pgfsys-pdftex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-pdftex.def
@@ -16,7 +16,7 @@
 %
 % Load common pdf commands:
 %
-\input pgfsys-common-pdf.def
+\input{pgfsys-common-pdf.def}
 
 %
 % pdftex-specific stuff:

--- a/tex/generic/pgf/systemlayer/pgfsys-tex4ht.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-tex4ht.def
@@ -16,7 +16,7 @@
 %
 % Load common pdf commands:
 %
-\input pgfsys-common-svg.def
+\input{pgfsys-common-svg.def}
 
 %
 % tex4ht-specific stuff:

--- a/tex/generic/pgf/systemlayer/pgfsys-textures.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-textures.def
@@ -25,7 +25,7 @@
 %
 % Load common postscript commands:
 %
-\input pgfsys-common-postscript.def
+\input{pgfsys-common-postscript.def}
 
 
 %

--- a/tex/generic/pgf/systemlayer/pgfsys-vtex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-vtex.def
@@ -26,7 +26,7 @@
 %
 % Load common postscript commands:
 %
-\input pgfsys-common-postscript.def
+\input{pgfsys-common-postscript.def}
 
 
 %

--- a/tex/generic/pgf/systemlayer/pgfsys-xetex.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-xetex.def
@@ -9,7 +9,7 @@
 
 \ProvidesFileRCS{pgfsys-xetex.def}
 
-\input pgfsys-dvipdfmx.def
+\input{pgfsys-dvipdfmx.def}
 
 \def\pgfsys@dvipdfmx@patternobj#1{%
     % I have NO idea why this is necessary for xdvipdfmx - but without

--- a/tex/generic/pgf/systemlayer/pgfsys.code.tex
+++ b/tex/generic/pgf/systemlayer/pgfsys.code.tex
@@ -12,7 +12,7 @@
 
 % Load key mechanism
 \ifdefined\pgfkeysloaded\else
-  \input pgfkeys.code.tex
+  \input{pgfkeys.code.tex}
 \fi
 
 % "pgf" is a family
@@ -1751,7 +1751,7 @@
   \pgfutil@guessdriver
 \fi
 
-\input pgf.cfg
+\input{pgf.cfg}
 
 \immediate\write-1{Driver file for pgf: \pgfsysdriver}
 \pgfutil@InputIfFileExists{\pgfsysdriver}{}{%

--- a/tex/generic/pgf/utilities/pgfcalendar.code.tex
+++ b/tex/generic/pgf/utilities/pgfcalendar.code.tex
@@ -10,7 +10,7 @@
 \ProvidesFileRCS{pgfcalendar.code.tex}
 
 \ifdefined\pgfintloaded\else
-  \input pgfint.code.tex
+  \input{pgfint.code.tex}
 \fi
 
 % Translation stuff

--- a/tex/generic/pgf/utilities/pgffor.code.tex
+++ b/tex/generic/pgf/utilities/pgffor.code.tex
@@ -11,7 +11,7 @@
 
 % pgfmath is needed
 \ifdefined\pgfmathloaded\else
-  \input pgfmath.code.tex
+  \input{pgfmath.code.tex}
 \fi
 
 \newdimen\pgffor@iter

--- a/tex/generic/pgf/utilities/pgfkeys.code.tex
+++ b/tex/generic/pgf/utilities/pgfkeys.code.tex
@@ -1213,7 +1213,7 @@
       \catcode`\|=12
       \catcode`\$=3
       \pgfkeys@IfFileExists{pgfkeyslibrary\pgf@temp.code.tex}{%
-        \input pgfkeyslibrary\pgf@temp.code.tex
+        \input{pgfkeyslibrary\pgf@temp.code.tex}
       }{%
         \pgfkeys@error{I did not find the pgfkeys library '\pgf@temp'. I looked for the
           file named pgfkeyslibrary\pgf@temp.code.tex, but could not find it in the
@@ -1227,6 +1227,6 @@
 }
 
 \let\pgfkeys@library@filtered@loaded\pgfkeys@empty
-\input pgfkeyslibraryfiltered.code.tex
+\input{pgfkeyslibraryfiltered.code.tex}
 
 \endinput

--- a/tex/generic/pgf/utilities/pgfrcs.code.tex
+++ b/tex/generic/pgf/utilities/pgfrcs.code.tex
@@ -22,7 +22,7 @@
 % string. This command will also be available in plain TeX, where it
 % prints out a message to the log.
 
-\pgfutil@IfFileExists{pgf.revision.tex}{\input pgf.revision.tex } {%
+\pgfutil@IfFileExists{pgf.revision.tex}{\input{pgf.revision.tex}}{%
     \def\pgfrevision{0.0}%
     \def\pgfversion{0.0}%
     \def\pgfversiondate{2014-07-01}%

--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -248,7 +248,7 @@
   \fi
   \closein\pgfutil@inputcheck}
 
-\def\pgfutil@InputIfFileExists#1#2#3{\pgfutil@IfFileExists{#1}{\input #1\relax#2}{#3}}%
+\def\pgfutil@InputIfFileExists#1#2#3{\pgfutil@IfFileExists{#1}{\input{#1}\relax#2}{#3}}%
 
 
 % pgfutil@loop (from plain.tex)
@@ -419,7 +419,7 @@
       \catcode`\@=11
       \catcode`\|=12
       \catcode`\$=3
-      \input pgfmodule\pgf@temp.code.tex
+      \input{pgfmodule\pgf@temp.code.tex}
       \catcode`\@=\csname pgf@module@#1@atcode\endcsname
       \catcode`\|=\csname pgf@module@#1@barcode\endcsname
       \catcode`\$=\csname pgf@module@#1@dollarcode\endcsname

--- a/tex/generic/pgf/utilities/pgfutil-context.def
+++ b/tex/generic/pgf/utilities/pgfutil-context.def
@@ -15,7 +15,7 @@
 
 % The aux files, needed for reading back coordinates
 \def\pgfutil@aux@read@hook{%
-  \pgfutil@IfFileExists{\jobname.pgf}{\input \jobname.pgf\relax}{}
+  \pgfutil@IfFileExists{\jobname.pgf}{\input{\jobname.pgf}\relax}{}
   \csname newwrite\endcsname\pgfutil@auxout
   \immediate\csname openout\endcsname\pgfutil@auxout\jobname.pgf\relax
 }

--- a/tex/generic/pgf/utilities/pgfutil-plain.def
+++ b/tex/generic/pgf/utilities/pgfutil-plain.def
@@ -14,7 +14,7 @@
 
 % The aux files, needed for reading back coordinates
 \def\pgfutil@aux@read@hook{
-  \pgfutil@IfFileExists{\jobname.pgf}{\input \jobname.pgf\relax}{}
+  \pgfutil@IfFileExists{\jobname.pgf}{\input{\jobname.pgf}\relax}{}
   \csname newwrite\endcsname\pgfutil@auxout
   \immediate\csname openout\endcsname\pgfutil@auxout\jobname.pgf
 }
@@ -238,7 +238,7 @@
 
 % Module stuff
 
-\def\pgfutil@usemodule#1{\input #1.tex}
+\def\pgfutil@usemodule#1{\input{#1.tex}}
 
 
 
@@ -284,7 +284,7 @@
 \let\pgfutil@abe\pgfutil@empty%
 
 % Code by Heiko Oberdiek on ctt
-\input atbegshi.sty\relax
+\input{atbegshi.sty}
 \AtBeginShipout{%
   \setbox\AtBeginShipoutBox=\vbox{%
     \setbox0=\hbox{%

--- a/tex/latex/pgf/doc/pgfmanual-en-macros.tex
+++ b/tex/latex/pgf/doc/pgfmanual-en-macros.tex
@@ -1041,7 +1041,7 @@
       {\ttfamily\char`\\usepackage\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX}}
     \index{#1@\protect\texttt{#1} package}%
     \index{Packages and files!#1@\protect\texttt{#1}}%
-    \pgfmanualentryheadline{{\ttfamily\char`\\input \declare{#1}.tex\space\space\space \char`\%\space\space  plain \TeX}}
+    \pgfmanualentryheadline{{\ttfamily\char`\\input{\declare{#1}.tex}\space\space\space \char`\%\space\space  plain \TeX}}
     \pgfmanualentryheadline{{\ttfamily\char`\\usemodule[\declare{#1}]\space\space \char`\%\space\space  Con\TeX t}}
     \pgfmanualbody
 }

--- a/tex/latex/pgf/doc/pgfmanual.code.tex
+++ b/tex/latex/pgf/doc/pgfmanual.code.tex
@@ -7,8 +7,8 @@
 %
 % See the file doc/generic/pgf/licenses/LICENSE for more details.
 
-\input pgfmanual.prettyprinter.code.tex
-\input pgfmanual.pdflinks.code.tex
+\input{pgfmanual.prettyprinter.code.tex}
+\input{pgfmanual.pdflinks.code.tex}
 
 % TODO for auto xrefs:
 % 1. check the already identified labels, preferably using

--- a/tex/latex/pgf/doc/pgfmanual.sty
+++ b/tex/latex/pgf/doc/pgfmanual.sty
@@ -9,4 +9,4 @@
 
 \ProvidesPackage{pgfmanual}[2009/10/15]
 
-\input pgfmanual.code.tex
+\input{pgfmanual.code.tex}

--- a/tex/latex/pgf/frontendlayer/libraries/tikzlibraryexternal.code.tex
+++ b/tex/latex/pgf/frontendlayer/libraries/tikzlibraryexternal.code.tex
@@ -36,7 +36,7 @@
 }%
 
 % source generic implementation:
-\input tikzexternalshared.code.tex
+\input{tikzexternalshared.code.tex}
 
 \pgfutil@IfUndefined{pdf@mdfivesum}{}{%
 	\let\tikzexternal@mdfivesum=\pdf@mdfivesum

--- a/tex/latex/pgf/utilities/pgfrcs.sty
+++ b/tex/latex/pgf/utilities/pgfrcs.sty
@@ -7,8 +7,8 @@
 %
 % See the file doc/generic/pgf/licenses/LICENSE for more details.
 
-\input pgfutil-common.tex
-\input pgfutil-latex.def
+\input{pgfutil-common.tex}
+\input{pgfutil-latex.def}
 
 \input{pgfrcs.code.tex}
 

--- a/tex/plain/pgf/basiclayer/pgf.tex
+++ b/tex/plain/pgf/basiclayer/pgf.tex
@@ -12,16 +12,16 @@
 \catcode`\@=11
 
 
-\input pgfrcs.tex
+\input{pgfrcs.tex}
 \ProvidesPackageRCS{pgf.tex}
 
-\input pgfcore.tex
+\input{pgfcore.tex}
 
 \usepgfmodule{shapes,plot}
 
-%\input pgfbasesnakes.tex
-%\input pgfbasedecorations.tex
-%\input pgfbasematrix.tex
+%\input{pgfbasesnakes.tex}
+%\input{pgfbasedecorations.tex}
+%\input{pgfbasematrix.tex}
 
 \catcode`\@=\pgfatcode
 

--- a/tex/plain/pgf/basiclayer/pgfbaseimage.tex
+++ b/tex/plain/pgf/basiclayer/pgfbaseimage.tex
@@ -11,7 +11,7 @@
 \edef\pgfbaseimageatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfcore.tex
+\input{pgfcore.tex}
 
 \PackageWarning{pgf}{This package is obsolete and no longer needed}
 

--- a/tex/plain/pgf/basiclayer/pgfbaselayers.tex
+++ b/tex/plain/pgf/basiclayer/pgfbaselayers.tex
@@ -11,7 +11,7 @@
 \edef\pgfbaselayersatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfcore.tex
+\input{pgfcore.tex}
 
 \PackageWarning{pgf}{This package is obsolete and no longer needed}
 

--- a/tex/plain/pgf/basiclayer/pgfbasematrix.tex
+++ b/tex/plain/pgf/basiclayer/pgfbasematrix.tex
@@ -11,7 +11,7 @@
 \edef\pgfbasematrixatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfcore.tex
+\input{pgfcore.tex}
 
 \PackageWarning{pgf}{This package is obsolete. Use \string\usepgfmodule{matrix} instead}
 

--- a/tex/plain/pgf/basiclayer/pgfbasepatterns.tex
+++ b/tex/plain/pgf/basiclayer/pgfbasepatterns.tex
@@ -11,7 +11,7 @@
 \edef\pgfbasepatternsatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfcore.tex
+\input{pgfcore.tex}
 
 \PackageWarning{pgf}{This package is obsolete and no longer needed}
 

--- a/tex/plain/pgf/basiclayer/pgfbaseplot.tex
+++ b/tex/plain/pgf/basiclayer/pgfbaseplot.tex
@@ -11,7 +11,7 @@
 \edef\pgfbaseplotatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfcore.tex
+\input{pgfcore.tex}
 
 \PackageWarning{pgf}{This package is obsolete. Use \string\usepgfmodule{plot} instead}
 

--- a/tex/plain/pgf/basiclayer/pgfbaseshapes.tex
+++ b/tex/plain/pgf/basiclayer/pgfbaseshapes.tex
@@ -11,7 +11,7 @@
 \edef\pgfbaseshapesatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfcore.tex
+\input{pgfcore.tex}
 
 \PackageWarning{pgf}{This package is obsolete. Use \string\usepgfmodule{shapes} instead}
 

--- a/tex/plain/pgf/basiclayer/pgfbasesnakes.tex
+++ b/tex/plain/pgf/basiclayer/pgfbasesnakes.tex
@@ -11,7 +11,7 @@
 \edef\pgfbasesnakesatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfcore.tex
+\input{pgfcore.tex}
 
 \PackageWarning{pgf}{This package is obsolete. Use \string\usepgfmodule{decorations} instead}
 

--- a/tex/plain/pgf/basiclayer/pgfcore.tex
+++ b/tex/plain/pgf/basiclayer/pgfcore.tex
@@ -14,8 +14,8 @@
 \edef\pgfcoreatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfsys.tex
-\input pgfcore.code.tex
+\input{pgfsys.tex}
+\input{pgfcore.code.tex}
 \catcode`\@=\pgfcoreatcode
 
 \fi

--- a/tex/plain/pgf/frontendlayer/tikz.tex
+++ b/tex/plain/pgf/frontendlayer/tikz.tex
@@ -12,11 +12,11 @@
 \edef\tikzatcode{\the\catcode`\@}
 \catcode`\@=11
 
-%\input xkeyval.tex % no longer used/needed
+%\input{xkeyval.tex} % no longer used/needed
 
-\input pgf.tex
-\input pgffor.tex
-\input tikz.code.tex
+\input{pgf.tex}
+\input{pgffor.tex}
+\input{tikz.code.tex}
 
 \catcode`\@=\tikzatcode
 

--- a/tex/plain/pgf/math/pgfmath.tex
+++ b/tex/plain/pgf/math/pgfmath.tex
@@ -14,8 +14,8 @@
 \edef\pgfmathatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfsys.tex
-\input pgfmath.code.tex
+\input{pgfsys.tex}
+\input{pgfmath.code.tex}
 \catcode`\@=\pgfmathatcode
 
 \fi

--- a/tex/plain/pgf/systemlayer/pgfsys.tex
+++ b/tex/plain/pgf/systemlayer/pgfsys.tex
@@ -15,11 +15,11 @@
 \edef\pgfsysatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfrcs.tex
+\input{pgfrcs.tex}
 
-\input pgfsys.code.tex
-\input pgfsyssoftpath.code.tex
-\input pgfsysprotocol.code.tex
+\input{pgfsys.code.tex}
+\input{pgfsyssoftpath.code.tex}
+\input{pgfsysprotocol.code.tex}
 
 \catcode`\@=\pgfsysatcode\relax
 

--- a/tex/plain/pgf/utilities/pgfcalendar.tex
+++ b/tex/plain/pgf/utilities/pgfcalendar.tex
@@ -10,8 +10,8 @@
 \edef\pgfcalendaratcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfrcs.tex
-\input pgfcalendar.code.tex
+\input{pgfrcs.tex}
+\input{pgfcalendar.code.tex}
 
 \catcode`\@=\pgfcalendaratcode
 

--- a/tex/plain/pgf/utilities/pgffor.tex
+++ b/tex/plain/pgf/utilities/pgffor.tex
@@ -10,9 +10,9 @@
 \edef\pgfforatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfrcs.tex
-\input pgfkeys.code.tex
-\input pgffor.code.tex
+\input{pgfrcs.tex}
+\input{pgfkeys.code.tex}
+\input{pgffor.code.tex}
 
 \catcode`\@=\pgfforatcode
 

--- a/tex/plain/pgf/utilities/pgfkeys.tex
+++ b/tex/plain/pgf/utilities/pgfkeys.tex
@@ -10,8 +10,8 @@
 \edef\pgfkeysatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfrcs.tex
-\input pgfkeys.code.tex
+\input{pgfrcs.tex}
+\input{pgfkeys.code.tex}
 
 \catcode`\@=\pgfkeysatcode
 

--- a/tex/plain/pgf/utilities/pgfrcs.tex
+++ b/tex/plain/pgf/utilities/pgfrcs.tex
@@ -14,10 +14,10 @@
 \edef\pgfrcsatcode{\the\catcode`\@}
 \catcode`\@=11
 
-\input pgfutil-common.tex
-\input pgfutil-plain.def
+\input{pgfutil-common.tex}
+\input{pgfutil-plain.def}
 
-\input pgfrcs.code.tex
+\input{pgfrcs.code.tex}
 
 \catcode`\@=\pgfrcsatcode
 


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Improves the compatibility with the LaTeX hooking framework.
This is a breaking change because it makes PGF/TikZ require TeX built with Web2C 2020 or newer.[^1]

Fixes #1424

[^1]: https://tug.org/texinfohtml/web2c.html#g_t_005cinput-braced-filename

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
