### PR TITLE
fix: use explicit braces for grouping in pgfscope

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Typo fixes in the manual
+- Replace `\begingroup`...`\endgroup` by an explicit brace group in `pgfscope` to fix usage in alignments #1417
 
 ### Contributors
 

--- a/tex/generic/pgf/basiclayer/pgfcorescopes.code.tex
+++ b/tex/generic/pgf/basiclayer/pgfcorescopes.code.tex
@@ -52,9 +52,9 @@
     \edef\pgfscope@linewidth{\the\pgflinewidth}%
     \let\pgfscope@stroke@color=\pgf@strokecolor@global%
     \let\pgfscope@fill@color=\pgf@fillcolor@global%
-    \begingroup}
+    {\romannumeral-`}\pgfutil@sptoken}
 \def\endpgfscope{%
-    \endgroup%
+    \romannumeral-`{}%
     \global\pgflinewidth=\pgfscope@linewidth%
     \global\let\pgf@strokecolor@global=\pgfscope@stroke@color%
     \global\let\pgf@fillcolor@global=\pgfscope@fill@color%


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Fixes https://github.com/pgf-tikz/pgf/issues/1417

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
