### PR TITLE
fix: correct syntax of conditional braced \input

### DIFF
--- a/tex/generic/pgf/systemlayer/pgfsys-dvisvgm4ht.def
+++ b/tex/generic/pgf/systemlayer/pgfsys-dvisvgm4ht.def
@@ -20,7 +20,7 @@
 % dvips driver is available through the tikz+ option. It doesn't support everything, 
 % but it worked better with nested pictures in the past.
 \ifdefined\ifOption
-\ifOption{tikz+}{\input{pgfsys-dvips.def}{\input} pgfsys-dvisvgm.def}
+\ifOption{tikz+}{\input{pgfsys-dvips.def}}{\input{pgfsys-dvisvgm.def}}
 \else
 % load the dvips driver by default
 \input{pgfsys-dvisvgm.def}


### PR DESCRIPTION
**Motivation for this change**

Fix wrong syntax introduced when applying braced `\input` in #1450.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
