### PR TITLE
docs: use "new" `circle` syntax

### DIFF
--- a/doc/generic/pgf/pgfmanual-en-base-design.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-design.tex
@@ -136,11 +136,11 @@ the low-level transformation the way they should):
         \pgflowlevel{\pgftransformxscale{3}}
         \pgflowlevel{\pgftransformyscale{.5}}
 
-        \draw (0,0) circle (0.5cm);
+        \draw (0,0) circle [radius=0.5cm];
         \draw (.55cm,0pt) node[right] {canvas};
     \end{scope}
     \begin{scope}[xshift=9cm,xscale=3,yscale=.5]
-        \draw (0,0) circle (0.5cm);
+        \draw (0,0) circle [radius=0.5cm];
         \draw (.55cm,0pt) node[right] {coordinate};
     \end{scope}
 \end{tikzpicture}

--- a/doc/generic/pgf/pgfmanual-en-base-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-external.tex
@@ -94,7 +94,7 @@ As we see in Figure~\ref{fig1}, the world is flat.
 \begin{figure}
   \beginpgfgraphicnamed{graphic-of-flat-world}
   \begin{tikzpicture}
-    \fill (0,0) circle (1cm);
+    \fill (0,0) circle [radius=1cm];
   \end{tikzpicture}
   \endpgfgraphicnamed
   \caption{The flat world.}
@@ -324,7 +324,7 @@ normal file called |survey.tex| that has the following contents:
 \begin{document}
 In the following figure, we see a circle:
 \begin{tikzpicture}
-  \fill (0,0) circle (10pt);
+  \fill (0,0) circle [radius=10pt];
 \end{tikzpicture}
 
 By comparison, in this figure we see a rectangle:
@@ -350,7 +350,7 @@ in separate PostScript or |.pdf|-files. For this, we enclose all figures in
 In the following figure, we see a circle:
 \beginpgfgraphicnamed{survey-f1}
 \begin{tikzpicture}
-  \fill (0,0) circle (10pt);
+  \fill (0,0) circle [radius=10pt];
 \end{tikzpicture}
 \endpgfgraphicnamed
 
@@ -413,7 +413,7 @@ Thus, we modify the main file |survey.tex| as follows:
 In the following figure, we see a circle:
 \beginpgfgraphicnamed{survey-f1}
 \begin{tikzpicture}
-  \fill (0,0) circle (10pt);
+  \fill (0,0) circle [radius=10pt];
 \end{tikzpicture}
 \endpgfgraphicnamed
 

--- a/doc/generic/pgf/pgfmanual-en-base-layers.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-layers.tex
@@ -100,7 +100,7 @@ certain commands should, instead, be added to the given layer.
 \pgfsetlayers{background layer,main,foreground layer}
 \begin{tikzpicture}
   % On main layer:
-  \fill[blue] (0,0) circle (1cm);
+  \fill[blue] (0,0) circle [radius=1cm];
 
   \begin{pgfonlayer}{background layer}
     \fill[yellow] (-1,-1) rectangle (1,1);

--- a/doc/generic/pgf/pgfmanual-en-base-nodes.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-nodes.tex
@@ -733,7 +733,8 @@ similar to the above:
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (3,2);
   { [local bounding box=outer box]
-    \draw (1,1) circle (.5) [local bounding box=inner box] (2,2) circle (.5);
+    \draw (1,1) circle [radius=.5]
+      [local bounding box=inner box] (2,2) circle [radius=.5];
   }
   \draw      (outer box.south west) rectangle (outer box.north east);
   \draw[red] (inner box.south west) rectangle (inner box.north east);
@@ -1085,11 +1086,11 @@ The following command declares a new shape:
 
 \begin{tikzpicture}
   \node[simple shape] (Test1) at (0,0) {};
-  \fill (Test1.anchor foo) circle (2pt) node[below] {anchor foo anchor};
+  \fill (Test1.anchor foo) circle [radius=2pt] node[below] {anchor foo anchor};
   %
   \def\foo{bar}
   \node[simple shape] (Test2) at (2,2) {};
-  \fill (Test2.anchor bar) circle (2pt) node[below] {anchor bar anchor};
+  \fill (Test2.anchor bar) circle [radius=2pt] node[below] {anchor bar anchor};
 \end{tikzpicture}
 \end{codeexample}
     \end{command}

--- a/doc/generic/pgf/pgfmanual-en-base-points.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-points.tex
@@ -499,8 +499,8 @@ determine border points of shapes.
 \begin{codeexample}[]
 \begin{tikzpicture}
   \draw[help lines] (0,0) grid (2,2);
-  \draw (0.5,0) circle (1);
-  \draw (1.5,1) circle (.8);
+  \draw (0.5,0) circle [radius=1];
+  \draw (1.5,1) circle [radius=.8];
   \pgfpathcircle{%
     \pgfpointintersectionofcircles
       {\pgfpointxy{.5}{0}}{\pgfpointxy{1.5}{1}}

--- a/doc/generic/pgf/pgfmanual-en-base-shadings.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-shadings.tex
@@ -681,7 +681,7 @@ than if you work in your intended color model.
 
   \begin{scope}[xshift=10cm]
     \draw (50bp,50bp) node{\pgfuseshading{myshadingF}};
-    \draw[white,thick] (50bp,50bp) circle (25bp);
+    \draw[white,thick] (50bp,50bp) circle [radius=25bp];
     \draw (50bp,0bp) node[below] {fourth application};
   \end{scope}
 \end{tikzpicture}

--- a/doc/generic/pgf/pgfmanual-en-base-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-transparency.tex
@@ -47,9 +47,9 @@ Specifying a stroke and/or fill opacity is quite easy.
 \begin{codeexample}[]
 \begin{tikzpicture}
   \pgfsetfillopacity{0.5}
-  \fill[red]   (90:1cm)  circle (11mm);
-  \fill[green] (210:1cm) circle (11mm);
-  \fill[blue]  (-30:1cm) circle (11mm);
+  \fill[red]   (90:1cm)  circle [radius=11mm];
+  \fill[green] (210:1cm) circle [radius=11mm];
+  \fill[blue]  (-30:1cm) circle [radius=11mm];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -61,8 +61,8 @@ filling and you stroke or fill the same area twice, the effect accumulates:
 \begin{codeexample}[]
 \begin{tikzpicture}
   \pgfsetfillopacity{0.5}
-  \fill[red] (0,0) circle (1);
-  \fill[red] (1,0) circle (1);
+  \fill[red] (0,0) circle [radius=1];
+  \fill[red] (1,0) circle [radius=1];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -83,9 +83,9 @@ To set the blend mode, use the following command:
 \tikz [transparency group] {
   \pgfsetblendmode{screen}
 
-  \fill[red!90!black]   ( 90:.6) circle (1);
-  \fill[green!80!black] (210:.6) circle (1);
-  \fill[blue!90!black]  (330:.6) circle (1);
+  \fill[red!90!black]   ( 90:.6) circle [radius=1];
+  \fill[green!80!black] (210:.6) circle [radius=1];
+  \fill[blue!90!black]  (330:.6) circle [radius=1];
 }
 \end{codeexample}
     %

--- a/doc/generic/pgf/pgfmanual-en-guidelines.tex
+++ b/doc/generic/pgf/pgfmanual-en-guidelines.tex
@@ -399,7 +399,7 @@ conveys this message more clearly:
     \draw (65:2.2cm) node[right] {``bad'': 8 (16\%)};
     \draw (93:2.2cm) node[right] {``very bad'': 0 (0\%)};
   \end{scope}
-  \draw[gray] (0,0) circle (2.2cm) circle (1.8cm);
+  \draw[gray] (0,0) circle [radius=2.2cm] circle [radius=1.8cm];
 \end{tikzpicture}
 
 \bigskip
@@ -442,7 +442,7 @@ a pie chart in \emph{Die Zeit}, June 4th, 2005:
       color(75bp)=(black);
       color(100bp)=(black)}
 
-    \shadedraw[very thin,shading=zeit,yshift=-1.5mm] (0,0) circle (1cm);
+    \shadedraw[very thin,shading=zeit,yshift=-1.5mm] (0,0) circle [radius=1cm];
 
     \fill[green!20!gray]   (0,0) -- (90:1cm) arc (90:-5:1cm);
     \fill[white!20!gray]   (0,0) -- (-5:1cm) arc (-5:-105:1cm);
@@ -463,7 +463,7 @@ a pie chart in \emph{Die Zeit}, June 4th, 2005:
       \draw (0,0) -- (135:1cm);
       \draw (0,0) -- (92:1cm);
 
-      \draw(0,0) circle (1cm);
+      \draw(0,0) circle [radius=1cm];
     \end{scope}
 
     \node (Regenerative)   at (115:.75cm)  {\bfseries 9,4\%};

--- a/doc/generic/pgf/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/pgfmanual-en-introduction.tex
@@ -22,8 +22,8 @@ to read the rest.
 I wish to start with the question ``What is \tikzname?'' Basically, it just
 defines a number of \TeX\ commands that draw graphics. For example, the code
 |\tikz \draw (0pt,0pt) -- (20pt,6pt);| yields the line \tikz \draw (0pt,0pt) --
-(20pt,6pt); and the code |\tikz \fill[orange] (1ex,1ex) circle (1ex);| yields
-\tikz \fill[orange] (1ex,1ex) circle (1ex);. In a sense, when you use
+(20pt,6pt); and the code |\tikz \fill[orange] (1ex,1ex) circle [radius=1ex];| yields
+\tikz \fill[orange] (1ex,1ex) circle [radius=1ex];. In a sense, when you use
 \tikzname\ you ``program'' your graphics, just as you ``program'' your document
 when you use \TeX. This also explains the name: \tikzname\ is a recursive
 acronym in the tradition of ``\textsc{gnu}'s Not Unix'' and means ``\tikzname\

--- a/doc/generic/pgf/pgfmanual-en-library-3d.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-3d.tex
@@ -222,17 +222,17 @@ following options help you to switch to a different plane.
 \begin{codeexample}[preamble={\usetikzlibrary{3d}}]
 \begin{tikzpicture}
   \begin{scope}[canvas is zy plane at x=0]
-    \draw (0,0) circle (1cm);
+    \draw (0,0) circle [radius=1cm];
     \draw (-1,0) -- (1,0) (0,-1) -- (0,1);
   \end{scope}
 
   \begin{scope}[canvas is zx plane at y=0]
-    \draw (0,0) circle (1cm);
+    \draw (0,0) circle [radius=1cm];
     \draw (-1,0) -- (1,0) (0,-1) -- (0,1);
   \end{scope}
 
   \begin{scope}[canvas is xy plane at z=0]
-    \draw (0,0) circle (1cm);
+    \draw (0,0) circle [radius=1cm];
     \draw (-1,0) -- (1,0) (0,-1) -- (0,1);
   \end{scope}
 \end{tikzpicture}

--- a/doc/generic/pgf/pgfmanual-en-library-backgrounds.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-backgrounds.tex
@@ -33,7 +33,7 @@ The first use of this library is to make the following key available:
 \begin{codeexample}[preamble={\usetikzlibrary{backgrounds}}]
 \begin{tikzpicture}
   % On main layer:
-  \fill[blue] (0,0) circle (1cm);
+  \fill[blue] (0,0) circle [radius=1cm];
 
   \begin{scope}[on background layer={color=yellow}]
     \fill (-1,-1) rectangle (1,1);
@@ -86,7 +86,7 @@ When this package is loaded, the following styles become available:
     %
 \begin{codeexample}[preamble={\usetikzlibrary{backgrounds}}]
 \begin{tikzpicture}[show background rectangle]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -135,7 +135,7 @@ When this package is loaded, the following styles become available:
   [background rectangle/.style=
      {double,ultra thick,draw=red,top color=blue,rounded corners},
    show background rectangle]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
         %
@@ -147,7 +147,7 @@ When this package is loaded, the following styles become available:
   [background rectangle/.style=
      {draw=blue!50,fill=blue!20,rounded corners=1ex},
    show background rectangle]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     \end{stylekey}
@@ -165,7 +165,7 @@ When this package is loaded, the following styles become available:
     %
 \begin{codeexample}[preamble={\usetikzlibrary{backgrounds}}]
 \begin{tikzpicture}[show background grid]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -178,7 +178,7 @@ When this package is loaded, the following styles become available:
 \begin{tikzpicture}
   [background grid/.style={thick,draw=red,step=.5cm},
    show background grid]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     \end{stylekey}
@@ -190,7 +190,7 @@ When this package is loaded, the following styles become available:
 \tikzset{background grid/.style={thick,draw=red,step=.5cm},
          background rectangle/.style={rounded corners,fill=yellow}}
 \begin{tikzpicture}[framed,gridded]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -209,7 +209,7 @@ When this package is loaded, the following styles become available:
 \begin{tikzpicture}[
     background rectangle/.style={fill=yellow},
     framed,show background top]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -224,7 +224,7 @@ When this package is loaded, the following styles become available:
    framed,
    show background top,
    outer frame xsep=1ex]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     \end{key}
@@ -246,7 +246,7 @@ When this package is loaded, the following styles become available:
    show background bottom,%
    show background left,%
    show background right]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -258,7 +258,7 @@ When this package is loaded, the following styles become available:
 \tikzset{background rectangle/.style={fill=blue!20},
          background top/.style={draw=blue!50,line width=1ex}}
 \begin{tikzpicture}[framed,show background top]
-  \draw (0,0) ellipse (10mm and 5mm);
+  \draw (0,0) ellipse [x radius=10mm, y radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     \end{stylekey}

--- a/doc/generic/pgf/pgfmanual-en-library-calendar.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-calendar.tex
@@ -197,7 +197,7 @@ say, the |\draw| command).
         %
 \begin{codeexample}[preamble={\usetikzlibrary{calendar}}]
 \tikz \calendar[dates=2000-01-01 to 2000-01-31,week list,
-                day code={\fill[blue] (0,0) circle (2pt);}];
+                day code={\fill[blue] (0,0) circle [radius=2pt];}];
 \end{codeexample}
         %
         The default code is the following:
@@ -221,7 +221,7 @@ say, the |\draw| command).
 \begin{tikzpicture}
   \calendar (mycal) [dates=2000-01-01 to 2000-01-31,week list];
 
-  \draw[red] (mycal-2000-01-20) circle (4pt);
+  \draw[red] (mycal-2000-01-20) circle [radius=4pt];
 \end{tikzpicture}
 \end{codeexample}
     \end{key}
@@ -399,7 +399,7 @@ say, the |\draw| command).
   \calendar
     [dates=2000-01-01 to 2000-01-31,week list]
     if (Sunday)            [red]
-    if (equals=2000-01-20) {\draw (0,0) circle (8pt);};
+    if (equals=2000-01-20) {\draw (0,0) circle [radius=8pt];};
 \end{codeexample}
     %
     You might wonder why the circle seems to be ``off'' the date. Actually, it
@@ -412,7 +412,7 @@ say, the |\draw| command).
   \calendar
     [dates=2000-01-01 to 2000-01-31,week list]
     if (Sunday)            [red]
-    if (equals=2000-01-20) {\draw (0,0) circle (8pt);};
+    if (equals=2000-01-20) {\draw (0,0) circle [radius=8pt];};
 \end{codeexample}
     %
     However, the single day dates are now no longer aligned correctly. For

--- a/doc/generic/pgf/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-decorations.tex
@@ -520,7 +520,7 @@ The following deformations use only straight lines in order to morph the paths.
 \begin{tikzpicture}[>=stealth, every node/.style={midway, sloped, font=\tiny},
   decoration={show path construction,
     moveto code={
-      \fill [red] (\tikzinputsegmentfirst) circle (2pt)
+      \fill [red] (\tikzinputsegmentfirst) circle [radius=2pt]
         node [fill=none, below] {moveto};},
     lineto code={
       \draw [blue,->] (\tikzinputsegmentfirst) -- (\tikzinputsegmentlast)

--- a/doc/generic/pgf/pgfmanual-en-library-mindmaps.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-mindmaps.tex
@@ -324,8 +324,8 @@ the |mindmap| library:
 \begin{codeexample}[preamble={\usetikzlibrary{mindmap}}]
 \begin{tikzpicture}
     [decoration={start radius=1cm,end radius=.5cm,amplitude=2mm,angle=30}]
-  \fill[blue!20] (0,0)   circle (1cm);
-  \fill[red!20]  (2.5,0) circle (.5cm);
+  \fill[blue!20] (0,0)   circle [radius=1cm];
+  \fill[red!20]  (2.5,0) circle [radius=.5cm];
 
   \filldraw [draw=red,fill=black,
              decorate,decoration=circle connection bar] (1,0) -- (2,0);
@@ -340,8 +340,8 @@ the |mindmap| library:
 \begin{tikzpicture}
   [blue!50,decoration={start radius=1cm,
                        end radius=.5cm,amplitude=2mm,angle=30}]
-  \fill (0,0)   circle (1cm);
-  \fill (2.5,0) circle (.5cm);
+  \fill (0,0)   circle [radius=1cm];
+  \fill (2.5,0) circle [radius=.5cm];
 
   \fill [decorate,decoration=circle connection bar] (1,0) -- (2,0);
 \end{tikzpicture}
@@ -361,8 +361,8 @@ the |mindmap| library:
 \begin{tikzpicture}
   [blue!50,decoration={start radius=1cm,
                        end radius=.5cm,amplitude=2mm,angle=30}]
-  \fill (0,0)   circle (1cm+1pt);
-  \fill (2.4,0) circle (.5cm+1pt);
+  \fill (0,0)   circle [radius=1cm+1pt];
+  \fill (2.4,0) circle [radius=.5cm+1pt];
 
   \fill [decorate,decoration=circle connection bar] (1,0) -- (1.9,0);
 \end{tikzpicture}

--- a/doc/generic/pgf/pgfmanual-en-library-perspective.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-perspective.tex
@@ -48,7 +48,7 @@
     viewpoint/.pic={
       \draw (22.5:0.45) -- (0,0) -- (-22.5:0.45);
       \draw (0,0) ++ (22.5:0.35) arc (22.5:-22.5:0.35);
-      \draw (0.225,0) circle (0.02 and 0.09);
+      \draw (0.225,0) circle [x radius=0.02, y radius=0.09];
     }]
     \begin{scope}[3d view={-20}{20}]
       \draw[->] (-3,0,0) -- (3,0,0) node[pos=1.05]{x};

--- a/doc/generic/pgf/pgfmanual-en-library-shadings.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-shadings.tex
@@ -91,9 +91,9 @@ this library is not used.
         %
 \begin{codeexample}[preamble={\usepgflibrary{shadings}}]
 \begin{tikzpicture}
-  \shade[ball color=white] (0,0) circle (2ex);
-  \shade[ball color=red] (1,0) circle (2ex);
-  \shade[ball color=black] (2,0) circle (2ex);
+  \shade[ball color=white] (0,0) circle [radius=2ex];
+  \shade[ball color=red]   (1,0) circle [radius=2ex];
+  \shade[ball color=black] (2,0) circle [radius=2ex];
 \end{tikzpicture}
 \end{codeexample}
     \end{key}
@@ -138,15 +138,15 @@ this library is not used.
     This shading fills the path with a color wheel.
     %
 \begin{codeexample}[preamble={\usepgflibrary{shadings}}]
-\tikz \shade[shading=color wheel] (0,0) circle (1.5);
+\tikz \shade[shading=color wheel] (0,0) circle [radius=1.5];
 \end{codeexample}
     %
     To produce a color ring, cut out a circle from the color wheel:
     %
 \begin{codeexample}[preamble={\usepgflibrary{shadings}}]
 \tikz \shade[shading=color wheel] [even odd rule]
-  (0,0) circle (1.5)
-  (0,0) circle (1);
+  (0,0) circle [radius=1.5]
+  (0,0) circle [radius=1];
 \end{codeexample}
     %
 \end{shading}
@@ -156,7 +156,7 @@ this library is not used.
     the center.
     %
 \begin{codeexample}[preamble={\usepgflibrary{shadings}}]
-\tikz \shade[shading=color wheel black center] (0,0) circle (1.5);
+\tikz \shade[shading=color wheel black center] (0,0) circle [radius=1.5];
 \end{codeexample}
     %
 \end{shading}
@@ -166,7 +166,7 @@ this library is not used.
     the center.
     %
 \begin{codeexample}[preamble={\usepgflibrary{shadings}}]
-\tikz \shade[shading=color wheel white center] (0,0) circle (1.5);
+\tikz \shade[shading=color wheel white center] (0,0) circle [radius=1.5];
 \end{codeexample}
     %
 \end{shading}

--- a/doc/generic/pgf/pgfmanual-en-library-shadows.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-shadows.tex
@@ -65,7 +65,8 @@ You will not need to use this option directly under normal circumstances.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{shadows}}]
 \tikz [even odd rule]
-  \draw [general shadow={fill=red}] (0,0) circle (.5) (0.5,0) circle (.5);
+  \draw [general shadow={fill=red}]
+    (0,0) circle [radius=.5] (0.5,0) circle [radius=.5];
 \end{codeexample}
 
     \begin{key}{/tikz/shadow scale=\meta{factor} (initially 1)}
@@ -74,7 +75,7 @@ You will not need to use this option directly under normal circumstances.
 \begin{codeexample}[preamble={\usetikzlibrary{shadows}}]
 \tikz [even odd rule]
   \draw [general shadow={fill=red,shadow scale=1.25}]
-    (0,0) circle (.5) (0.5,0) circle (.5);
+    (0,0) circle [radius=.5] (0.5,0) circle [radius=.5];
 \end{codeexample}
     \end{key}
     %
@@ -84,7 +85,7 @@ You will not need to use this option directly under normal circumstances.
 \begin{codeexample}[preamble={\usetikzlibrary{shadows}}]
 \tikz [even odd rule]
   \draw [general shadow={fill=red,shadow xshift=-5pt}]
-    (0,0) circle (.5) (0.5,0) circle (.5);
+    (0,0) circle [radius=.5] (0.5,0) circle [radius=.5];
 \end{codeexample}
     \end{key}
     %
@@ -110,7 +111,8 @@ You will not need to use this option directly under normal circumstances.
 
 \begin{codeexample}[preamble={\usetikzlibrary{shadows}}]
 \tikz [even odd rule]
-  \filldraw [drop shadow,fill=white] (0,0) circle (.5) (0.5,0) circle (.5);
+  \filldraw [drop shadow,fill=white]
+    (0,0) circle [radius=.5] (0.5,0) circle [radius=.5];
 \end{codeexample}
 
 \begin{codeexample}[preamble={\usetikzlibrary{shadows,shapes.symbols}}]
@@ -124,10 +126,10 @@ You will not need to use this option directly under normal circumstances.
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (3,2);
   \filldraw [drop shadow={opacity=1},fill=white]
-    (1,2)  circle (.5) (1.5,2)  circle (.5);
+    (1,2)  circle [radius=.5] (1.5,2)  circle [radius=.5];
 
   \filldraw [drop shadow={opacity=0.25},fill=white]
-    (1,.5) circle (.5) (1.5,.5) circle (.5);
+    (1,.5) circle [radius=.5] (1.5,.5) circle [radius=.5];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -139,7 +141,8 @@ You will not need to use this option directly under normal circumstances.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{shadows}}]
 \begin{tikzpicture}[every shadow/.style={opacity=.8,fill=blue!50!black}]
-  \filldraw [drop shadow,fill=white] (0,0) circle (.5) (0.5,0) circle (.5);
+  \filldraw [drop shadow,fill=white]
+    (0,0) circle [radius=.5] (0.5,0) circle [radius=.5];
 \end{tikzpicture}
 \end{codeexample}
     %

--- a/doc/generic/pgf/pgfmanual-en-library-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-shapes.tex
@@ -896,7 +896,7 @@ anchors.
 \begin{codeexample}[preamble={\usetikzlibrary{shapes.symbols}}]
 \begin{tikzpicture}
   \draw [help lines] grid (3,2);
-  \draw [blue, dashed] (1.5, 1) ellipse (1.5cm and 1cm);
+  \draw [blue, dashed] (1.5, 1) ellipse [x radius=1.5cm, y radius=1cm];
   \node [cloud, cloud puffs=9, draw, minimum width=3cm, minimum height=2cm]
     at (1.5, 1) {};
 \end{tikzpicture}

--- a/doc/generic/pgf/pgfmanual-en-main-body.tex
+++ b/doc/generic/pgf/pgfmanual-en-main-body.tex
@@ -733,14 +733,14 @@ inheritance), \emph{methods}, \emph{attributes} and \emph{objects}.
   \foreach \pos in {-1,1,2,3}
     \draw[shift={(0,\pos)}] (2pt,0pt) -- (-2pt,0pt) node[left] {$\pos$};
 
-  \fill (0,0) circle (0.064cm);
+  \fill (0,0) circle [radius=0.064cm];
   \draw[thick,parametric,domain=0.4:1.5,samples=200]
     % The plot is reparameterised such that there are more samples
     % near the center.
     plot[id=asymptotic-example] function{(t*t*t)*sin(1/(t*t*t)),(t*t*t)*cos(1/(t*t*t))}
     node[right] {$\bigl(x(t),y(t)\bigr) = (t\sin \frac{1}{t}, t\cos \frac{1}{t})$};
 
-  \fill[red] (0.63662,0) circle (2pt)
+  \fill[red] (0.63662,0) circle [radius=2pt]
     node [below right,fill=white,yshift=-4pt] {$(\frac{2}{\pi},0)$};
 \end{tikzpicture}
 \end{codeexample}
@@ -837,7 +837,7 @@ work.
     (3,-1)--(4,-1);
   \draw[below left] (0,0) node(s){$s$};
   \draw[below left] (2,5) node(t){$t$};
-  \fill (0,0) circle (0.06cm) (2,5) circle (0.06cm);
+  \fill (0,0) circle [radius=0.06cm] (2,5) circle [radius=0.06cm];
   \draw[->,rounded corners=0.2cm,shorten >=2pt]
     (1.5,0.5)-- ++(0,-1)-- ++(1,0)-- ++(0,2)-- ++(-1,0)-- ++(0,2)-- ++(1,0)--
     ++(0,1)-- ++(-1,0)-- ++(0,-1)-- ++(-2,0)-- ++(0,3)-- ++(2,0)-- ++(0,-1)--

--- a/doc/generic/pgf/pgfmanual-en-pgffor.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgffor.tex
@@ -74,7 +74,7 @@ This section describes the package |pgffor|, which is loaded automatically by
 \begin{codeexample}[]
 \tikz
   \foreach \x in {0,1,2,3}
-    \draw (\x,0) circle (0.2cm);
+    \draw (\x,0) circle [radius=0.2cm];
 \end{codeexample}
 
     However, the ``reading till the next semicolon'' is not the whole truth.
@@ -87,8 +87,8 @@ This section describes the package |pgffor|, which is loaded automatically by
   \foreach \x in {0,1,2,3}
     \foreach \y in {0,1,2,3}
       {
-        \draw (\x,\y) circle (0.2cm);
-        \fill (\x,\y) circle (0.1cm);
+        \draw (\x,\y) circle [radius=0.2cm];
+        \fill (\x,\y) circle [radius=0.1cm];
       }
 \end{tikzpicture}
 \end{codeexample}
@@ -252,17 +252,17 @@ This section describes the package |pgffor|, which is loaded automatically by
 \begin{tikzpicture}
   % Let's draw circles at interesting points:
   \foreach \x / \y / \r in {0 / 0 / 2mm, 1 / 1 / 3mm, 2 / 0 / 1mm}
-    \draw (\x,\y) circle (\r);
+    \draw (\x,\y) circle [radius=\r];
 
   % Same effect
   \foreach \center/\r in {{(0,0)/2mm}, {(1,1)/3mm}, {(2,0)/1mm}}
-    \draw[yshift=2.5cm] \center circle (\r);
+    \draw[yshift=2.5cm] \center circle [radius=\r];
 \end{tikzpicture}
 \end{codeexample}
 
 \begin{codeexample}[]
 \begin{tikzpicture}[line cap=round,line width=3pt]
-  \filldraw [fill=yellow!80!black] (0,0) circle (2cm);
+  \filldraw [fill=yellow!80!black] (0,0) circle [radius=2cm];
 
   \foreach \angle / \label in
     {0/3, 30/2, 60/1, 90/12, 120/11, 150/10, 180/9,
@@ -284,7 +284,7 @@ This section describes the package |pgffor|, which is loaded automatically by
 \tikz[shading=ball]
   \foreach \x / \cola in {0/red,1/green,2/blue,3/yellow}
     \foreach \y / \colb in {0/red,1/green,2/blue,3/yellow}
-      \shade[ball color=\cola!50!\colb] (\x,\y) circle (0.4cm);
+      \shade[ball color=\cola!50!\colb] (\x,\y) circle [radius=0.4cm];
 \end{codeexample}
 
 
@@ -406,7 +406,7 @@ This section describes the package |pgffor|, which is loaded automatically by
   \foreach \x in {1,...,4}
     \foreach \y in {1,...,4}
     {
-      \fill[red!50] (\x,\y) ellipse (3pt and 6pt);
+      \fill[red!50] (\x,\y) ellipse [x radius=3pt, y radius=6pt];
 
       \ifnum \x<\y
         \breakforeach

--- a/doc/generic/pgf/pgfmanual-en-tikz-actions.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-actions.tex
@@ -24,21 +24,21 @@ special cases of the more general method: Here, the |\path| command is used to
 specify the path. Then, options encountered on the path indicate what should be
 done with the path.
 
-For example, |\path (0,0) circle (1cm);| means: ``This is a path consisting of
+For example, |\path (0,0) circle [radius=1cm];| means: ``This is a path consisting of
 a circle around the origin. Do not do anything with it (throw it away).''
 However, if the option |draw| is encountered anywhere on the path, the circle
 will be drawn. ``Anywhere'' is any point on the path where an option can be
-given, which is everywhere where a path command like |circle (1cm)| or
+given, which is everywhere where a path command like |circle [radius=1cm]| or
 |rectangle (1,1)| or even just |(0,0)| would also be allowed. Thus, the
 following commands all draw the same circle:
 %
 \begin{codeexample}[code only]
-\path [draw] (0,0) circle (1cm);
-\path (0,0) [draw] circle (1cm);
-\path (0,0) circle (1cm) [draw];
+\path [draw] (0,0) circle [radius=1cm];
+\path (0,0) [draw] circle [radius=1cm];
+\path (0,0) circle [radius=1cm] [draw];
 \end{codeexample}
 %
-Finally, |\draw (0,0) circle (1cm);| also draws a path, because |\draw| is an
+Finally, |\draw (0,0) circle [radius=1cm];| also draws a path, because |\draw| is an
 abbreviation for |\path [draw]| and thus the command expands to the first line
 of the above example.
 
@@ -47,12 +47,12 @@ abbreviation for the command |\path[fill,draw]|. Since options accumulate, the
 following commands all have the same effect:
 %
 \begin{codeexample}[code only]
-\path [draw,fill]   (0,0) circle (1cm);
-\path [draw] [fill] (0,0) circle (1cm);
-\path [fill] (0,0) circle (1cm) [draw];
-\draw [fill] (0,0) circle (1cm);
-\fill (0,0) [draw] circle (1cm);
-\filldraw (0,0) circle (1cm);
+\path [draw,fill]   (0,0) circle [radius=1cm];
+\path [draw] [fill] (0,0) circle [radius=1cm];
+\path [fill] (0,0) circle [radius=1cm] [draw];
+\draw [fill] (0,0) circle [radius=1cm];
+\fill (0,0) [draw] circle [radius=1cm];
+\filldraw (0,0) circle [radius=1cm];
 \end{codeexample}
 
 In the following subsection the different actions that can be performed on a
@@ -107,13 +107,13 @@ The most unspecific option for setting colors is the following:
     extensions are allowed. Here is an example:
     %
 \begin{codeexample}[]
-\tikz \fill[color=red!20] (0,0) circle (1ex);
+\tikz \fill[color=red!20] (0,0) circle [radius=1ex];
 \end{codeexample}
 
     It is possible to ``leave out'' the |color=| part and you can also write:
     %
 \begin{codeexample}[]
-\tikz \fill[red!20] (0,0) circle (1ex);
+\tikz \fill[red!20] (0,0) circle [radius=1ex];
 \end{codeexample}
     %
     What happens is that every option that \tikzname\ does not know, like
@@ -183,7 +183,7 @@ You can draw a path using the following option:
     %
 \begin{codeexample}[]
 \begin{tikzpicture}
-  \path[draw=red] (0,0) -- (1,1) -- (2,1) circle (10pt);
+  \path[draw=red] (0,0) -- (1,1) -- (2,1) circle [radius=10pt];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -662,9 +662,9 @@ To fill a path, use the following option:
 \begin{codeexample}[]
 \begin{tikzpicture}
   \fill (0,0) -- (1,1) -- (2,1);
-  \fill (4,0) circle (.5cm)  (4.5,0) circle (.5cm);
-  \fill[even odd rule] (6,0) circle (.5cm)  (6.5,0) circle (.5cm);
-  \fill (8,0) -- (9,1) -- (10,0) circle (.5cm);
+  \fill (4,0) circle [radius=.5cm]  (4.5,0) circle [radius=.5cm];
+  \fill[even odd rule] (6,0) circle [radius=.5cm]  (6.5,0) circle [radius=.5cm];
+  \fill (8,0) -- (9,1) -- (10,0) circle [radius=.5cm];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -680,9 +680,9 @@ To fill a path, use the following option:
 \begin{codeexample}[]
 \begin{tikzpicture}[fill=yellow!80!black,line width=5pt]
   \filldraw (0,0) -- (1,1) -- (2,1);
-  \filldraw (4,0) circle (.5cm)  (4.5,0) circle (.5cm);
-  \filldraw[even odd rule] (6,0) circle (.5cm)  (6.5,0) circle (.5cm);
-  \filldraw (8,0) -- (9,1) -- (10,0) circle (.5cm);
+  \filldraw (4,0) circle [radius=.5cm]  (4.5,0) circle [radius=.5cm];
+  \filldraw[even odd rule] (6,0) circle [radius=.5cm]  (6.5,0) circle [radius=.5cm];
+  \filldraw (8,0) -- (9,1) -- (10,0) circle [radius=.5cm];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -725,7 +725,7 @@ simulated ones.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{patterns}}]
 \begin{tikzpicture}
-  \draw[pattern=dots] (0,0) circle (1cm);
+  \draw[pattern=dots] (0,0) circle [radius=1cm];
   \draw[pattern=fivepointed stars] (0,0) rectangle (3,1);
 \end{tikzpicture}
 \end{codeexample}
@@ -738,7 +738,7 @@ simulated ones.
     %
 \begin{codeexample}[preamble={\usetikzlibrary{patterns}}]
 \begin{tikzpicture}
-  \draw[pattern color=red,pattern=fivepointed stars]  (0,0) circle (1cm);
+  \draw[pattern color=red,pattern=fivepointed stars]  (0,0) circle [radius=1cm];
   \draw[pattern color=blue,pattern=fivepointed stars] (0,0) rectangle (3,1);
 \end{tikzpicture}
 \end{codeexample}
@@ -816,7 +816,7 @@ determined:
 \begin{codeexample}[]
 \begin{tikzpicture}
   \filldraw[fill=yellow!80!black,even odd rule]
-    (0,0) rectangle (1,1) (0.5,0.5) circle (0.4cm);
+    (0,0) rectangle (1,1) (0.5,0.5) circle [radius=0.4cm];
   \draw[->] (0.5,0.5) -- +(0,1) [above] node{crossings: $1+1 = 2$};
 \end{tikzpicture}
 \end{codeexample}
@@ -875,7 +875,7 @@ that makes this process much easier:
 \begin{codeexample}[]
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (3,2);
-  \filldraw [fill=blue!10,draw=blue,thick] (1.5,1) circle (1)
+  \filldraw [fill=blue!10,draw=blue,thick] (1.5,1) circle [radius=1]
     [path picture={
       \node at (path picture bounding box.center) {
         This is a long text.
@@ -893,7 +893,7 @@ that makes this process much easier:
             (path picture bounding box.north east);
     }}]
   \draw [help lines] (0,0) grid (3,2);
-  \filldraw [cross,fill=blue!10,draw=blue,thick] (1,1) circle (1);
+  \filldraw [cross,fill=blue!10,draw=blue,thick] (1,1) circle [radius=1];
   \path     [cross,top color=red,draw=red,thick] (2,0) -- (3,2) -- (3,0);
 \end{tikzpicture}
 \end{codeexample}
@@ -907,7 +907,7 @@ that makes this process much easier:
   \draw     [help lines] (0,0) grid (3,2);
 
   \draw [path image=brave-gnu-world-logo,draw=blue,thick]
-          (0,1) circle (1);
+          (0,1) circle [radius=1];
   \draw [path image=brave-gnu-world-logo,draw=red,very thick,->]
           (1,0) parabola[parabola height=2cm] (3,0);
 
@@ -931,18 +931,18 @@ only the shading changes its color smoothly from one color to another.
     it makes no sense.
     %
 \begin{codeexample}[]
-\tikz \shade (0,0) circle (1ex);
+\tikz \shade (0,0) circle [radius=1ex];
 \end{codeexample}
 
 \begin{codeexample}[]
-\tikz \shadedraw (0,0) circle (1ex);
+\tikz \shadedraw (0,0) circle [radius=1ex];
 \end{codeexample}
     %
 \end{key}
 
 For some shadings it is not really clear how they can ``fill'' the path. For
 example, the |ball| shading normally looks like this:
-\tikz \shade[shading=ball] (0,0) circle (0.75ex);. How is this supposed to
+\tikz \shade[shading=ball] (0,0) circle [radius=0.75ex];. How is this supposed to
 shade a rectangle? Or a triangle?
 
 To solve this problem, the predefined shadings like |ball| or |axis| fill a
@@ -966,7 +966,7 @@ are needed, which are explained below.
 \begin{codeexample}[]
 \tikz \shadedraw [shading=axis] (0,0) rectangle (1,1);
 \tikz \shadedraw [shading=radial] (0,0) rectangle (1,1);
-\tikz \shadedraw [shading=ball] (0,0) circle (.5cm);
+\tikz \shadedraw [shading=ball] (0,0) circle [radius=.5cm];
 \end{codeexample}
 
     The shadings as well as additional shadings are described in more detail in
@@ -1040,7 +1040,7 @@ Left of picture\begin{tikzpicture}
 Left of picture
 \begin{tikzpicture}
   \useasboundingbox (0,0) rectangle (3,1);
-  \fill (.75,.25) circle (.5cm);
+  \fill (.75,.25) circle [radius=.5cm];
 \end{tikzpicture}
 right of picture.
 \end{codeexample}
@@ -1062,13 +1062,13 @@ the size of the bounding box of the current path.
 %
 \begin{codeexample}[]
 \begin{tikzpicture}
-  \draw[red] (0,0) circle (2pt);
-  \draw[red] (2,1) circle (3pt);
+  \draw[red] (0,0) circle [radius=2pt];
+  \draw[red] (2,1) circle [radius=3pt];
 
   \draw (current bounding box.south west) rectangle
         (current bounding box.north east);
 
-  \draw[red] (3,-1) circle (4pt);
+  \draw[red] (3,-1) circle [radius=4pt];
 
   \draw[thick] (current bounding box.south west) rectangle
                (current bounding box.north east);
@@ -1098,7 +1098,7 @@ keys:
 Text before image.%
     \begin{tikzpicture}[trim left]
         \draw (-1,-1) grid (3,2);
-        \fill (0,0) circle (5pt);
+        \fill (0,0) circle [radius=5pt];
     \end{tikzpicture}%
 Text after image.
 \end{codeexample}
@@ -1112,25 +1112,25 @@ Text after image.
 \begin{codeexample}[pre={\vbox\bgroup\hsize=5cm},post=\egroup,width=8cm]
 \begin{tikzpicture}
     \draw (0,1) -- (0,0) -- (1,1) -- cycle;
-    \fill (0,0) circle (2pt);
+    \fill (0,0) circle [radius=2pt];
     \node[left] at (0,0) {$-1$};
 \end{tikzpicture}
 \par
 \begin{tikzpicture}
     \draw (0,1) -- (0,0) -- (1,1) -- cycle;
-    \fill (0,0) circle (2pt);
+    \fill (0,0) circle [radius=2pt];
     \node[left] at (0,0) {$1$};
 \end{tikzpicture}
 \par
 \begin{tikzpicture}[trim left]
     \draw (0,1) -- (0,0) -- (1,1) -- cycle;
-    \fill (0,0) circle (2pt);
+    \fill (0,0) circle [radius=2pt];
     \node[left] at (0,0) {$-1$};
 \end{tikzpicture}
 \par
 \begin{tikzpicture}[trim left]
     \draw (0,1) -- (0,0) -- (1,1) -- cycle;
-    \fill (0,0) circle (2pt);
+    \fill (0,0) circle [radius=2pt];
     \node[left] at (0,0) {$1$};
 \end{tikzpicture}
 \end{codeexample}
@@ -1151,7 +1151,7 @@ Text after image.
 Text before image.%
     \begin{tikzpicture}[trim left, trim right=2cm, baseline]
         \draw (-1,-1) grid (3,2);
-        \fill (0,0) circle (5pt);
+        \fill (0,0) circle [radius=5pt];
     \end{tikzpicture}%
 Text after image.
 \end{codeexample}
@@ -1207,8 +1207,8 @@ transparency in general.
     %
 \begin{codeexample}[]
 \begin{tikzpicture}
-  \draw[clip] (0,0) circle (1cm);
-  \fill[red] (1,0) circle (1cm);
+  \draw[clip] (0,0) circle [radius=1cm];
+  \fill[red] (1,0) circle [radius=1cm];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1220,8 +1220,8 @@ transparency in general.
     %
 \begin{codeexample}[]
 \begin{tikzpicture}
-  \clip (0,0) circle (1cm);
-  \fill[red] (1,0) circle (1cm);
+  \clip (0,0) circle [radius=1cm];
+  \fill[red] (1,0) circle [radius=1cm];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1310,7 +1310,7 @@ the following two options:
     [preaction={fill=black,opacity=.5,
                 transform canvas={xshift=1mm,yshift=-1mm}}]
     [fill=red] (0,0) rectangle (1,2)
-               (1,2) circle (5mm);
+               (1,2) circle [radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1334,7 +1334,7 @@ the following two options:
                 transform canvas={xshift=1mm,yshift=-1mm}}]
     [preaction={top color=blue,bottom color=white}]
                (0,0) rectangle (1,2)
-               (1,2) circle (5mm);
+               (1,2) circle [radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1413,7 +1413,7 @@ the following two options:
     [postaction={path fading=south,fading angle=45,fill=blue,opacity=.5}]
     [left color=black,right color=red,draw=white,line width=2mm]
                (0,0) rectangle (1,2)
-               (1,2) circle (5mm);
+               (1,2) circle [radius=5mm];
 \end{tikzpicture}
 \end{codeexample}
     %

--- a/doc/generic/pgf/pgfmanual-en-tikz-animations.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-animations.tex
@@ -72,7 +72,7 @@ As a simple example, let us move a circle within thirty seconds by three
 centimeters to the left:
 %
 \begin{codeexample}[width=2cm,preamble={\usetikzlibrary{animations}}]
-\tikz \draw :xshift = {0s = "0cm", 30s = "-3cm", repeats} (0,0) circle (5mm);
+\tikz \draw :xshift = {0s = "0cm", 30s = "-3cm", repeats} (0,0) circle [radius=5mm];
 \end{codeexample}
 
 As can be seen, a special syntax is used in several places: Entries with a

--- a/doc/generic/pgf/pgfmanual-en-tikz-coordinates.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-coordinates.tex
@@ -104,8 +104,8 @@ Let us start with the basic coordinate systems.
 \begin{tikzpicture}
   \draw[help lines] (0,0) grid (3,2);
 
-  \fill (canvas cs:x=1cm,y=1.5cm)    circle (2pt);
-  \fill (canvas cs:x=2cm,y=-5mm+2pt) circle (2pt);
+  \fill (canvas cs:x=1cm,y=1.5cm)    circle [radius=2pt];
+  \fill (canvas cs:x=2cm,y=-5mm+2pt) circle [radius=2pt];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -117,8 +117,8 @@ Let us start with the basic coordinate systems.
 \begin{tikzpicture}
   \draw[help lines] (0,0) grid (3,2);
 
-  \fill (1cm,1.5cm)    circle (2pt);
-  \fill (2cm,-5mm+2pt) circle (2pt);
+  \fill (1cm,1.5cm)    circle [radius=2pt];
+  \fill (2cm,-5mm+2pt) circle [radius=2pt];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -533,7 +533,7 @@ following coordinate system:
 %
 %   \fill[red] (intersection cs:
 %     first line={(A)--(B)},
-%     second line={(1,2)--(3,0)}) circle (2pt);
+%     second line={(1,2)--(3,0)}) circle [radius=2pt];
 % \end{tikzpicture}
 % \end{codeexample}
 %
@@ -579,7 +579,7 @@ following coordinate system:
 %   \coordinate [label=135:$e$] (e) at (intersection of u--v and a--b);
 %
 %   \foreach \p in {a,b,c,d,e,u,v}
-%     \fill [opacity=.5] (\p) circle (8pt);
+%     \fill [opacity=.5] (\p) circle [radius=8pt];
 % \end{tikzpicture}
 % \end{codeexample}
 % \end{coordinatesystem}
@@ -672,7 +672,7 @@ coordinate systems. For this, the following commands are used:
 \begin{tikzpicture}[z=0.2pt]
   \draw [->] (0,0,0) -- (0,0,350);
   \foreach \num in {0,10,...,350}
-    \fill (cylindrical cs:angle=\num,radius=1,z=\num) circle (1pt);
+    \fill (cylindrical cs:angle=\num,radius=1,z=\num) circle [radius=1pt];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -808,11 +808,11 @@ To find the intersection of named paths, the following key is used:
 \begin{codeexample}[preamble={\usetikzlibrary{intersections}}]
 \begin{tikzpicture}[every node/.style={opacity=1, black, above left}]
   \draw [help lines] grid (3,2);
-  \draw [name path=ellipse] (2,0.5) ellipse (0.75cm and 1cm);
+  \draw [name path=ellipse] (2,0.5) ellipse [x radius=0.75cm, y radius=1cm];
   \draw [name path=rectangle, rotate=10] (0.5,0.5) rectangle +(2,1);
   \fill [red, opacity=0.5, name intersections={of=ellipse and rectangle}]
-    (intersection-1) circle (2pt) node {1}
-    (intersection-2) circle (2pt) node {2};
+    (intersection-1) circle [radius=2pt] node {1}
+    (intersection-2) circle [radius=2pt] node {2};
 \end{tikzpicture}
 \end{codeexample}
 
@@ -841,7 +841,7 @@ To find the intersection of named paths, the following key is used:
 
   \fill [name intersections={of=curve 1 and curve 2, name=i, total=\t}]
         [red, opacity=0.5, every node/.style={above left, black, opacity=1}]
-        \foreach \s in {1,...,\t}{(i-\s) circle (2pt) node {\footnotesize\s}};
+    \foreach \s in {1,...,\t}{(i-\s) circle [radius=2pt] node {\footnotesize\s}};
 \end{tikzpicture}
 \end{codeexample}
 
@@ -861,8 +861,8 @@ To find the intersection of named paths, the following key is used:
   \draw [name path=curve 2] (-1,-2) .. controls (-1,8) and (1,-8) .. (1,2);
 
   \fill [name intersections={of=curve 1 and curve 2, by={a,b}}]
-        (a) circle (2pt)
-        (b) circle (2pt);
+        (a) circle [radius=2pt]
+        (b) circle [radius=2pt];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -904,7 +904,7 @@ To find the intersection of named paths, the following key is used:
   \draw [->, name path=line]  (0,-.5) -- (1,2) ;
   \fill [name intersections={of=line and curve,sort by=\pathname, name=i}]
     [red, opacity=0.5, every node/.style={left=.25cm, black, opacity=1}]
-    \foreach \s in {1,2,3}{(i-\s) circle (2pt) node {\footnotesize\s}};
+    \foreach \s in {1,2,3}{(i-\s) circle [radius=2pt] node {\footnotesize\s}};
 }
 \end{tikzpicture}
 \end{codeexample}
@@ -1079,7 +1079,7 @@ that is $1/3 \text{cm}$ to the right of the point |a|:
   \draw [help lines] (0,0) grid (3,2);
 
   \node (a) at (1,1) {A};
-  \fill [red] ($(a) + 1/3*(1cm,0)$) circle (2pt);
+  \fill [red] ($(a) + 1/3*(1cm,0)$) circle [radius=2pt];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1145,10 +1145,10 @@ Here are some examples of coordinate specifications that consist of exactly one
 \begin{tikzpicture}
   \draw [help lines] (0,0) grid (3,2);
 
-  \fill [red] ($2*(1,1)$) circle (2pt);
-  \fill [green] (${1+1}*(1,.5)$) circle (2pt);
-  \fill [blue] ($cos(0)*sin(90)*(1,1)$) circle (2pt);
-  \fill [black] (${3*(4-3)}*(1,0.5)$) circle (2pt);
+  \fill [red] ($2*(1,1)$) circle [radius=2pt];
+  \fill [green] (${1+1}*(1,.5)$) circle [radius=2pt];
+  \fill [blue] ($cos(0)*sin(90)*(1,1)$) circle [radius=2pt];
+  \fill [black] (${3*(4-3)}*(1,0.5)$) circle [radius=2pt];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1214,7 +1214,7 @@ Here are two examples:
 
   \draw[->,red] (a) -- (c);
 
-  \fill ($ (a)!.5! 10:(b) $) circle (2pt);
+  \fill ($ (a)!.5! 10:(b) $) circle [radius=2pt];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1223,7 +1223,7 @@ Here are two examples:
   \draw [help lines] (0,0) grid (4,4);
 
   \foreach \i in {0,0.125,...,2}
-    \fill ($(2,2) !\i! \i*180:(3,2)$) circle (2pt);
+    \fill ($(2,2) !\i! \i*180:(3,2)$) circle [radius=2pt];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1236,7 +1236,7 @@ another (possibly different) modifier.
 
   \draw (0,0) -- (3,2);
   \draw[red] ($(0,0)!.3!(3,2)$) -- (3,0);
-  \fill[red] ($(0,0)!.3!(3,2)!.7!(3,0)$) circle (2pt);
+  \fill[red] ($(0,0)!.3!(3,2)!.7!(3,0)$) circle [radius=2pt];
 \end{tikzpicture}
 \end{codeexample}
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-decorations.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-decorations.tex
@@ -362,7 +362,7 @@ the following option, which allows you to decorate a path ``after the fact''.
 \begin{tikzpicture}[decoration=zigzag]
   \draw [help lines] (0,0) grid (3,5);
 
-  \draw [fill=blue!20,decorate] (1.5,4) circle (1cm);
+  \draw [fill=blue!20,decorate] (1.5,4) circle [radius=1cm];
 
   \node at (1.5,2.5) [fill=red!20,decorate,ellipse] {Ellipse};
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-matrices.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-matrices.tex
@@ -55,8 +55,8 @@ tree, and so on. Also, you can refer to the different anchors of a matrix.
   \draw[help lines] (0,0) grid (4,2);
   \node [matrix,fill=red!20,draw=blue,very thick] (my matrix) at (2,1)
   {
-    \draw (0,0)   circle (4mm); & \node[rotate=10] {Hello};        \\
-    \draw (0.2,0) circle (2mm); & \fill[red]   (0,0) circle (3mm); \\
+    \draw (0,0)   circle [radius=4mm]; & \node[rotate=10] {Hello};             \\
+    \draw (0.2,0) circle [radius=2mm]; & \fill[red] (0,0) circle [radius=3mm]; \\
   };
 
   \draw [very thick,->] (0,0) |- (my matrix.west);
@@ -137,9 +137,9 @@ bounding boxes).
 
   \matrix [draw=red]
   {
-    \node {a}; \fill[blue] (0,0) circle (2pt); &
-    \node {X}; \fill[blue] (0,0) circle (2pt); &
-    \node {g}; \fill[blue] (0,0) circle (2pt); \\
+    \node {a}; \fill[blue] (0,0) circle [radius=2pt]; &
+    \node {X}; \fill[blue] (0,0) circle [radius=2pt]; &
+    \node {g}; \fill[blue] (0,0) circle [radius=2pt]; \\
   };
 \end{tikzpicture}
 \end{codeexample}
@@ -188,9 +188,9 @@ an implementation detail.)
 \begin{tikzpicture}[every node/.style={draw}]
   \matrix [draw=red]
   {
-    \node[left]  {Hallo}; \fill[blue] (0,0) circle (2pt); \\
-    \node        {X};     \fill[blue] (0,0) circle (2pt); \\
-    \node[right] {g};     \fill[blue] (0,0) circle (2pt); \\
+    \node[left]  {Hallo}; \fill[blue] (0,0) circle [radius=2pt]; \\
+    \node        {X};     \fill[blue] (0,0) circle [radius=2pt]; \\
+    \node[right] {g};     \fill[blue] (0,0) circle [radius=2pt]; \\
   };
 \end{tikzpicture}
 \end{codeexample}
@@ -310,14 +310,14 @@ locally overrule the standard setting for this line pair.
 %
 \begin{codeexample}[]
 \begin{tikzpicture}
-  \matrix [row sep=1mm]
+  \matrix [row sep=1mm, radius=2mm]
   {
-    \draw (0,0) circle (2mm); & \draw (0,0) circle (2mm); \\
-    \draw (0,0) circle (2mm); & \draw (0,0) circle (2mm); \\[-1mm]
-    \draw (0,0) coordinate (a) circle (2mm); &
-    \draw (0,0) circle (2mm); \\[1cm,between origins]
-    \draw (0,0) coordinate (b) circle (2mm); &
-    \draw (0,0) circle (2mm); \\
+    \draw (0,0) circle; & \draw (0,0) circle; \\
+    \draw (0,0) circle; & \draw (0,0) circle; \\[-1mm]
+    \draw (0,0) coordinate (a) circle; &
+    \draw (0,0) circle; \\[1cm,between origins]
+    \draw (0,0) coordinate (b) circle; &
+    \draw (0,0) circle; \\
   };
   \draw [<->,red,thick] (a.center) -- (b.center) node [right,midway] {1cm};
 \end{tikzpicture}
@@ -698,7 +698,7 @@ an argument to a matrix:
     \node {a}; & \node(inner node) {b}; & \node {c}; & \node {d}; \\
     \node {a}; & \node             {b}; & \node {c}; & \node {d}; \\
   };
-  \draw (inner node.south) circle (1pt);
+  \draw (inner node.south) circle [radius=1pt];
 \end{tikzpicture}
 \end{codeexample}
     %
@@ -727,8 +727,8 @@ option to avoid having to type |\pgfmatrixnextcell| each time:
 \tikz
   \matrix [ampersand replacement=\&]
   {
-    \draw (0,0)   circle (4mm); \& \node[rotate=10] {Hello};        \\
-    \draw (0.2,0) circle (2mm); \& \fill[red]   (0,0) circle (3mm); \\
+    \draw (0,0)   circle [radius=4mm]; \& \node[rotate=10] {Hello};             \\
+    \draw (0.2,0) circle [radius=2mm]; \& \fill[red] (0,0) circle [radius=3mm]; \\
   };
 \end{codeexample}
     %

--- a/doc/generic/pgf/pgfmanual-en-tikz-paths.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-paths.tex
@@ -1344,7 +1344,7 @@ to the |node| operation and discussed in detail in Section~\ref{section-pics}.
     current path, see Section~\ref{section-tikz-animations} for details.
     %
 \begin{codeexample}[width=2cm,preamble={\usetikzlibrary{animations}}]
-\tikz \draw :xshift = {0s = "0cm", 30s = "-3cm", repeats} (0,0) circle (5mm);
+\tikz \draw :xshift = {0s = "0cm", 30s = "-3cm", repeats} (0,0) circle [radius=5mm];
 \end{codeexample}
     %
 \end{pathoperation}
@@ -1418,7 +1418,7 @@ soft path subsystem, refer to section~\ref{section-soft-paths}.
   \path[save path=\pathB,name path=B]
     (0,0) .. controls (.33,.1) and (.66,.9) .. (1,1);
 
-  \fill[name intersections={of=A and B}] (intersection-1) circle (1pt);
+  \fill[name intersections={of=A and B}] (intersection-1) circle [radius=1pt];
 
   \draw[blue][use path=\pathA];
   \draw[red] [use path=\pathB];

--- a/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
@@ -1187,12 +1187,12 @@ list for predefined shapes is given in Section~\ref{section-predefined-shapes}).
 \medskip\noindent
 \begin{tikzpicture}
   \path node[minimum height=2cm,minimum width=5cm,fill=blue!25](x) {Big node};
-  \fill (x.north)      circle (2pt) node[above] {|north|}
-        (x.north east) circle (2pt) node[above] {|north east|}
-        (x.north west) circle (2pt) node[above] {|north west|}
-        (x.west) circle (2pt)       node[left]  {|west|}
-        (x.east) circle (2pt)       node[right] {|east|}
-        (x.base) circle (2pt)       node[below] {|base|};
+  \fill (x.north)      circle [radius=2pt] node[above] {|north|}
+        (x.north east) circle [radius=2pt] node[above] {|north east|}
+        (x.north west) circle [radius=2pt] node[above] {|north west|}
+        (x.west) circle [radius=2pt]       node[left]  {|west|}
+        (x.east) circle [radius=2pt]       node[right] {|east|}
+        (x.base) circle [radius=2pt]       node[below] {|base|};
 \end{tikzpicture}
 
 Now, when you place a node at a certain coordinate, you can ask \tikzname\ to
@@ -1250,11 +1250,11 @@ you to select the standard anchors more intuitively:
     node is additionally shifted upwards by the given \meta{offset}.
     %
 \begin{codeexample}[]
-\tikz \fill (0,0) circle (2pt) node[above] {above};
+\tikz \fill (0,0) circle [radius=2pt] node[above] {above};
 \end{codeexample}
     %
 \begin{codeexample}[]
-\tikz \fill (0,0) circle (2pt) node[above=2pt] {above};
+\tikz \fill (0,0) circle [radius=2pt] node[above=2pt] {above};
 \end{codeexample}
     %
 \end{key}
@@ -1280,7 +1280,7 @@ you to select the standard anchors more intuitively:
     parameter to something more sensible.)
     %
 \begin{codeexample}[]
-\tikz \fill (0,0) circle (2pt) node[above left] {above left};
+\tikz \fill (0,0) circle [radius=2pt] node[above left] {above left};
 \end{codeexample}
     %
 \end{key}
@@ -1289,7 +1289,7 @@ you to select the standard anchors more intuitively:
     Similar to  |above left|.
     %
 \begin{codeexample}[]
-\tikz \fill (0,0) circle (2pt) node[above right] {above right};
+\tikz \fill (0,0) circle [radius=2pt] node[above right] {above right};
 \end{codeexample}
     %
 \end{key}
@@ -2978,7 +2978,7 @@ The next example adds a circle in the middle of the page.
 \begin{codeexample}[]
 \begin{tikzpicture}[remember picture,overlay]
   \draw [line width=1mm,opacity=.25]
-    (current page.center) circle (3cm);
+    (current page.center) circle [radius=3cm];
 \end{tikzpicture}
 \end{codeexample}
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
@@ -159,9 +159,9 @@ time.
     %
 \begin{codeexample}[]
 \begin{tikzpicture}[thick,fill opacity=0.5]
-  \filldraw[fill=red]   (0:1cm)    circle (12mm);
-  \filldraw[fill=green] (120:1cm)  circle (12mm);
-  \filldraw[fill=blue]  (-120:1cm) circle (12mm);
+  \filldraw[fill=red]   (0:1cm)    circle [radius=12mm];
+  \filldraw[fill=green] (120:1cm)  circle [radius=12mm];
+  \filldraw[fill=blue]  (-120:1cm) circle [radius=12mm];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -196,8 +196,8 @@ filling and you stroke or fill the same area twice, the effect accumulates:
 %
 \begin{codeexample}[]
 \begin{tikzpicture}[fill opacity=0.5]
-  \fill[red] (0,0) circle (1);
-  \fill[red] (1,0) circle (1);
+  \fill[red] (0,0) circle [radius=1];
+  \fill[red] (1,0) circle [radius=1];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -237,9 +237,9 @@ renderers, let alone printers, will have trouble rendering blending correctly.
 \tikz {
   \begin{scope}[transparency group]
     \begin{scope}[blend mode=screen]
-      \fill[red!90!black]   ( 90:.6) circle (1);
-      \fill[green!80!black] (210:.6) circle (1);
-      \fill[blue!90!black]  (330:.6) circle (1);
+      \fill[red!90!black]   ( 90:.6) circle [radius=1];
+      \fill[green!80!black] (210:.6) circle [radius=1];
+      \fill[blue!90!black]  (330:.6) circle [radius=1];
     \end{scope}
   \end{scope}
 }
@@ -256,9 +256,9 @@ renderers, let alone printers, will have trouble rendering blending correctly.
         %
 \begin{codeexample}[]
 \tikz [blend group=screen] {
-  \fill[red!90!black]   ( 90:.6) circle (1);
-  \fill[green!80!black] (210:.6) circle (1);
-  \fill[blue!90!black]  (330:.6) circle (1);
+  \fill[red!90!black]   ( 90:.6) circle [radius=1];
+  \fill[green!80!black] (210:.6) circle [radius=1];
+  \fill[blue!90!black]  (330:.6) circle [radius=1];
 }
 \end{codeexample}
     \end{key}
@@ -286,29 +286,29 @@ renderers, let alone printers, will have trouble rendering blending correctly.
     \def\showmode#1#2{
         \makeline{
             \tikz [blend mode=#1,baseline=-.5ex] {
-              \fill[red]      ( 90:.5em) circle (.75em);
-              \fill[green]    (210:.5em) circle (.75em);
-              \fill[blue]     (330:.5em) circle (.75em);
+              \fill[red]      ( 90:.5em) circle [radius=.75em];
+              \fill[green]    (210:.5em) circle [radius=.75em];
+              \fill[blue]     (330:.5em) circle [radius=.75em];
               \scoped[yshift=-2.5em]{
-                \fill[red!50]   ( 90:.5em) circle (.75em);
-                \fill[green!50] (210:.5em) circle (.75em);
-                \fill[blue!50]  (330:.5em) circle (.75em);
+                \fill[red!50]   ( 90:.5em) circle [radius=.75em];
+                \fill[green!50] (210:.5em) circle [radius=.75em];
+                \fill[blue!50]  (330:.5em) circle [radius=.75em];
               }
             }
             \tikz [blend mode=#1,baseline=-.5ex] {
-              \fill[rg]       ( 90:.5em) circle (.75em);
-              \fill[gb]       (210:.5em) circle (.75em);
-              \fill[br]       (330:.5em) circle (.75em);
+              \fill[rg]       ( 90:.5em) circle [radius=.75em];
+              \fill[gb]       (210:.5em) circle [radius=.75em];
+              \fill[br]       (330:.5em) circle [radius=.75em];
               \scoped[yshift=-2.5em]{
-                \fill[rg!50]  ( 90:.5em) circle (.75em);
-                \fill[gb!50]  (210:.5em) circle (.75em);
-                \fill[br!50]  (330:.5em) circle (.75em);
+                \fill[rg!50]  ( 90:.5em) circle [radius=.75em];
+                \fill[gb!50]  (210:.5em) circle [radius=.75em];
+                \fill[br!50]  (330:.5em) circle [radius=.75em];
               }
             }
             \tikz [blend mode=#1,baseline=-.5ex+1.25em] {
-              \shade[ball color=red]   ( 90:1em) circle (1.5em);
-              \shade[ball color=green] (210:1em) circle (1.5em);
-              \shade[ball color=blue]  (330:1em) circle (1.5em);
+              \shade[ball color=red]   ( 90:1em) circle [radius=1.5em];
+              \shade[ball color=green] (210:1em) circle [radius=1.5em];
+              \shade[ball color=blue]  (330:1em) circle [radius=1.5em];
             }}{\verb|#1|}{#2}%
                % this argument was changed from {|#1|}
                % --> see <https://sourceforge.net/p/pgf/bugs/486/>
@@ -437,7 +437,7 @@ commands, which are \emph{only defined in the library}, namely the library
 \begin{tikzfadingfrompicture}[name=fade right with circle]
   \shade[left color=transparent!0,
          right color=transparent!100] (0,0) rectangle (2,2);
-  \fill[transparent!50] (1,1) circle (0.7);
+  \fill[transparent!50] (1,1) circle [radius=0.7];
 \end{tikzfadingfrompicture}
 
 % Now we use the fading in another picture:
@@ -569,8 +569,8 @@ current scope or path.
   \fill [color=blue]                   (0.5,1.5) rectangle +(1,1);
   \fill [color=blue,path fading=north] (2.5,1.5) rectangle +(1,1);
 
-  \fill [color=red,path fading]        (1,0.75) ellipse (.75 and .5);
-  \fill [color=red]                    (3,0.75) ellipse (.75 and .5);
+  \fill [color=red,path fading]  (1,0.75) ellipse [x radius=.75, y radius=.5];
+  \fill [color=red]              (3,0.75) ellipse [x radius=.75, y radius=.5];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -600,9 +600,9 @@ current scope or path.
   \path [pattern=checkerboard,pattern color=black!30] (0,0) rectangle (4,1.5);
 
   \fill [red,path fading,fading transform={rotate=90}]
-    (1,0.75) ellipse (.75 and .5);
+    (1,0.75) ellipse [x radius=.75, y radius=.5];
   \fill [red,path fading,fading transform={rotate=30}]
-    (3,0.75) ellipse (.75 and .5);
+    (3,0.75) ellipse [x radius=.75, y radius=.5];
 \end{tikzpicture}
 \end{codeexample}
     \end{key}
@@ -620,7 +620,7 @@ current scope or path.
   \fill [black!20] (0,0) rectangle (4,4);
   \path [pattern=checkerboard,pattern color=black!30] (0,0) rectangle (4,4);
 
-  \shade [ball color=blue,path fading=south] (2,2) circle (1.8);
+  \shade [ball color=blue,path fading=south] (2,2) circle [radius=1.8];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -636,8 +636,8 @@ current scope or path.
   \fill [black!20] (0,0) rectangle (4,4);
   \path [pattern=checkerboard,pattern color=black!30] (0,0) rectangle (4,4);
 
-  \shade [ball color=red] (3,3) circle (0.8);
-  \shade [ball color=white,path fading=fade inside] (2,2) circle (1.8);
+  \shade [ball color=red] (3,3) circle [radius=0.8];
+  \shade [ball color=white,path fading=fade inside] (2,2) circle [radius=1.8];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -661,10 +661,10 @@ pleasing effects:
               minimum size=3.6cm] {};
   \pattern   [path fading=north,
               pattern=horizontal lines dark gray]
-    (0,0) circle (1.8cm);
+    (0,0) circle [radius=1.8cm];
   \pattern   [path fading=middle,
               pattern=crosshatch dots light steel blue]
-    (0,0) circle (1.8cm);
+    (0,0) circle [radius=1.8cm];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -706,9 +706,9 @@ then all subsequent drawings in the scope are faded. You will use a
   \path [scope fading=south,fit fading=false] (0,0);
   % fading is centered at its natural size
 
-  \fill[red]   ( 90:1) circle (1);
-  \fill[green] (210:1) circle (1);
-  \fill[blue]  (330:1) circle (1);
+  \fill[red]   ( 90:1) circle [radius=1];
+  \fill[green] (210:1) circle [radius=1];
+  \fill[blue]  (330:1) circle [radius=1];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -723,9 +723,9 @@ then all subsequent drawings in the scope are faded. You will use a
 
   \path [scope fading=south] (-2,-2) rectangle (2,2);
 
-  \fill[red]   ( 90:1) circle (1);
-  \fill[green] (210:1) circle (1);
-  \fill[blue]  (330:1) circle (1);
+  \fill[red]   ( 90:1) circle [radius=1];
+  \fill[green] (210:1) circle [radius=1];
+  \fill[blue]  (330:1) circle [radius=1];
 \end{tikzpicture}
 \end{codeexample}
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-trees.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-trees.tex
@@ -160,8 +160,8 @@ beginning of the path. Here is an example:
 \begin{codeexample}[]
 \begin{tikzpicture}
   \node {root}
-    child {[fill] circle (2pt)}
-    child {[fill] circle (2pt)};
+    child {[fill] circle [radius=2pt]}
+    child {[fill] circle [radius=2pt]};
 \end{tikzpicture}
 \end{codeexample}
 

--- a/doc/generic/pgf/pgfmanual-en-tutorial-Euclid.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial-Euclid.tex
@@ -63,7 +63,7 @@ found on his website at Clark University.}
   \draw [output] (B) -- (C);
 
   \foreach \point in {A,B,C}
-    \fill [black,opacity=.5] (\point) circle (2pt);
+    \fill [black,opacity=.5] (\point) circle [radius=2pt];
 
   \begin{pgfonlayer}{background}
     \fill[triangle!80] (A) -- (C) -- (B) -- cycle;
@@ -236,7 +236,7 @@ Euclid would write the following:
   \draw (A) let
               \p1 = ($ (B) - (A) $)
             in
-              circle ({veclen(\x1,\y1)});
+              circle [radius={veclen(\x1,\y1)}];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -277,8 +277,8 @@ braces.
   \draw let \p1 = ($ (B) - (A) $),
             \n2 = {veclen(\x1,\y1)}
         in
-          (A) circle (\n2)
-          (B) circle (\n2);
+          (A) circle [radius=\n2]
+          (B) circle [radius=\n2];
 \end{tikzpicture}
 \end{codeexample}
 %
@@ -298,8 +298,8 @@ also use a longer name, but then we have to use curly braces:
   \draw let \p1        = ($ (B) - (A) $),
             \n{radius} = {veclen(\x1,\y1)}
         in
-          (A) circle (\n{radius})
-          (B) circle (\n{radius});
+          (A) circle [radius=\n{radius}]
+          (B) circle [radius=\n{radius}];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -412,7 +412,7 @@ drawing the triangle behind everything at the end.
   \draw [output] (A) -- (C) -- (B);
 
   \foreach \point in {A,B,C}
-    \fill [black,opacity=.5] (\point) circle (2pt);
+    \fill [black,opacity=.5] (\point) circle [radius=2pt];
 
   \begin{pgfonlayer}{background}
     \fill[triangle!80] (A) -- (C) -- (B) -- cycle;
@@ -470,7 +470,7 @@ The second proposition in the Elements is the following:
   \draw [output] (A) -- (L);
 
   \foreach \point in {A,B,C,D,G,L}
-    \fill [black,opacity=.5] (\point) circle (2pt);
+    \fill [black,opacity=.5] (\point) circle [radius=2pt];
 
   \node [below right, text width=9cm,align=justify] at (4,4) {
     \small\textbf{Proposition II}\par
@@ -622,7 +622,7 @@ by the radius of the circle~$H$. Here is the code for computing $H$:
   \node (H) [label=135:$H$,draw,circle through=(C)] at (B) {};
   \path let \p1 = ($ (B) - (C) $) in
     coordinate [label=left:$G$] (G) at ($ (B) ! veclen(\x1,\y1) ! (F) $);
-  \fill[red,opacity=.5] (G) circle (2pt);
+  \fill[red,opacity=.5] (G) circle [radius=2pt];
 \end{codeexample}
 
 However, there is a simpler way: We can simply name the path of the circle and
@@ -645,7 +645,7 @@ intersections.
   \node (H) [name path=H,label=135:$H$,draw,circle through=(C)] at (B) {};
   \path [name path=B--F] (B) -- (F);
   \path [name intersections={of=H and B--F,by={[label=left:$G$]G}}];
-  \fill[red,opacity=.5] (G) circle (2pt);
+  \fill[red,opacity=.5] (G) circle [radius=2pt];
 \end{codeexample}
 }%
 
@@ -685,7 +685,7 @@ intersections.
   \draw [output] (A) -- (L);
 
   \foreach \point in {A,B,C,D,G,L}
-    \fill [black,opacity=.5] (\point) circle (2pt);
+    \fill [black,opacity=.5] (\point) circle [radius=2pt];
 
   % \node ...
 \end{tikzpicture}

--- a/doc/generic/pgf/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial.tex
@@ -583,7 +583,7 @@ say |\path[draw,clip]|.) Here is an example:
 %
 \begin{codeexample}[]
 \begin{tikzpicture}[scale=3]
-  \clip[draw] (0.5,0.5) circle (.6cm);
+  \clip[draw] (0.5,0.5) circle [radius=.6cm];
   \draw[step=.5cm,gray,very thin] (-1.4,-1.4) grid (1.4,1.4);
   \draw (-1.5,0) -- (1.5,0);
   \draw (0,-1.5) -- (0,1.5);
@@ -696,7 +696,7 @@ transition between different colors is used. For this, |\shade| and
 |\shadedraw|, for shading and drawing at the same time, can be used:
 %
 \begin{codeexample}[]
-  \tikz \shade (0,0) rectangle (2,1)  (3,0.5) circle (.5cm);
+  \tikz \shade (0,0) rectangle (2,1)  (3,0.5) circle [radius=.5cm];
 \end{codeexample}
 %
 The default shading is a smooth transition from gray to white. To specify
@@ -707,7 +707,7 @@ different colors, you can use options:
   \shade[top color=yellow,bottom color=black] (0,0) rectangle +(2,1);
   \shade[left color=yellow,right color=black] (3,0) rectangle +(2,1);
   \shadedraw[inner color=yellow,outer color=black,draw=yellow] (6,0) rectangle +(2,1);
-  \shade[ball color=green] (9,.5) circle (.5cm);
+  \shade[ball color=green] (9,.5) circle [radius=.5cm];
 \end{tikzpicture}
 \end{codeexample}
 
@@ -1096,7 +1096,7 @@ however, be dimensionless real numbers) as in the following example:
 %
 \begin{codeexample}[]
 \tikz \foreach \x in {1,...,10}
-        \draw (\x,0) circle (0.4cm);
+        \draw (\x,0) circle [radius=0.4cm];
 \end{codeexample}
 
 If you provide \emph{two} numbers before the |...|, the |\foreach| statement


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

Fixes #999 

**Maybe open points**

- [ ] some codes now extend over the blue box on the right by one or two characters. Is this ok, shall I change the indention or introduce new lines?
  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-tikz-coordinates.tex#L844

    <img width="616" height="163" alt="grafik" src="https://github.com/user-attachments/assets/4fafdaff-fd43-4f1f-b0ba-13dc63062429" />

  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-tikz-matrices.tex#L58-L59
    
    <img width="621" height="180" alt="grafik" src="https://github.com/user-attachments/assets/145f0c73-2a07-418c-b0dd-19215e3aeb72" />

  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-tikz-matrices.tex#L730-L731

    <img width="558" height="91" alt="grafik" src="https://github.com/user-attachments/assets/4d8b2306-541b-4c73-9134-a4b444448a7e" />

- [ ] some examples could be improved to use a "global" `radius` option to avoid repetition like in
  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-base-nodes.tex#L732-L742
  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-library-shadows.tex#L66-L70
    and the following examples
  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-main-body.tex#L840
- [ ] the changes lead to (TeX file) line length >80. I guess I should refrain from adjusting that, right?
  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-introduction.tex#L25
  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-tikz-actions.tex#L27
  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-tikz-actions.tex#L41
  - [ ] https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-tikz-actions.tex#L945
- [ ] unrelated noticed stuff which could be fixed here as well, in another PR or let it as it is. What do you think?
  - [ ] spaces only line
        https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-base-nodes.tex#L1110
  - [ ] final space
        https://github.com/Mo-Gul/pgf/blob/b59e677baf2297d5fd893286aea5d50adb9fdc39/doc/generic/pgf/pgfmanual-en-introduction.tex#L256


**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
