### PR TITLE
ci: add versioned name suffix to manual archives

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -41,17 +41,30 @@ jobs:
         )
         echo "::notice file=build/doc/pgfmanual.log,title=Overfull hbox(es)::$OVERFULL_HBOX"
 
+    - name: Generate versioned name
+      run: |
+        if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            # example: feat_feature-branch-dc5462ca
+            prefix="${GITHUB_HEAD_REF//\//_}-$(git describe --always)"
+        else
+            # example: 3.1.11-4-dc5462ca
+            prefix="$(git describe --tags)"
+        fi
+        echo "prefix=$prefix" >> "$GITHUB_ENV"
+        cp build/doc/pgfmanual.pdf build/doc/pgfmanual-"${prefix}".pdf
+
     - name: Upload manual
       uses: actions/upload-artifact@v7
       with:
-        name: pgfmanual
-        path: build/doc/pgfmanual.pdf
+        path: build/doc/pgfmanual-${{ env.prefix }}.pdf
+        archive: false
 
     - name: Upload manual with aux
       uses: actions/upload-artifact@v7
       with:
-        name: pgfmanual-with-aux
+        name: pgfmanual-with-aux-${{ env.prefix }}
         path: |
+          # versioned manual PDF is not included here
           build/doc/pgfmanual.*
           !build/doc/pgfmanual.tex
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -45,24 +45,24 @@ jobs:
       run: |
         if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             # example: feat_feature-branch-dc5462ca
-            prefix="${GITHUB_HEAD_REF//\//_}-$(git describe --always)"
+            suffix="${GITHUB_HEAD_REF//\//_}-$(git describe --always)"
         else
             # example: 3.1.11-4-dc5462ca
-            prefix="$(git describe --tags)"
+            suffix="$(git describe --tags)"
         fi
-        echo "prefix=$prefix" >> "$GITHUB_ENV"
-        cp build/doc/pgfmanual.pdf build/doc/pgfmanual-"${prefix}".pdf
+        echo "suffix=$suffix" >> "$GITHUB_ENV"
+        cp build/doc/pgfmanual.pdf build/doc/pgfmanual-"${suffix}".pdf
 
     - name: Upload manual
       uses: actions/upload-artifact@v7
       with:
-        path: build/doc/pgfmanual-${{ env.prefix }}.pdf
+        path: build/doc/pgfmanual-${{ env.suffix }}.pdf
         archive: false
 
     - name: Upload manual with aux
       uses: actions/upload-artifact@v7
       with:
-        name: pgfmanual-with-aux-${{ env.prefix }}
+        name: pgfmanual-with-aux-${{ env.suffix }}
         path: |
           # versioned manual PDF is not included here
           build/doc/pgfmanual.*


### PR DESCRIPTION
**Motivation for this change**

Distinct long names are better than auto-renamed thus confusing (e.g., "manual (1).zip") short names.

Also do not zip the single-PDF manual archive.

Names of test diff archives are _not_ changed, as I think they are more likely to be short-lived.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
