### PR TITLE
chore: setup pre-commit for example extraction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# https://pre-commit.com/
+
+# required by "language: unsupported" hook config
+minimum_pre_commit_version: "4.4.0"
+
+repos:
+- repo: local
+  hooks:
+  - id: manual-examples
+    name: Extract manual examples
+    language: unsupported
+    entry: l3build examples
+    files: |
+      (?x)^(
+        build\.lua$|
+        doc/generic/pgf/|
+        tex/generic/pgf/(lua|graphdrawing/lua)/|
+        testfiles-examples/|
+      )
+    pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   - id: manual-examples
     name: Extract manual examples
     language: unsupported
-    entry: l3build examples
+    entry: env PGF_QUIET=1 l3build examples
     files: |
       (?x)^(
         build\.lua$|

--- a/doc/generic/pgf/extract-common.lua
+++ b/doc/generic/pgf/extract-common.lua
@@ -10,6 +10,14 @@ local C, Cf, Cg, Ct, P, S, V = lpeg.C, lpeg.Cf, lpeg.Cg, lpeg.Ct, lpeg.P, lpeg.S
 
 local common = {}
 
+-- print if PGF_QUIET is not set
+local function print_new(str)
+  if not os.getenv("PGF_QUIET") then
+    print(str)
+  end
+end
+common.print = print_new
+
 -- strip leading and trailing whitespace
 local function strip(str)
     return str:match"^%s*(.-)%s*$"

--- a/doc/generic/pgf/extract-gd.lua
+++ b/doc/generic/pgf/extract-gd.lua
@@ -123,7 +123,7 @@ local function render(module)
     pcall(require, module)
     local ok, err = pcall(DocumentParser.include, module)
     if not ok then
-        print("Skipping " .. module .. ": " .. tostring(err))
+        common.print("Skipping " .. module .. ": " .. tostring(err))
         return nil
     end
     return table.concat(buffer, "\n")
@@ -145,7 +145,7 @@ for _, module in ipairs(module_list(manualdir)) do
     if text then
         local matches = common.extractor:match(text) or {}
         if #matches > 0 then
-            print("Processing " .. module)
+            common.print("Processing " .. module)
             -- A short, deterministic label derived from the module name, e.g.
             -- pgf.gd.layered.library -> gd-layered-library-1.
             local prefix = "gd-" .. module:gsub("^pgf%.gd%.", ""):gsub("%.", "-")

--- a/doc/generic/pgf/extract.lua
+++ b/doc/generic/pgf/extract.lua
@@ -55,7 +55,7 @@ local function walk(sourcedir, targetdir)
             lfs.mkdir(targetdir .. file)
             walk(sourcedir .. file .. pathsep, targetdir .. file .. pathsep)
         elseif lfs.attributes(sourcedir .. file, "mode") == "file" then
-            print("Processing " .. sourcedir .. file)
+            common.print("Processing " .. sourcedir .. file)
 
             -- Read file into memory
             local f = io.open(sourcedir .. file)


### PR DESCRIPTION
**Motivation for this change**

Setup [`pre-commit`](https://pre-commit.com/) so it's easier to ensure the extracted manual examples are in sync with the manual sources.

`l3build examples` took ~1s to finish on my machine and in CI.

**Minimal introduction to `pre-commit`**

- Install `pre-commit`: `uv tool install pre-commit` for [`uv`](https://docs.astral.sh/uv/) users
- Install `pre-commit` to local repo:
  ```shell
  cd /path/to/repo

  # install into "pre-commit" git hook
  pre-commit install  
  
  # install into other git hook, e.g., "pre-push"
  pre-commit install --hook-type pre-push
  ```
  Then the hooks defined in `.pre-commit-config.yaml` will run automatically at certain git step(s). See also [git hooks doc](https://git-scm.com/docs/githooks).
- Misc
  ```
  # trigger `pre-commit` manually
  # use -a/--all-files to run on all files, skipping file filtering
  pre-commit run
  
  # use --no-verify to bypass git hooks
  # for example to bypass the "pre-commit" git hook
  git commit --no-verify ...
  ```

**Example `pre-commit` outputs, with this PR, in `pgf` repo**

Hook was skipped
```
Extract manual examples..............................(no files to check)Skipped
```
Hook was run and passed
```
Extract manual examples..................................................Passed
```
Hook was run but failed
```
Extract manual examples..................................................Failed
- hook id: manual-examples
- files were modified by this hook

[stdout of "l3build examples"]
```

In the last case, long stdout of `l3build example` made the `pre-commit` error message  less helpful, which could be improved.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
