### PR TITLE
docs: format TeX logos using `hologo` pkg

### DIFF
--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [Unreleased]
 
 ### Changed
 

--- a/doc/generic/pgf/CHANGELOG.md
+++ b/doc/generic/pgf/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+
+- Typo fixes in the manual
+
 ## [3.1.12] - 2026-08-01 Henri Menke
 
 ### BREAKING CHANGES

--- a/doc/generic/pgf/pgfmanual-en-base-actions.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-actions.tex
@@ -222,8 +222,8 @@ count on this.
     filling. However, a |\color| command will always ``immediately override''
     any special settings for the stroke and fill colors.
 
-    In plain \TeX, this command will also work, but the problem of
-    \emph{defining} a color arises. After all, plain \TeX\ does not provide
+    In \hologo{plainTeX}, this command will also work, but the problem of
+    \emph{defining} a color arises. After all, \hologo{plainTeX} does not provide
     \LaTeX\ colors. For this reason, \pgfname\ implements a minimalistic
     ``emulation'' of the |\definecolor|, |\colorlet|, and |\color| commands.
     Only gray-scale and rgb colors are supported. For most cases this turns out

--- a/doc/generic/pgf/pgfmanual-en-base-decorations.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-decorations.tex
@@ -716,7 +716,7 @@ Once a decoration has been declared, it can be used.
 \end{environment}
 
 \begin{plainenvironment}{{pgfdecoration}\marg{name}}
-    The plain-\TeX{} version of the |{pgfdecorate}| environment.
+    The \hologo{plainTeX} version of the |{pgfdecorate}| environment.
     \todosp{`pgfdecorate' right or `pgfdecoration'? really no idea}
 \end{plainenvironment}
 
@@ -973,7 +973,7 @@ only use one meta-decoration per path.
 \end{environment}
 
 \begin{plainenvironment}{{pgfmetadecoration}\marg{name}}
-    The plain \TeX{} version of the |{pgfmetadecoration}| environment.
+    The \hologo{plainTeX} version of the |{pgfmetadecoration}| environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfmetadecoration}\marg{name}}

--- a/doc/generic/pgf/pgfmanual-en-base-decorations.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-decorations.tex
@@ -716,8 +716,7 @@ Once a decoration has been declared, it can be used.
 \end{environment}
 
 \begin{plainenvironment}{{pgfdecoration}\marg{name}}
-    The \hologo{plainTeX} version of the |{pgfdecorate}| environment.
-    \todosp{`pgfdecorate' right or `pgfdecoration'? really no idea}
+    The \hologo{plainTeX} version of the |{pgfdecoration}| environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfdecoration}\marg{name}}
@@ -973,9 +972,9 @@ only use one meta-decoration per path.
 \end{environment}
 
 \begin{plainenvironment}{{pgfmetadecoration}\marg{name}}
-    The \hologo{plainTeX} version of the |{pgfmetadecoration}| environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfmetadecoration}\marg{name}}
-    The \hologo{ConTeXt} version of the |{pgfmetadecoration}| environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}

--- a/doc/generic/pgf/pgfmanual-en-base-decorations.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-decorations.tex
@@ -721,7 +721,7 @@ Once a decoration has been declared, it can be used.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfdecoration}\marg{name}}
-    The Con\TeX t version of the |{pgfdecoration}| environment.
+    The \hologo{ConTeXt} version of the |{pgfdecoration}| environment.
 \end{contextenvironment}
 
 For convenience, the following macros provide a ``shorthand'' for decorations
@@ -977,5 +977,5 @@ only use one meta-decoration per path.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfmetadecoration}\marg{name}}
-    The Con\TeX t version of the |{pgfmetadecoration}| environment.
+    The \hologo{ConTeXt} version of the |{pgfmetadecoration}| environment.
 \end{contextenvironment}

--- a/doc/generic/pgf/pgfmanual-en-base-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-external.tex
@@ -222,7 +222,7 @@ page that contains exactly the graphic produced by the code between
 |\beginpgfgraphicnamed{survey-graphic1}| and |\endpgfgraphicnamed|.
 Furthermore, the size of this single page is exactly the size of the graphic.
 
-If you use pdf\TeX, producing the graphic is even simpler:
+If you use \hologo{pdfTeX}, producing the graphic is even simpler:
 %
 \begin{codeexample}[code only, tikz syntax=false]
 bash> pdflatex --jobname=survey-graphic1 survey.tex
@@ -426,7 +426,7 @@ By comparison, in this figure we see a rectangle:
 \end{document}
 \end{codeexample}
 %
-If we now run pdf\LaTeX, then, indeed, \pgfname\ is no longer needed:
+If we now run \hologo{pdfLaTeX}, then, indeed, \pgfname\ is no longer needed:
 % In the following, we switch off typesetting of listings because the
 % parentheses confuse the pretty printer
 %

--- a/doc/generic/pgf/pgfmanual-en-base-images.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-images.tex
@@ -26,12 +26,12 @@ facilities of \pgfname:
 %
 \begin{itemize}
     \item There is no standard image inclusion mechanism in your format. For
-        example, plain \TeX\ does not have one, so \pgfname's inclusion
+        example, \hologo{plainTeX} does not have one, so \pgfname's inclusion
         mechanism is ``better than nothing''.
 
         However, this applies only to the |pdftex| backend. For all other
         backends, \pgfname\ currently maps its commands back to the |graphicx|
-        package. Thus, in plain \TeX, this does not really help. It might be a
+        package. Thus, in \hologo{plainTeX}, this does not really help. It might be a
         good idea to fix this in the future such that \pgfname\ becomes
         independent of \LaTeX, thereby providing a uniform image abstraction
         for all formats.

--- a/doc/generic/pgf/pgfmanual-en-base-layers.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-layers.tex
@@ -122,7 +122,7 @@ certain commands should, instead, be added to the given layer.
 \end{environment}
 
 \begin{plainenvironment}{{pgfonlayer}\marg{layer name}}
-    This is the plain \TeX\ version of the environment.
+    This is the \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfonlayer}\marg{layer name}}

--- a/doc/generic/pgf/pgfmanual-en-base-layers.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-layers.tex
@@ -126,7 +126,7 @@ certain commands should, instead, be added to the given layer.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfonlayer}\marg{layer name}}
-    This is the Con\TeX t version of the environment.
+    This is the \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 

--- a/doc/generic/pgf/pgfmanual-en-base-layers.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-layers.tex
@@ -122,11 +122,11 @@ certain commands should, instead, be added to the given layer.
 \end{environment}
 
 \begin{plainenvironment}{{pgfonlayer}\marg{layer name}}
-    This is the \hologo{plainTeX} version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfonlayer}\marg{layer name}}
-    This is the \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 

--- a/doc/generic/pgf/pgfmanual-en-base-nodes.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-nodes.tex
@@ -629,7 +629,7 @@ proceed as follows:
 %
 \begin{enumerate}
     \item You have to use a backend driver that supports position tracking.
-        pdf\TeX\ is one such driver, |dvips| currently is not.
+        \hologo{pdfTeX} is one such driver, |dvips| currently is not.
     \item You have to say |\pgfrememberpicturepositiononpagetrue| somewhere
         before or inside every picture
         %

--- a/doc/generic/pgf/pgfmanual-en-base-plots.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-plots.tex
@@ -364,7 +364,7 @@ set table "#1.table"; set format "%.5f"
     \begin{key}{/pgf/plot/gnuplot call=\meta{gnuplot invocation} (initially gnuplot)}
         This key can be used to change the way gnuplot is called.
 
-        Some portable MiK\TeX{} distribution needs something like the
+        Some portable \hologo{MiKTeX} distribution needs something like the
         following.
         %
 \begin{codeexample}[code only]

--- a/doc/generic/pgf/pgfmanual-en-base-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-scopes.tex
@@ -341,13 +341,13 @@ Rectangles \begin{pgfpicture}
 
     There are several reasons why the remembering is not switched on by
     default. First, it does not work for all backend drivers (currently, it
-    works only for pdf\TeX). Second, it requires two passes of \TeX\ over the
+    works only for \hologo{pdfTeX}). Second, it requires two passes of \TeX\ over the
     file; on the first pass all positions will be wrong. Third, for every
     remembered picture a line is added to the |.aux|-file, which may result in
     a large number of extra lines.
 
     Despite all these ``problems'', for documents that are processed with
-    pdf\TeX\ and in which there is only a small number of pictures (less than a
+    \hologo{pdfTeX} and in which there is only a small number of pictures (less than a
     hundred or so), you can switch on this option globally, it will not cause
     any significant slowing of \TeX.
 \end{environment}

--- a/doc/generic/pgf/pgfmanual-en-base-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-scopes.tex
@@ -183,7 +183,7 @@ The following package is just a convenience.
     Once the core has been loaded, you can use this command to load further
     modules. The modules in the \meta{module names} list should be separated by
     commas. Instead of curly braces, you can also use square brackets, which is
-    something Con\TeX t users will like. If you try to load a module a second
+    something \hologo{ConTeXt} users will like. If you try to load a module a second
     time, nothing will happen.
 
     \example |\usepgfmodule{matrix,shapes}|
@@ -192,7 +192,7 @@ The following package is just a convenience.
     |pgfmodule|\meta{module}|.code.tex| for each \meta{module} in the list of
     \meta{module names}. Thus, to write your own module, all you need to do is
     to place a file of the appropriate name somewhere \TeX\ can find it.
-    \LaTeX, plain \TeX, and Con\TeX t users can then use your library.
+    \LaTeX, plain \TeX, and \hologo{ConTeXt} users can then use your library.
 \end{command}
 
 The following modules are available for use with |pgfcore|: \todosp{In the
@@ -232,7 +232,7 @@ decorations.
     loaded for each \meta{library} in the \meta{list of libraries}. This means
     that in order to write your own library file, place a file of the
     appropriate name somewhere where \TeX\ can find it. \LaTeX, plain \TeX, and
-    Con\TeX t users can then use your library.
+    \hologo{ConTeXt} users can then use your library.
 
     You should also consider adding a \tikzname\ library that simply includes
     your \pgfname\ library.
@@ -358,7 +358,7 @@ Rectangles \begin{pgfpicture}
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfpicture}}
-    This is the Con\TeX t version of the environment.
+    This is the \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 {\let\ifpgfrememberpicturepositiononpage=\relax
@@ -499,7 +499,7 @@ following environment:
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfscope}}
-    This is the Con\TeX t version of the environment.
+    This is the \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 The following scopes also encapsulate certain properties of the graphic state.
@@ -530,7 +530,7 @@ However, they are typically not used directly by the user.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptpath}}
-    Con\TeX t version of the environment.
+    \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 \begin{environment}{{pgfinterruptpicture}}
@@ -566,7 +566,7 @@ However, they are typically not used directly by the user.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptpicture}}
-    Con\TeX t version of the environment.
+    \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 \begin{environment}{{pgfinterruptboundingbox}}
@@ -582,7 +582,7 @@ However, they are typically not used directly by the user.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptboundingbox}}
-    Con\TeX t version of the environment.
+    \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 
@@ -772,7 +772,7 @@ commands (and, also, by the commands that call them, in turn):
     call |\pgfscope| inside or outside the id scope.
 \end{environment}
 
-The Plain\TeX\ and Con\TeX t versions of the environment are:
+The Plain\TeX\ and \hologo{ConTeXt} versions of the environment are:
 %
 \begin{plainenvironment}{{pgfidscope}}
 \end{plainenvironment}

--- a/doc/generic/pgf/pgfmanual-en-base-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-scopes.tex
@@ -358,7 +358,7 @@ Rectangles \begin{pgfpicture}
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfpicture}}
-    This is the \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 {\let\ifpgfrememberpicturepositiononpage=\relax
@@ -495,11 +495,11 @@ following environment:
 \end{environment}
 
 \begin{plainenvironment}{{pgfscope}}
-    \Hologo{plainTeX} version of the |{pgfscope}| environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfscope}}
-    This is the \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 The following scopes also encapsulate certain properties of the graphic state.
@@ -526,11 +526,11 @@ However, they are typically not used directly by the user.
 \end{environment}
 
 \begin{plainenvironment}{{pgfinterruptpath}}
-    \Hologo{plainTeX} version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptpath}}
-    \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 \begin{environment}{{pgfinterruptpicture}}
@@ -562,11 +562,11 @@ However, they are typically not used directly by the user.
 \end{environment}
 
 \begin{plainenvironment}{{pgfinterruptpicture}}
-    \Hologo{plainTeX} version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptpicture}}
-    \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 \begin{environment}{{pgfinterruptboundingbox}}
@@ -578,11 +578,11 @@ However, they are typically not used directly by the user.
 \end{environment}
 
 \begin{plainenvironment}{{pgfinterruptboundingbox}}
-    \Hologo{plainTeX} version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptboundingbox}}
-    \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 
@@ -772,12 +772,12 @@ commands (and, also, by the commands that call them, in turn):
     call |\pgfscope| inside or outside the id scope.
 \end{environment}
 
-The \Hologo{plainTeX} and \hologo{ConTeXt} versions of the environment are:
-%
 \begin{plainenvironment}{{pgfidscope}}
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfidscope}}
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 

--- a/doc/generic/pgf/pgfmanual-en-base-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-scopes.tex
@@ -192,7 +192,7 @@ The following package is just a convenience.
     |pgfmodule|\meta{module}|.code.tex| for each \meta{module} in the list of
     \meta{module names}. Thus, to write your own module, all you need to do is
     to place a file of the appropriate name somewhere \TeX\ can find it.
-    \LaTeX, plain \TeX, and \hologo{ConTeXt} users can then use your library.
+    \LaTeX, \hologo{plainTeX}, and \hologo{ConTeXt} users can then use your library.
 \end{command}
 
 The following modules are available for use with |pgfcore|: \todosp{In the
@@ -231,7 +231,7 @@ decorations.
     This command causes the file |pgflibrary|\meta{library}|.code.tex| to be
     loaded for each \meta{library} in the \meta{list of libraries}. This means
     that in order to write your own library file, place a file of the
-    appropriate name somewhere where \TeX\ can find it. \LaTeX, plain \TeX, and
+    appropriate name somewhere where \TeX\ can find it. \LaTeX, \hologo{plainTeX}, and
     \hologo{ConTeXt} users can then use your library.
 
     You should also consider adding a \tikzname\ library that simply includes
@@ -353,7 +353,7 @@ Rectangles \begin{pgfpicture}
 \end{environment}
 
 \begin{plainenvironment}{{pgfpicture}}
-    The plain \TeX\ version of the environment. Note that in this version,
+    The \hologo{plainTeX} version of the environment. Note that in this version,
     also, a \TeX\ group is created around the environment.
 \end{plainenvironment}
 
@@ -495,7 +495,7 @@ following environment:
 \end{environment}
 
 \begin{plainenvironment}{{pgfscope}}
-    Plain \TeX\ version of the |{pgfscope}| environment.
+    \Hologo{plainTeX} version of the |{pgfscope}| environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfscope}}
@@ -526,7 +526,7 @@ However, they are typically not used directly by the user.
 \end{environment}
 
 \begin{plainenvironment}{{pgfinterruptpath}}
-    Plain \TeX\ version of the environment.
+    \Hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptpath}}
@@ -562,7 +562,7 @@ However, they are typically not used directly by the user.
 \end{environment}
 
 \begin{plainenvironment}{{pgfinterruptpicture}}
-    Plain \TeX\ version of the environment.
+    \Hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptpicture}}
@@ -578,7 +578,7 @@ However, they are typically not used directly by the user.
 \end{environment}
 
 \begin{plainenvironment}{{pgfinterruptboundingbox}}
-    Plain \TeX\ version of the environment.
+    \Hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfinterruptboundingbox}}
@@ -772,7 +772,7 @@ commands (and, also, by the commands that call them, in turn):
     call |\pgfscope| inside or outside the id scope.
 \end{environment}
 
-The Plain\TeX\ and \hologo{ConTeXt} versions of the environment are:
+The \Hologo{plainTeX} and \hologo{ConTeXt} versions of the environment are:
 %
 \begin{plainenvironment}{{pgfidscope}}
 \end{plainenvironment}

--- a/doc/generic/pgf/pgfmanual-en-base-transformations.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-transformations.tex
@@ -702,11 +702,11 @@ section).
 \end{environment}
 
 \begin{plainenvironment}{{pgflowlevelscope}\marg{transformation code}}
-    \Hologo{plainTeX} version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgflowlevelscope}\marg{transformation code}}
-    \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 
@@ -760,11 +760,11 @@ graphic.
 \end{environment}
 
 \begin{plainenvironment}{{pgfviewboxscope}\marg{$ll_1$}\marg{$ur_1$}\marg{$ll_2$}\marg{$ur_2$}\marg{meet or slice}}
-    \Hologo{plainTeX} version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfviewboxscope}\marg{$ll_1$}\marg{$ur_1$}\marg{$ll_2$}\marg{$ur_2$}\marg{meet or slice}}
-    \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 

--- a/doc/generic/pgf/pgfmanual-en-base-transformations.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-transformations.tex
@@ -702,7 +702,7 @@ section).
 \end{environment}
 
 \begin{plainenvironment}{{pgflowlevelscope}\marg{transformation code}}
-    Plain \TeX\ version of the environment.
+    \Hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgflowlevelscope}\marg{transformation code}}
@@ -760,7 +760,7 @@ graphic.
 \end{environment}
 
 \begin{plainenvironment}{{pgfviewboxscope}\marg{$ll_1$}\marg{$ur_1$}\marg{$ll_2$}\marg{$ur_2$}\marg{meet or slice}}
-    Plain \TeX\ version of the environment.
+    \Hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfviewboxscope}\marg{$ll_1$}\marg{$ur_1$}\marg{$ll_2$}\marg{$ur_2$}\marg{meet or slice}}

--- a/doc/generic/pgf/pgfmanual-en-base-transformations.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-transformations.tex
@@ -706,7 +706,7 @@ section).
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgflowlevelscope}\marg{transformation code}}
-    Con\TeX t version of the environment.
+    \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 
@@ -764,7 +764,7 @@ graphic.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{pgfviewboxscope}\marg{$ll_1$}\marg{$ur_1$}\marg{$ll_2$}\marg{$ur_2$}\marg{meet or slice}}
-    Con\TeX t version of the environment.
+    \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 

--- a/doc/generic/pgf/pgfmanual-en-base-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-transparency.tex
@@ -380,7 +380,7 @@ Transparency groups are declared using the following commands.
     \end{plainenvironment}
 
     \begin{contextenvironment}{{pgftransparencygroup}}
-        This is the Con\TeX t version of the environment.
+        This is the \hologo{ConTeXt} version of the environment.
     \end{contextenvironment}
 \end{environment}
 

--- a/doc/generic/pgf/pgfmanual-en-base-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-transparency.tex
@@ -376,7 +376,7 @@ Transparency groups are declared using the following commands.
 }%
 
     \begin{plainenvironment}{{pgftransparencygroup}}
-        Plain \TeX\ version of the |{pgftransparencygroup}| environment.
+        \Hologo{plainTeX} version of the |{pgftransparencygroup}| environment.
     \end{plainenvironment}
 
     \begin{contextenvironment}{{pgftransparencygroup}}

--- a/doc/generic/pgf/pgfmanual-en-base-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-base-transparency.tex
@@ -375,14 +375,15 @@ Transparency groups are declared using the following commands.
 \end{codeexample}
 }%
 
-    \begin{plainenvironment}{{pgftransparencygroup}}
-        \Hologo{plainTeX} version of the |{pgftransparencygroup}| environment.
-    \end{plainenvironment}
-
-    \begin{contextenvironment}{{pgftransparencygroup}}
-        This is the \hologo{ConTeXt} version of the environment.
-    \end{contextenvironment}
 \end{environment}
+
+\begin{plainenvironment}{{pgftransparencygroup}}
+    The \hologo{plainTeX} version of the environment.
+\end{plainenvironment}
+
+\begin{contextenvironment}{{pgftransparencygroup}}
+    The \hologo{ConTeXt} version of the environment.
+\end{contextenvironment}
 
 
 %%% Local Variables:

--- a/doc/generic/pgf/pgfmanual-en-drivers.tex
+++ b/doc/generic/pgf/pgfmanual-en-drivers.tex
@@ -17,7 +17,7 @@ explains which input formats there are and how they are supported by \pgfname.
 It also explains which different output formats can be produced.
 
 
-\subsection{Supported Input Formats: \LaTeX, Plain \TeX, Con\TeX t}
+\subsection{Supported Input Formats: \LaTeX, Plain \TeX, \hologo{ConTeXt}}
 
 \TeX\ does not prescribe exactly how your input should be formatted. While it
 is \emph{customary} that, say, an opening brace starts a scope in \TeX, this is
@@ -29,7 +29,7 @@ Even though \TeX\ can be reconfigured, users can not. For this reason, certain
 \emph{input formats} specify a set of commands and conventions how input for
 \TeX\ should be formatted. There are currently three ``major'' formats: Donald
 Knuth's original |plain| \TeX\ format, Leslie Lamport's popular \LaTeX\ format,
-and Hans Hangen's Con\TeX t format.
+and Hans Hangen's \hologo{ConTeXt} format.
 
 
 \subsubsection{Using the \LaTeX\ Format}
@@ -81,9 +81,9 @@ Like the \LaTeX\ style files, the plain \TeX\ files like |tikz.tex| also just
 include the correct |tikz.code.tex| file.
 
 
-\subsubsection{Using the Con\TeX t Format}
+\subsubsection{Using the \hologo{ConTeXt} Format}
 
-When using the Con\TeX t format, you say |\usemodule[pgf]| or
+When using the \hologo{ConTeXt} format, you say |\usemodule[pgf]| or
 |\usemodule[tikz]|. As for the plain \TeX\ format you also have to replace the
 start- and end-of-environment tags as follows: Instead of |\begin{pgfpicture}|
 and |\end{pgfpicture}| you use |\startpgfpicture| and |\stoppgfpicture|;
@@ -91,7 +91,7 @@ similarly, instead of |\begin{tikzpicture}| and |\end{tikzpicture}| you use
 must now use |\starttikzpicture| and |\stoptikzpicture|; and so on for other
 environments.
 
-The Con\TeX t support is very similar to the plain \TeX\ support, so the same
+The \hologo{ConTeXt} support is very similar to the plain \TeX\ support, so the same
 restrictions apply: You may have to set the output format directly and graphics
 inclusion may be a problem.
 
@@ -99,10 +99,10 @@ In addition to |pgf| and |tikz| there also exist modules like |pgfcore| or
 |pgfmodulematrix|. To use them, you may need to include the module |pgfmod|
 first (the modules |pgf| and |tikz| both include |pgfmod| for you, so typically
 you can skip this). This special module is necessary since old versions of
-Con\TeX t~MkII before 2005 satanically restricted the length of module names to
+\hologo{ConTeXt}~MkII before 2005 satanically restricted the length of module names to
 8 characters and \pgfname's long names are mapped to cryptic 6-letter-names for
 you by the module |pgfmod|.  This restriction was never in place in
-Con\TeX t~MkIV and the |pgfmod| module can be safely ignored nowadays.
+\hologo{ConTeXt}~MkIV and the |pgfmod| module can be safely ignored nowadays.
 
 
 \subsection{Supported Output Formats}

--- a/doc/generic/pgf/pgfmanual-en-drivers.tex
+++ b/doc/generic/pgf/pgfmanual-en-drivers.tex
@@ -17,7 +17,7 @@ explains which input formats there are and how they are supported by \pgfname.
 It also explains which different output formats can be produced.
 
 
-\subsection{Supported Input Formats: \LaTeX, Plain \TeX, \hologo{ConTeXt}}
+\subsection{Supported Input Formats: \LaTeX, \Hologo{plainTeX}, \hologo{ConTeXt}}
 
 \TeX\ does not prescribe exactly how your input should be formatted. While it
 is \emph{customary} that, say, an opening brace starts a scope in \TeX, this is
@@ -28,7 +28,7 @@ name.
 Even though \TeX\ can be reconfigured, users can not. For this reason, certain
 \emph{input formats} specify a set of commands and conventions how input for
 \TeX\ should be formatted. There are currently three ``major'' formats: Donald
-Knuth's original |plain| \TeX\ format, Leslie Lamport's popular \LaTeX\ format,
+Knuth's original \hologo{plainTeX} format, Leslie Lamport's popular \LaTeX\ format,
 and Hans Hangen's \hologo{ConTeXt} format.
 
 
@@ -64,34 +64,34 @@ file |latex/pgf/frontends/tikz.sty|:
 The files in the |generic/pgf| directory do the actual work.
 
 
-\subsubsection{Using the Plain \TeX\ Format}
+\subsubsection{Using the \Hologo{plainTeX} Format}
 
-When using the plain \TeX\ format, you say |\input{pgf.tex}| or
+When using the \hologo{plainTeX} format, you say |\input{pgf.tex}| or
 |\input{tikz.tex}|. Then, instead of  |\begin{pgfpicture}| and
 |\end{pgfpicture}| you use |\pgfpicture| and |\endpgfpicture|.
 
 Unlike for the \LaTeX\ format, \pgfname\ is not as good at discerning the
-appropriate configuration for the plain \TeX\ format. In particular, it can
+appropriate configuration for the \hologo{plainTeX} format. In particular, it can
 only automatically determine the correct output format if you use |pdftex| or
 |tex| plus |dvips|. For all other output formats you need to set the macro
 |\pgfsysdriver| to the correct value. See the description of using output
 formats later on.
 
-Like the \LaTeX\ style files, the plain \TeX\ files like |tikz.tex| also just
+Like the \LaTeX\ style files, the \hologo{plainTeX} files like |tikz.tex| also just
 include the correct |tikz.code.tex| file.
 
 
 \subsubsection{Using the \hologo{ConTeXt} Format}
 
 When using the \hologo{ConTeXt} format, you say |\usemodule[pgf]| or
-|\usemodule[tikz]|. As for the plain \TeX\ format you also have to replace the
+|\usemodule[tikz]|. As for the \hologo{plainTeX} format you also have to replace the
 start- and end-of-environment tags as follows: Instead of |\begin{pgfpicture}|
 and |\end{pgfpicture}| you use |\startpgfpicture| and |\stoppgfpicture|;
 similarly, instead of |\begin{tikzpicture}| and |\end{tikzpicture}| you use
 must now use |\starttikzpicture| and |\stoptikzpicture|; and so on for other
 environments.
 
-The \hologo{ConTeXt} support is very similar to the plain \TeX\ support, so the same
+The \hologo{ConTeXt} support is very similar to the \hologo{plainTeX} support, so the same
 restrictions apply: You may have to set the output format directly and graphics
 inclusion may be a problem.
 
@@ -196,7 +196,7 @@ is exactly the same.
     \begin{enumerate}
         \item In \LaTeX\ mode it uses |graphicx| for the graphics inclusion
             and does not support masking.
-        \item In plain \TeX\ mode it does not support image inclusion.
+        \item In \hologo{plainTeX} mode it does not support image inclusion.
     \end{enumerate}
 \end{filedescription}
 
@@ -223,7 +223,7 @@ file (see below) and then using a PostScript-to-\pdf\ conversion program like
         \item In \LaTeX\ mode it uses |graphicx| for the graphics inclusion.
             Image masking is supported if the PostScript output is further
             processed with |ps2pdf| to produce \textsc{pdf}.
-        \item In plain \TeX\ mode it does not support image inclusion.
+        \item In \hologo{plainTeX} mode it does not support image inclusion.
         \item Functional shadings are approximated with Type-0 functions
             (sampled functions), because Type-4 functions are not available in
             the latest (version 3) PostScript language definition. Due to
@@ -308,7 +308,7 @@ dvisvgm example
     %
     \begin{enumerate}
         \item In \LaTeX\ mode it uses |graphicx| for the graphics inclusion.
-        \item In plain \TeX\ mode it does not support image inclusion.
+        \item In \hologo{plainTeX} mode it does not support image inclusion.
         \item Remembering of pictures (inter-picture connections) is not
             supported.
         \item Text inside |pgfpicture|s is not supported very well. The

--- a/doc/generic/pgf/pgfmanual-en-drivers.tex
+++ b/doc/generic/pgf/pgfmanual-en-drivers.tex
@@ -179,7 +179,7 @@ same as the |pdftex| program: it uses a different input format, but the output
 is exactly the same.
 
 \begin{filedescription}{pgfsys-pdftex.def}
-    This is the driver file for use with pdf\TeX, that is, with the |pdftex| or
+    This is the driver file for use with \hologo{pdfTeX}, that is, with the |pdftex| or
     |pdflatex| command. It includes |pgfsys-common-pdf.def|.
 
     This driver has a lot of functionality. (Almost) everything \pgfname\ ``can

--- a/doc/generic/pgf/pgfmanual-en-drivers.tex
+++ b/doc/generic/pgf/pgfmanual-en-drivers.tex
@@ -286,7 +286,7 @@ lualatex --output-format=dvi example
 dvisvgm example
 \end{codeexample}
     %
-    (This is ``better'' since it gives you access to the full power of Lua\TeX\
+    (This is ``better'' since it gives you access to the full power of \hologo{LuaTeX}
     inside your \TeX-file. In particular, \tikzname\ is able to run graph
     drawing algorithms in this case.)
 

--- a/doc/generic/pgf/pgfmanual-en-dv-formats.tex
+++ b/doc/generic/pgf/pgfmanual-en-dv-formats.tex
@@ -205,7 +205,7 @@ data [format=named] {
 
 \begin{dataformat}{TeX code}
     This format will simply execute each line of the data, each of which should
-    contain some normal TeX code. Note that at the end of each line control
+    contain some normal \TeX{} code. Note that at the end of each line control
     returns to the format handler, so for instance the arguments of a command
     may not be spread over several lines. However, not each line needs to
     produce a data point.

--- a/doc/generic/pgf/pgfmanual-en-gd-algorithm-layer.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-algorithm-layer.tex
@@ -17,7 +17,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}.
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-algorithms-in-c.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-algorithms-in-c.tex
@@ -71,19 +71,19 @@ link C libraries at runtime -- provided a strict regime of rules is adhered to:
 For each of the above points, there are some bells and whistles:
 %
 \begin{enumerate}
-    \item \hologo{LuateX} looks at slightly inconvenient places for shared libraries:
+    \item \hologo{LuaTeX} looks at slightly inconvenient places for shared libraries:
         By default, (currently, 2013) it looks in a |lib| subdirectory of the
-        directory containing the \hologo{LuateX} executable. The logic behind is that
+        directory containing the \hologo{LuaTeX} executable. The logic behind is that
         the shared libraries depend on the specific architecture of the
         executable. Thus, unlike normal Lua files, the library needs to be
         installed ``far away'' from the actual package of which it is part.
-    \item Certain versions of \hologo{LuateX} have a broken handling of filenames of
+    \item Certain versions of \hologo{LuaTeX} have a broken handling of filenames of
         libraries written in C. The TL2013 version of \hologo{LuaTeX}, for instance,
         crashes when the filename of a shared library does not contain the
         complete path (while this works for normal file). Hopefully, this, too,
         will be fixed in future versions.
     \item On certain platforms, the support for dynamic linking against
-        \hologo{LuateX} is broken since the symbol table of the Lua library has been
+        \hologo{LuaTeX} is broken since the symbol table of the Lua library has been
         stripped away. Hopefully, this will be fixed soon; in the meantime, a
         highly fragile workaround is to link in another copy of the Lua
         library.
@@ -233,7 +233,7 @@ We simply add this code to the startup function above.
 
 Now it is time to compile and link the code. For this, you must, well, compile
 it, link it against the library |InterfaceFromC|, and build a shared library
-out of it. Also, you must place it somewhere where \hologo{LuateX} will find it. You
+out of it. Also, you must place it somewhere where \hologo{LuaTeX} will find it. You
 will find a Makefile that should be able to achieve all of this in the
 directory |pgf/c/graphdrawing/pgf/gd/examples/c|, where you  will also find the
 code of the above example.
@@ -251,13 +251,13 @@ or in \tikzname
 \usegdlibrary {examples.c.SimpleDemoC}
 \end{codeexample}
 
-This should cause \hologo{LuateX} to find the shared library, load it, and then call
+This should cause \hologo{LuaTeX} to find the shared library, load it, and then call
 the function in that library with the lengthy name (the name is always
 |luaopen_| followed by the path and filename with slashes replaced by
 underscores).
 
 \emph{Remark:} Unfortunately, the above does not work with the \hologo{TeXLive} 2013
-versions of \hologo{LuateX} due to a bugs that causes the ``replace dots by slashes''
+versions of \hologo{LuaTeX} due to a bugs that causes the ``replace dots by slashes''
 to fail. For this reason, we currently need to rename our shared library file
 to
 %
@@ -314,7 +314,7 @@ for each key), assuming that the documentation resides in the file
 
 Note that since the documentation is a normal Lua file, it will be searched in
 the usual places Lua files are located (in the texmf trees) and not, like the C
-shared library, in the special |lib| subdirectory of the \hologo{LuateX} binary.
+shared library, in the special |lib| subdirectory of the \hologo{LuaTeX} binary.
 
 Here are typical contents of the documentation file:
 %
@@ -476,7 +476,7 @@ Note that it is the job of the interface classes to free the passed
 |declarations| object. For this reason, you really need to call |new| and
 cannot pass the address of a temporary object.
 
-As before, because of the bug in some \hologo{LuateX} versions, to actually load the
+As before, because of the bug in some \hologo{LuaTeX} versions, to actually load the
 library at runtime, we need to rename it to
 %
 \begin{codeexample}[code only, tikz syntax=false]

--- a/doc/generic/pgf/pgfmanual-en-gd-algorithms-in-c.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-algorithms-in-c.tex
@@ -15,7 +15,7 @@
 \bigskip
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}.
     \expandafter\endinput
 \fi
 
@@ -47,7 +47,7 @@ a link.
 In order to use C code for graph drawing algorithms during a run of the \TeX\
 program, there is no need to build a new version of \TeX. Rather, it is
 possible that C code is linked into the \TeX\ executable at runtime. This is
-made possible by the fact that Lua (which part of Lua\TeX$\dots$) is able to
+made possible by the fact that Lua (which part of \hologo{LuaTeX}$\dots$) is able to
 link C libraries at runtime -- provided a strict regime of rules is adhered to:
 %
 \begin{enumerate}
@@ -71,19 +71,19 @@ link C libraries at runtime -- provided a strict regime of rules is adhered to:
 For each of the above points, there are some bells and whistles:
 %
 \begin{enumerate}
-    \item Lua\TeX\ looks at slightly inconvenient places for shared libraries:
+    \item \hologo{LuateX} looks at slightly inconvenient places for shared libraries:
         By default, (currently, 2013) it looks in a |lib| subdirectory of the
-        directory containing the Lua\TeX\ executable. The logic behind is that
+        directory containing the \hologo{LuateX} executable. The logic behind is that
         the shared libraries depend on the specific architecture of the
         executable. Thus, unlike normal Lua files, the library needs to be
         installed ``far away'' from the actual package of which it is part.
-    \item Certain versions of Lua\TeX\ have a broken handling of filenames of
-        libraries written in C. The TL2013 version of Lua\TeX, for instance,
+    \item Certain versions of \hologo{LuateX} have a broken handling of filenames of
+        libraries written in C. The TL2013 version of \hologo{LuaTeX}, for instance,
         crashes when the filename of a shared library does not contain the
         complete path (while this works for normal file). Hopefully, this, too,
         will be fixed in future versions.
     \item On certain platforms, the support for dynamic linking against
-        Lua\TeX\ is broken since the symbol table of the Lua library has been
+        \hologo{LuateX} is broken since the symbol table of the Lua library has been
         stripped away. Hopefully, this will be fixed soon; in the meantime, a
         highly fragile workaround is to link in another copy of the Lua
         library.
@@ -233,7 +233,7 @@ We simply add this code to the startup function above.
 
 Now it is time to compile and link the code. For this, you must, well, compile
 it, link it against the library |InterfaceFromC|, and build a shared library
-out of it. Also, you must place it somewhere where Lua\TeX\ will find it. You
+out of it. Also, you must place it somewhere where \hologo{LuateX} will find it. You
 will find a Makefile that should be able to achieve all of this in the
 directory |pgf/c/graphdrawing/pgf/gd/examples/c|, where you  will also find the
 code of the above example.
@@ -251,13 +251,13 @@ or in \tikzname
 \usegdlibrary {examples.c.SimpleDemoC}
 \end{codeexample}
 
-This should cause Lua\TeX\ to find the shared library, load it, and then call
+This should cause \hologo{LuateX} to find the shared library, load it, and then call
 the function in that library with the lengthy name (the name is always
 |luaopen_| followed by the path and filename with slashes replaced by
 underscores).
 
 \emph{Remark:} Unfortunately, the above does not work with the \hologo{TeXLive} 2013
-versions of Lua\TeX\ due to a bugs that causes the ``replace dots by slashes''
+versions of \hologo{LuateX} due to a bugs that causes the ``replace dots by slashes''
 to fail. For this reason, we currently need to rename our shared library file
 to
 %
@@ -277,7 +277,7 @@ or in \tikzname
 \usegdlibrary {pgf_gd_examples_c_SimpleDemoC}
 \end{codeexample}
 
-In future versions of Lua\TeX, things should be ``back to normal'' in this
+In future versions of \hologo{LuaTeX}, things should be ``back to normal'' in this
 regard. Also, the bug only concerns shared libraries; you can still create a
 normal Lua file with a nice name and place at a nice location and the only
 contents of this file is then the above |require| command.
@@ -314,7 +314,7 @@ for each key), assuming that the documentation resides in the file
 
 Note that since the documentation is a normal Lua file, it will be searched in
 the usual places Lua files are located (in the texmf trees) and not, like the C
-shared library, in the special |lib| subdirectory of the Lua\TeX\ binary.
+shared library, in the special |lib| subdirectory of the \hologo{LuateX} binary.
 
 Here are typical contents of the documentation file:
 %
@@ -476,7 +476,7 @@ Note that it is the job of the interface classes to free the passed
 |declarations| object. For this reason, you really need to call |new| and
 cannot pass the address of a temporary object.
 
-As before, because of the bug in some Lua\TeX\ versions, to actually load the
+As before, because of the bug in some \hologo{LuateX} versions, to actually load the
 library at runtime, we need to rename it to
 %
 \begin{codeexample}[code only, tikz syntax=false]
@@ -819,7 +819,7 @@ keys should then also get an |alias| field set, which will cause an automatic
 forwarding of the key to something more ``user friendly'' like just |radius|.
 
 It remains to put the above methods in a ``script'' file. It is this file that,
-when compiled, must be linked at runtime against Lua\TeX.
+when compiled, must be linked at runtime against \hologo{LuaTeX}
 %
 \begin{codeexample}[code only, tikz syntax=false]
 // File HelloWorldLayout_script.c++

--- a/doc/generic/pgf/pgfmanual-en-gd-algorithms-in-c.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-algorithms-in-c.tex
@@ -256,7 +256,7 @@ the function in that library with the lengthy name (the name is always
 |luaopen_| followed by the path and filename with slashes replaced by
 underscores).
 
-\emph{Remark:} Unfortunately, the above does not work with the \TeX Live 2013
+\emph{Remark:} Unfortunately, the above does not work with the \hologo{TeXLive} 2013
 versions of Lua\TeX\ due to a bugs that causes the ``replace dots by slashes''
 to fail. For this reason, we currently need to rename our shared library file
 to

--- a/doc/generic/pgf/pgfmanual-en-gd-binding-layer.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-binding-layer.tex
@@ -19,7 +19,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-circular.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-circular.tex
@@ -14,7 +14,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-display-layer.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-display-layer.tex
@@ -21,7 +21,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-edge-routing.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-edge-routing.tex
@@ -18,7 +18,7 @@ doesn't seem to be used.}}
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-force.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-force.tex
@@ -15,7 +15,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-layered.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-layered.tex
@@ -14,7 +14,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-ogdf.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-ogdf.tex
@@ -20,7 +20,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-ogdf.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-ogdf.tex
@@ -26,7 +26,7 @@
 
 \ifgdccodeogdf
 \else
-    In order to typeset this section, LuaTeX\ must be able to link C code at
+    In order to typeset this section, \hologo{LuaTeX} must be able to link C code at
     runtime and the \textsc{ogdf} graph drawing C libraries must be installed
     on your system. You will find the sources in the |c| subdirectory of the
     installation, where you will also find example Makefiles.

--- a/doc/generic/pgf/pgfmanual-en-gd-overview.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-overview.tex
@@ -287,7 +287,7 @@ The documentation of the graph drawing engine is structured as follows:
 Graph drawing in \tikzname\ began as a student's project under my supervision.
 Ren\'ee Ahrens, Olof-Joachim Frahm, Jens Kluttig, Matthias Schulz, and Stephan
 Schuster wrote the first prototype of a graph drawing system inside \tikzname\
-that uses \hologo{LuateX} for the implementation of graph drawing algorithms.
+that uses \hologo{LuaTeX} for the implementation of graph drawing algorithms.
 
 This first, early version was greatly extended on the algorithmic side by
 Jannis Pohlmann who wrote his Diploma thesis on graph drawing under my

--- a/doc/generic/pgf/pgfmanual-en-gd-overview.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-overview.tex
@@ -17,7 +17,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 
@@ -287,7 +287,7 @@ The documentation of the graph drawing engine is structured as follows:
 Graph drawing in \tikzname\ began as a student's project under my supervision.
 Ren\'ee Ahrens, Olof-Joachim Frahm, Jens Kluttig, Matthias Schulz, and Stephan
 Schuster wrote the first prototype of a graph drawing system inside \tikzname\
-that uses Lua\TeX\ for the implementation of graph drawing algorithms.
+that uses \hologo{LuateX} for the implementation of graph drawing algorithms.
 
 This first, early version was greatly extended on the algorithmic side by
 Jannis Pohlmann who wrote his Diploma thesis on graph drawing under my

--- a/doc/generic/pgf/pgfmanual-en-gd-phylogenetics.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-phylogenetics.tex
@@ -15,7 +15,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-trees.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-trees.tex
@@ -17,7 +17,7 @@ seem to be used.}}
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-usage-pgf.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-usage-pgf.tex
@@ -28,7 +28,7 @@
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-gd-usage-tikz.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-usage-tikz.tex
@@ -14,13 +14,13 @@
 
 \begin{tikzlibrary}{graphdrawing}
     This package provides capabilities for automatic graph drawing. It requires
-    that the document is typeset using Lua\TeX. This package should work with
-    Lua\TeX\ 0.54 or higher.
+    that the document is typeset using \hologo{LuaTeX} This package should work with
+    \hologo{LuateX} 0.54 or higher.
 \end{tikzlibrary}
 
 \ifluatex
 \else
-    This section of the manual can only be typeset using Lua\TeX.
+    This section of the manual can only be typeset using \hologo{LuaTeX}
     \expandafter\endinput
 \fi
 
@@ -44,8 +44,8 @@ this, you need to use the following command, which is defined by the
     \meta{list of libraries} we do:
     %
     \begin{enumerate}
-        \item Check whether Lua\TeX\ can call |require| on the library file
-            |pgf.gd.|\meta{name}|.library|. Lua\TeX's usual file search
+        \item Check whether \hologo{LuateX} can call |require| on the library file
+            |pgf.gd.|\meta{name}|.library|. \hologo{LuaTeX}'s usual file search
             mechanism  will search the texmf-trees in the usual manner and the
             dots in the file name get converted into directory slashes.
         \item If the above failed, try to |require| the string

--- a/doc/generic/pgf/pgfmanual-en-gd-usage-tikz.tex
+++ b/doc/generic/pgf/pgfmanual-en-gd-usage-tikz.tex
@@ -15,7 +15,7 @@
 \begin{tikzlibrary}{graphdrawing}
     This package provides capabilities for automatic graph drawing. It requires
     that the document is typeset using \hologo{LuaTeX} This package should work with
-    \hologo{LuateX} 0.54 or higher.
+    \hologo{LuaTeX} 0.54 or higher.
 \end{tikzlibrary}
 
 \ifluatex
@@ -44,7 +44,7 @@ this, you need to use the following command, which is defined by the
     \meta{list of libraries} we do:
     %
     \begin{enumerate}
-        \item Check whether \hologo{LuateX} can call |require| on the library file
+        \item Check whether \hologo{LuaTeX} can call |require| on the library file
             |pgf.gd.|\meta{name}|.library|. \hologo{LuaTeX}'s usual file search
             mechanism  will search the texmf-trees in the usual manner and the
             dots in the file name get converted into directory slashes.

--- a/doc/generic/pgf/pgfmanual-en-installation.tex
+++ b/doc/generic/pgf/pgfmanual-en-installation.tex
@@ -73,7 +73,7 @@ I do not create or manage prebundled packages of \pgfname, but, fortunately,
 nice other people do. I cannot give detailed instructions on how to install
 these packages, since I do not manage them, but I \emph{can} tell you were to
 find them. If you have a problem with installing, you might wish to have a look
-at the Debian page or the MiK\TeX\ page first.
+at the Debian page or the \hologo{MiKTeX} page first.
 
 
 \subsubsection{Debian}
@@ -84,7 +84,7 @@ Sit back and relax.
 
 \subsubsection{MiKTeX}
 
-For MiK\TeX, use the update wizard to install the (latest versions of the)
+For \hologo{MiKTeX}, use the update wizard to install the (latest versions of the)
 packages called |pgf| and |xcolor|.
 
 
@@ -125,7 +125,7 @@ you have chosen create a sub-sub-directory called |texmf/tex/generic/pgf| or
 |texmf/tex/generic/pgf-|\texttt{\pgfversion}, if you prefer. Then place all
 files of the |pgf| package in this directory. Finally, rebuild \TeX's filename
 database. This is done by running the command |texhash| or |mktexlsr| (they are
-the same). In MiK\TeX, there is a menu option to do this.
+the same). In \hologo{MiKTeX}, there is a menu option to do this.
 
 
 \subsubsection{Installation that is TDS-Compliant}

--- a/doc/generic/pgf/pgfmanual-en-installation.tex
+++ b/doc/generic/pgf/pgfmanual-en-installation.tex
@@ -34,7 +34,7 @@ also work):
 With plain \TeX, |xcolor| is not needed, but you obviously do not get its
 (full) functionality.
 
-Currently, \pgfname\ requires at least TeX Live 2020 which corresponds to the
+Currently, \pgfname\ requires at least \hologo{TeXLive} 2020 which corresponds to the
 following backend drivers (earlier versions also work in some cases):
 %
 \begin{itemize}

--- a/doc/generic/pgf/pgfmanual-en-installation.tex
+++ b/doc/generic/pgf/pgfmanual-en-installation.tex
@@ -59,9 +59,9 @@ Currently, \pgfname\ supports the following formats:
 \begin{itemize}
     \item |latex| with complete functionality.
     \item |plain| with complete functionality, except for graphics inclusion,
-        which works only for pdf\TeX.
+        which works only for \hologo{pdfTeX}.
     \item |context| with complete functionality, except for graphics
-        inclusion, which works only for pdf\TeX.
+        inclusion, which works only for \hologo{pdfTeX}.
 \end{itemize}
 
 For more details, see Section~\ref{section-formats}.

--- a/doc/generic/pgf/pgfmanual-en-installation.tex
+++ b/doc/generic/pgf/pgfmanual-en-installation.tex
@@ -31,7 +31,7 @@ also work):
     \item |xcolor| version \xcolorversion.
 \end{itemize}
 %
-With plain \TeX, |xcolor| is not needed, but you obviously do not get its
+With \hologo{plainTeX}, |xcolor| is not needed, but you obviously do not get its
 (full) functionality.
 
 Currently, \pgfname\ requires at least \hologo{TeXLive} 2020 which corresponds to the

--- a/doc/generic/pgf/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/pgfmanual-en-introduction.tex
@@ -12,7 +12,7 @@
 
 Welcome to the documentation of \tikzname\ and the underlying \pgfname\ system.
 What began as a small \LaTeX\ style for creating the graphics in my (Till
-Tantau's) PhD thesis directly with pdf\LaTeX\ has now grown to become a
+Tantau's) PhD thesis directly with \hologo{pdfLaTeX} has now grown to become a
 full-blown graphics language with a manual of over a thousand pages. The wealth
 of options offered by \tikzname\ is often daunting to beginners; but
 fortunately this documentation comes with a number of slowly-paced tutorials that
@@ -38,7 +38,7 @@ like.
 
 Now that we know what \tikzname\ is, what about ``\pgfname''? As mentioned
 earlier, \tikzname\ started out as a project to implement \TeX\ graphics macros
-that can be used both with pdf\LaTeX\ and also with the classical
+that can be used both with \hologo{pdfLaTeX} and also with the classical
 (PostScript-based) \LaTeX. In other words, I wanted to implement a ``portable
 graphics format'' for \TeX\ -- hence the name \pgfname. These early macros are
 still around and they form the ``basic layer'' of the system described in this

--- a/doc/generic/pgf/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/pgfmanual-en-introduction.tex
@@ -148,7 +148,7 @@ to give a reasonably fair comparison of \tikzname\ and other packages.
         very small, which may or may not be an advantage.
     \item The |metapost| program is a powerful alternative to \tikzname. It
         used to be an external program, which entailed a bunch of problems,
-        but in \hologo{LuateX} it is now built in. An obstacle with |metapost| is
+        but in \hologo{LuaTeX} it is now built in. An obstacle with |metapost| is
         the inclusion of labels. This is \emph{much} easier to achieve using
         \pgfname.
     \item The |xfig| program is an important alternative to \tikzname\ for

--- a/doc/generic/pgf/pgfmanual-en-introduction.tex
+++ b/doc/generic/pgf/pgfmanual-en-introduction.tex
@@ -148,7 +148,7 @@ to give a reasonably fair comparison of \tikzname\ and other packages.
         very small, which may or may not be an advantage.
     \item The |metapost| program is a powerful alternative to \tikzname. It
         used to be an external program, which entailed a bunch of problems,
-        but in Lua\TeX\ it is now built in. An obstacle with |metapost| is
+        but in \hologo{LuateX} it is now built in. An obstacle with |metapost| is
         the inclusion of labels. This is \emph{much} easier to achieve using
         \pgfname.
     \item The |xfig| program is an important alternative to \tikzname\ for

--- a/doc/generic/pgf/pgfmanual-en-library-decorations.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-decorations.tex
@@ -1395,7 +1395,7 @@ shapes. This library is included mostly for historical reasons, using the
             effects.
         \item It is only possible to typeset text in math mode under
             considerable restrictions. Math mode is entered and exited using
-            any character of category code 3 (e.g., in plain \TeX{} this is |$|). %$
+            any character of category code 3 (e.g., in \hologo{plainTeX} this is |$|). %$
             Math subscripts and superscripts need to be  contained within
             braces (e.g., |{^y_i}|) as do commands like |\times| or |\cdot|.
             However, even modestly complex mathematical  typesetting is

--- a/doc/generic/pgf/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-external.tex
@@ -58,14 +58,14 @@ For most users, the library does not need special attention since requirements
 are met anyway. It collects all tokens between |\begin{tikzpicture}| and the
 next following |\end{tikzpicture}| and replaces them by the appropriate
 graphics or it takes steps to generate such an image.
-%For Con\TeX t and plain \TeX\ users, the appropriate begin and end picture
+%For \hologo{ConTeXt} and plain \TeX\ users, the appropriate begin and end picture
 %statements apply.
 
 It can't expand macros during this step, so the only requirement is that every
 picture's end is directly reachable from its beginning, without further macro
 expansion. Furthermore, the library assumes that all \LaTeX\ pictures are ended
 with |\end{tikzpicture}|.
-%In Con\TeX t, the end command is assumed to be |\stoptikzpicture| and for plain
+%In \hologo{ConTeXt}, the end command is assumed to be |\stoptikzpicture| and for plain
 %\TeX\ it is |\endtikzpicture|.
 
 The library always searches for the \emph{next} picture's end,
@@ -79,13 +79,13 @@ Consider using the |\tikzexternaldisable| method in case you'd like to skip
 selected pictures which do not meet the requirements.
 
 
-\subsection{A Word About Con\TeX t And Plain \TeX}
+\subsection{A Word About \hologo{ConTeXt} And Plain \TeX}
 
 Currently, the basic layer backend |\beginpgfgraphicnamed| $\dotsc$
 |\endpgfgraphicnamed| relies on \LaTeX\ only, so externalization is currently
 only supported for \LaTeX.
-%The library comes in three different versions, one for \LaTeX, one for Con\TeX
-%t and one for plain \TeX. For reasons of simplicity, examples in this manual
+%The library comes in three different versions, one for \LaTeX, one for \hologo{ConTeXt}
+%and one for plain \TeX. For reasons of simplicity, examples in this manual
 %only refer to \LaTeX\ (especially |pdflatex|).
 
 

--- a/doc/generic/pgf/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-external.tex
@@ -58,15 +58,15 @@ For most users, the library does not need special attention since requirements
 are met anyway. It collects all tokens between |\begin{tikzpicture}| and the
 next following |\end{tikzpicture}| and replaces them by the appropriate
 graphics or it takes steps to generate such an image.
-%For \hologo{ConTeXt} and plain \TeX\ users, the appropriate begin and end picture
+%For \hologo{ConTeXt} and \hologo{plainTeX} users, the appropriate begin and end picture
 %statements apply.
 
 It can't expand macros during this step, so the only requirement is that every
 picture's end is directly reachable from its beginning, without further macro
 expansion. Furthermore, the library assumes that all \LaTeX\ pictures are ended
 with |\end{tikzpicture}|.
-%In \hologo{ConTeXt}, the end command is assumed to be |\stoptikzpicture| and for plain
-%\TeX\ it is |\endtikzpicture|.
+%In \hologo{ConTeXt}, the end command is assumed to be |\stoptikzpicture| and for
+%\hologo{plainTeX} it is |\endtikzpicture|.
 
 The library always searches for the \emph{next} picture's end,
 |\end{tikzpicture}|. As a consequence, you can't use nested pictures directly.
@@ -85,7 +85,7 @@ Currently, the basic layer backend |\beginpgfgraphicnamed| $\dotsc$
 |\endpgfgraphicnamed| relies on \LaTeX\ only, so externalization is currently
 only supported for \LaTeX.
 %The library comes in three different versions, one for \LaTeX, one for \hologo{ConTeXt}
-%and one for plain \TeX. For reasons of simplicity, examples in this manual
+%and one for \hologo{plainTeX}. For reasons of simplicity, examples in this manual
 %only refer to \LaTeX\ (especially |pdflatex|).
 
 

--- a/doc/generic/pgf/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-external.tex
@@ -79,7 +79,7 @@ Consider using the |\tikzexternaldisable| method in case you'd like to skip
 selected pictures which do not meet the requirements.
 
 
-\subsection{A Word About \hologo{ConTeXt} And Plain \TeX}
+\subsection{A Word About \hologo{ConTeXt} And \Hologo{plainTeX}}
 
 Currently, the basic layer backend |\beginpgfgraphicnamed| $\dotsc$
 |\endpgfgraphicnamed| relies on \LaTeX\ only, so externalization is currently

--- a/doc/generic/pgf/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-external.tex
@@ -220,7 +220,7 @@ such a file to environments where \pgfname\ is not available.
 
 \begin{key}{/tikz/external/shell escape=\marg{command-line arg} (initially -shell-escape)}
     Contains the command line option for |latex| which enables the |\write18|
-    feature. For \TeX-Live, this is |-shell-escape|. For MiK\TeX, you should
+    feature. For \TeX-Live, this is |-shell-escape|. For \hologo{MiKTeX}, you should
     use |\tikzexternalize[shell escape=-enable-write18]|.
 \end{key}
 

--- a/doc/generic/pgf/pgfmanual-en-library-external.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-external.tex
@@ -563,7 +563,7 @@ pdflatex -shell-escape main
     previous run, which, in turn, will be written into an extra file with the
     extension |.md5|. This file will be modified if and only if the MD5
     comparison indicates a difference. The MD5 computation is based on the
-    pdf\TeX\ method |\pdfmdfivesum|. If it is unavailable for some reason, the
+    \hologo{pdfTeX} method |\pdfmdfivesum|. If it is unavailable for some reason, the
     choice |diff| will be used instead.
 
     The choice \declare{diff} is the same as MD5 -- except that it compares the

--- a/doc/generic/pgf/pgfmanual-en-library-profiler.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-profiler.tex
@@ -17,7 +17,7 @@
 
     It relies on the |pdftex| primitive
     \declareandlabel{\pdfelapsedtime}\footnote{The primitive is emulated in
-    lua\TeX.} to count (fractional) seconds and counts total time and self time
+    \hologo{LuaTeX}.} to count (fractional) seconds and counts total time and self time
     for macro invocations.
 \end{pgflibrary}
 

--- a/doc/generic/pgf/pgfmanual-en-library-rdf.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-rdf.tex
@@ -984,7 +984,7 @@ will result where the blue nodes represent resources:
 
 \ifluatex
 \else
-    This example can only be typeset using Lua\TeX.
+    This example can only be typeset using \hologo{LuaTeX}
     \endgroup\expandafter\endinput
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-library-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-library-shapes.tex
@@ -1669,7 +1669,7 @@ center of the appropriate side.
         This key checks if \meta{number} boxes have been allocated, and if not,
         it allocates the required boxes using |\newbox| (some ``magic'' is
         performed to get around the fact that |\newbox| is declared |\outer| in
-        plain \TeX).
+        \hologo{plainTeX}).
     \end{key}
 
     When split vertically, the rectangle split will meet any |minimum width|

--- a/doc/generic/pgf/pgfmanual-en-main-body.tex
+++ b/doc/generic/pgf/pgfmanual-en-main-body.tex
@@ -420,7 +420,7 @@ implement new algorithms in the Lua programming language. \vskip1cm
 \end{codeexample}
 
 \else
-    You need to use Lua\TeX\ to typeset this part of the manual (and, also, to
+    You need to use \hologo{LuateX} to typeset this part of the manual (and, also, to
     use algorithmic graph drawing).
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-main-body.tex
+++ b/doc/generic/pgf/pgfmanual-en-main-body.tex
@@ -420,7 +420,7 @@ implement new algorithms in the Lua programming language. \vskip1cm
 \end{codeexample}
 
 \else
-    You need to use \hologo{LuateX} to typeset this part of the manual (and, also, to
+    You need to use \hologo{LuaTeX} to typeset this part of the manual (and, also, to
     use algorithmic graph drawing).
 \fi
 

--- a/doc/generic/pgf/pgfmanual-en-main-preamble.tex
+++ b/doc/generic/pgf/pgfmanual-en-main-preamble.tex
@@ -134,8 +134,6 @@
 
 \fi
 
-\def\LuaTeX{Lua\TeX}%
-
 
 \newif\ifpgfmanualexternalize
 \pgfmanualexternalizefalse
@@ -152,6 +150,7 @@
 
 \usepackage[a4paper,left=2.25cm,right=2.25cm,top=2.5cm,bottom=2.5cm,nohead]{geometry}
 \usepackage{amsmath,amssymb}
+\usepackage{hologo}
 \usepackage{xxcolor}
 \usepackage{pifont}
 

--- a/doc/generic/pgf/pgfmanual-en-math-parsing.tex
+++ b/doc/generic/pgf/pgfmanual-en-math-parsing.tex
@@ -58,7 +58,7 @@ mathematical engine is the following:
         \item The parser will recognize \TeX{} registers and box dimensions, so
             |\mydimen|, |0.5\mydimen|, |\wd\mybox|, |0.5\dp\mybox|,
             |\mycount\mydimen| and so on can be parsed.
-        \item The $\varepsilon$-TeX\ extensions |\dimexpr|, |\numexpr|,
+        \item The \hologo{eTeX} extensions |\dimexpr|, |\numexpr|,
             |\glueexpr|, and |\muexpr| are recognized and evaluated. The values
             they result in will be used in the further evaluation, as if you
             had put |\the| before them.

--- a/doc/generic/pgf/pgfmanual-en-pages.tex
+++ b/doc/generic/pgf/pgfmanual-en-pages.tex
@@ -14,7 +14,7 @@ This section describes the |pgfpages| package. Although this package is not
 concerned with creating pictures, its implementation relies so heavily on
 \pgfname\ that it is documented here. Currently, |pgfpages| only works with
 \LaTeX, but if you are adventurous, feel free to hack the code so that it also
-works with plain \TeX.
+works with \hologo{plainTeX}.
 
 The aim of |pgfpages| is to provide a flexible way of putting multiple pages on
 a single page \emph{inside \TeX}. Thus, |pgfpages| is quite different from

--- a/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfkeys.tex
@@ -17,7 +17,7 @@ both \pgfname\ and \tikzname.
 \begin{package}{pgfkeys}
     This package can be used independently of \pgfname. Note that no
     other package of \pgfname\ needs to be loaded (so neither the
-    emulation layer nor the system layer is needed). The Con\TeX t
+    emulation layer nor the system layer is needed). The \hologo{ConTeXt}
     abbreviation is |pgfkey| \todosp{pgfkey --> pgfkeys?} if |pgfmod| is not loaded.
 \end{package}
 

--- a/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex
@@ -496,7 +496,7 @@ colors. These command coexist with commands from the |color| and |xcolor|
 package, which perform similar functions. However, the |color| package does not
 support having two different colors for stroking and filling, which is a useful
 feature that is supported by \pgfname. For this reason, the \pgfname\ system
-layer offers commands for setting these colors separately. Also, plain \TeX\
+layer offers commands for setting these colors separately. Also, \hologo{plainTeX}
 profits from the fact that \pgfname\ can set colors.
 
 For \pdf, implementing these color commands is easy since \pdf\ supports

--- a/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfsys-commands.tex
@@ -75,19 +75,19 @@ current transformations and clippings being in force. For this escaping, the
 following command is used:
 
 \begin{command}{\pgfsys@hbox\marg{box number}}
-    Called to insert a (horizontal) TeX box inside a |{pgfpicture}|.
+    Called to insert a (horizontal) \TeX{} box inside a |{pgfpicture}|.
 
     Most drivers will need to (re-)implement this command.
 \end{command}
 
 \begin{command}{\pgfsys@hboxsynced\marg{box number}}
-    Called to insert a (horizontal) TeX box inside a |{pgfpicture}|, but with
+    Called to insert a (horizontal) \TeX{} box inside a |{pgfpicture}|, but with
     the current coordinate transformation matrix synced with the canvas
     transformation matrix.
 
     This command should do the same as if you used |\pgflowlevelsynccm|
     followed by |\pgfsys@hbox|. However, the default implementation of this
-    command will use a ``TeX-translation'' for the translation part of the
+    command will use a ``\TeX{}-translation'' for the translation part of the
     transformation matrix. This will ensure that hyperlinks ``survive'' at
     least translations. On the other hand, a driver may choose to revert to a
     simpler implementation. This is done, for example, for the \textsc{svg}
@@ -800,7 +800,7 @@ The system layer provides some commands for image inclusion.
 
     \meta{name} is the name of the shading, which is also used in the output
     macro name. \meta{height} is the height of the shading and must be given as
-    a TeX dimension like |2cm| or |10pt|. \meta{specification} is a shading
+    a \TeX{} dimension like |2cm| or |10pt|. \meta{specification} is a shading
     color specification as specified in Section~\ref{section-shadings}. The
     shading specification implicitly fixes the width of the shading.
 

--- a/doc/generic/pgf/pgfmanual-en-pgfsys-overview.tex
+++ b/doc/generic/pgf/pgfmanual-en-pgfsys-overview.tex
@@ -40,7 +40,7 @@ The system layer is loaded and set up by the following package:
 \begin{command}{\pgfsysdriver}
     This macro should expand to the name of the driver to be used by |pgfsys|.
     The default from |pgf.cfg| is |pgfsys-\Gin@driver|. This is very likely to
-    be correct if you are using \LaTeX. For plain \TeX, the macro will be set
+    be correct if you are using \LaTeX. For \hologo{plainTeX}, the macro will be set
     to |pgfsys-pdftex.def| if |pdftex| is used and to |pgfsys-dvips.def|
     otherwise.
 \end{command}

--- a/doc/generic/pgf/pgfmanual-en-tikz-actions.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-actions.tex
@@ -119,8 +119,8 @@ The most unspecific option for setting colors is the following:
     What happens is that every option that \tikzname\ does not know, like
     |red!20|, gets a ``second chance'' as a color name.
 
-    For plain \TeX\ users, it is not so easy to specify colors since plain
-    \TeX\ has no ``standardized'' color naming mechanism. Because of this,
+    For \hologo{plainTeX} users, it is not so easy to specify colors since
+    \hologo{plainTeX} has no ``standardized'' color naming mechanism. Because of this,
     \pgfname\ emulates the |xcolor| package, though the emulation is
     \emph{extremely basic} (more precisely, what I could hack together in two
     hours or so). The emulation allows you to do the following:

--- a/doc/generic/pgf/pgfmanual-en-tikz-actions.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-actions.tex
@@ -127,9 +127,9 @@ The most unspecific option for setting colors is the following:
     %
     \begin{itemize}
         \item Specify a new color using |\definecolor|. Only the color models
-            |gray|, |rgb|, and |RGB| are supported\footnote{Con\TeX t users
+            |gray|, |rgb|, and |RGB| are supported\footnote{\hologo{ConTeXt} users
             should be aware that \texttt{\textbackslash definecolor} has a
-            different meaning in Con\TeX t. There is a low-level equivalent
+            different meaning in \hologo{ConTeXt}. There is a low-level equivalent
             named \texttt{\textbackslash pgfutil@definecolor} which can be
             used instead.}.
             %

--- a/doc/generic/pgf/pgfmanual-en-tikz-design.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-design.tex
@@ -13,7 +13,7 @@
 This section describes the design principles behind the \tikzname\ frontend,
 where \tikzname\ means ``\tikzname\ ist \emph{kein} Zeichenprogramm''. To use
 \tikzname, as a \LaTeX\ user say |\usepackage{tikz}| somewhere in the preamble,
-as a plain \TeX\ user say |\input{tikz.tex}|. \tikzname's job is to make your
+as a \hologo{plainTeX} user say |\input{tikz.tex}|. \tikzname's job is to make your
 life easier by providing an easy-to-learn and easy-to-use syntax for describing
 graphics.
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-design.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-design.tex
@@ -220,7 +220,7 @@ The syntax of the |graph| command extends the so-called \textsc{dot}-notation
 used in the popular \textsc{graphviz} program.
 
 Depending on the version of \TeX\ you use (it must allow you to call Lua code,
-which is the case for Lua\TeX), you can also ask \tikzname\ to do automatically
+which is the case for \hologo{LuaTeX}), you can also ask \tikzname\ to do automatically
 compute good positions for the nodes of a graph using one of several integrated
 \emph{graph drawing algorithms}.
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
@@ -263,7 +263,7 @@ preamble) results in the following somewhat more pleasing rendering:
   }
 };
 \else
-    (You need to use \hologo{LuateX} to typeset this graphic.)
+    (You need to use \hologo{LuaTeX} to typeset this graphic.)
 \fi
 
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
@@ -104,7 +104,7 @@ commands.
 As an example, consider the above drawing of a trie, which is drawn without
 using the graph drawing libraries. Its layout can be somewhat improved by
 loading the |layered| graph drawing library, saying |\tikz[layered layout,...|,
-and then using Lua\TeX, resulting in the following drawing of the same graph:
+and then using \hologo{LuaTeX}, resulting in the following drawing of the same graph:
 \medskip
 
 \tikz [layered layout, >={To[sep]}, rotate=90, xscale=-1,
@@ -263,7 +263,7 @@ preamble) results in the following somewhat more pleasing rendering:
   }
 };
 \else
-    (You need to use Lua\TeX\ to typeset this graphic.)
+    (You need to use \hologo{LuateX} to typeset this graphic.)
 \fi
 
 
@@ -1351,7 +1351,7 @@ several nodes have the same label.
     You can even ``reiterate'' over a path in conjunction with the |simple|
     option. However, in this case, the default placement strategies will not
     work and you will need options like |layered layout| from the graph drawing
-    libraries, which need Lua\TeX.
+    libraries, which need \hologo{LuaTeX}
     %
 \ifluatex
 \begin{codeexample}[preamble={\usetikzlibrary{graphs,graphdrawing}\usegdlibrary{layered}}]

--- a/doc/generic/pgf/pgfmanual-en-tikz-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-scopes.tex
@@ -31,8 +31,8 @@ given that apply to everything within the environment.
     \pgfname\ needs to know what \TeX\ driver you are intending to use. In most
     cases \pgfname\ is clever enough to determine the correct driver for you;
     this is true in particular if you use \LaTeX. One situation where \pgfname\
-    cannot know the driver ``by itself'' is when you use plain \TeX\ or Con\TeX
-    t together with |dvipdfm|. In this case, you have to write
+    cannot know the driver ``by itself'' is when you use plain \TeX\ or \hologo{ConTeXt}
+    together with |dvipdfm|. In this case, you have to write
     |\def\pgfsysdriver{pgfsys-dvipdfm.def}| \emph{before} you input |tikz.tex|.
 \end{package}
 
@@ -40,7 +40,7 @@ given that apply to everything within the environment.
     Once \tikzname\ has been loaded, you can use this command to load further
     libraries. The list of libraries should contain the names of libraries
     separated by commas. Instead of curly braces, you can also use square
-    brackets, which is something Con\TeX t users will like. If you try to load
+    brackets, which is something \hologo{ConTeXt} users will like. If you try to load
     a library a second time, nothing will happen.
 
     \example |\usetikzlibrary{arrows.meta}|
@@ -53,7 +53,7 @@ given that apply to everything within the environment.
     |pgflibrary|\meta{library}|.code.tex| is loaded instead. If this file also
     does not exist, an error message is printed. Thus, to write your own
     library file, all you need to do is to place a file of the appropriate name
-    somewhere where \TeX\ can find it. \LaTeX, plain \TeX, and Con\TeX t users
+    somewhere where \TeX\ can find it. \LaTeX, plain \TeX, and \hologo{ConTeXt} users
     can then use your library.
 \end{command}
 
@@ -218,7 +218,7 @@ In other \TeX\ formats, you should use the following commands instead:
 \end{plainenvironment}
 
 \begin{contextenvironment}{{tikzpicture}\opt{\oarg{options}}}
-    This is the Con\TeX t version of the environment.
+    This is the \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 
@@ -341,7 +341,7 @@ environment, so once more, there is little chance of doing anything wrong.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{scope}\opt{\meta{animations spec}}\opt{\oarg{options}}}
-    Con\TeX t version of the environment.
+    \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-scopes.tex
@@ -211,14 +211,12 @@ Top align:
     This will have the desired effect.
 \end{environment}
 
-In other \TeX\ formats, you should use the following commands instead:
-
 \begin{plainenvironment}{{tikzpicture}\opt{\oarg{options}}}
-    This is the \hologo{plainTeX} version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{tikzpicture}\opt{\oarg{options}}}
-    This is the \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 
@@ -337,11 +335,11 @@ environment, so once more, there is little chance of doing anything wrong.
 \end{environment}
 
 \begin{plainenvironment}{{scope}\opt{\meta{animations spec}}\opt{\oarg{options}}}
-    \Hologo{plainTeX} version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{scope}\opt{\meta{animations spec}}\opt{\oarg{options}}}
-    \hologo{ConTeXt} version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 

--- a/doc/generic/pgf/pgfmanual-en-tikz-scopes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-scopes.tex
@@ -31,7 +31,7 @@ given that apply to everything within the environment.
     \pgfname\ needs to know what \TeX\ driver you are intending to use. In most
     cases \pgfname\ is clever enough to determine the correct driver for you;
     this is true in particular if you use \LaTeX. One situation where \pgfname\
-    cannot know the driver ``by itself'' is when you use plain \TeX\ or \hologo{ConTeXt}
+    cannot know the driver ``by itself'' is when you use \hologo{plainTeX} or \hologo{ConTeXt}
     together with |dvipdfm|. In this case, you have to write
     |\def\pgfsysdriver{pgfsys-dvipdfm.def}| \emph{before} you input |tikz.tex|.
 \end{package}
@@ -53,7 +53,7 @@ given that apply to everything within the environment.
     |pgflibrary|\meta{library}|.code.tex| is loaded instead. If this file also
     does not exist, an error message is printed. Thus, to write your own
     library file, all you need to do is to place a file of the appropriate name
-    somewhere where \TeX\ can find it. \LaTeX, plain \TeX, and \hologo{ConTeXt} users
+    somewhere where \TeX\ can find it. \LaTeX, \hologo{plainTeX}, and \hologo{ConTeXt} users
     can then use your library.
 \end{command}
 
@@ -214,7 +214,7 @@ Top align:
 In other \TeX\ formats, you should use the following commands instead:
 
 \begin{plainenvironment}{{tikzpicture}\opt{\oarg{options}}}
-    This is the plain \TeX\ version of the environment.
+    This is the \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{tikzpicture}\opt{\oarg{options}}}
@@ -337,7 +337,7 @@ environment, so once more, there is little chance of doing anything wrong.
 \end{environment}
 
 \begin{plainenvironment}{{scope}\opt{\meta{animations spec}}\opt{\oarg{options}}}
-    Plain \TeX\ version of the environment.
+    \Hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{scope}\opt{\meta{animations spec}}\opt{\oarg{options}}}

--- a/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
@@ -978,7 +978,7 @@ Let us now first have a look at the |text width| command.
         \item[|align=|\declare{\texttt{flush left}}] For alignment without line
             breaking this option has exactly the same effect as |left|.
             However, for alignment with line breaking, there is a difference:
-            While |left| uses the original plain \TeX\ definition of a ragged
+            While |left| uses the original \hologo{plainTeX} definition of a ragged
             right border, in which \TeX\ will try to balance the right border
             as well as possible, |flush left| causes the right border to be
             ragged in the \LaTeX-style, in which no balancing occurs. This

--- a/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
@@ -483,7 +483,7 @@ commands, which are \emph{only defined in the library}, namely the library
 \end{plainenvironment}
 
 \begin{contextenvironment}{{tikzfadingfrompicture}\oarg{options}}
-    The Con\TeX t version of the environment.
+    The \hologo{ConTeXt} version of the environment.
 \end{contextenvironment}
 
 \begin{command}{\tikzfading\oarg{options}}

--- a/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
@@ -35,7 +35,7 @@ several times with a semitransparent color. Sometimes you want the effect to
 accumulate, sometimes you do not.
 
 \emph{Note:} Transparency (or Opacity, as it may be called as well) is best
-supported by the pdf\TeX\ driver. The \textsc{svg} driver also has some
+supported by the \hologo{pdfTeX} driver. The \textsc{svg} driver also has some
 support. The PostScript file format does not know about transparency. In
 |dvips|-generated PostScript files, transparency of graphic objects is defined
 through special commands that need further processing to become visible in the

--- a/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
+++ b/doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
@@ -479,7 +479,7 @@ commands, which are \emph{only defined in the library}, namely the library
 \end{environment}
 
 \begin{plainenvironment}{{tikzfadingfrompicture}\oarg{options}}
-    The plain\TeX\ version of the environment.
+    The \hologo{plainTeX} version of the environment.
 \end{plainenvironment}
 
 \begin{contextenvironment}{{tikzfadingfrompicture}\oarg{options}}

--- a/doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
@@ -151,9 +151,9 @@ When using \LaTeX\ use:
 \end{codeexample}
 
 
-\subsubsection{Setting up the Environment in Plain \TeX}
+\subsubsection{Setting up the Environment in \Hologo{plainTeX}}
 
-When using plain \TeX\ use:
+When using \Hologo{plainTeX} use:
 %
 \begin{codeexample}[code only]
 %% Plain TeX file

--- a/doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
@@ -153,7 +153,7 @@ When using \LaTeX\ use:
 
 \subsubsection{Setting up the Environment in \Hologo{plainTeX}}
 
-When using \Hologo{plainTeX} use:
+When using \hologo{plainTeX} use:
 %
 \begin{codeexample}[code only]
 %% Plain TeX file

--- a/doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
@@ -169,9 +169,9 @@ When using plain \TeX\ use:
 \end{codeexample}
 
 
-\subsubsection{Setting up the Environment in Con\TeX t}
+\subsubsection{Setting up the Environment in \hologo{ConTeXt}}
 
-When using Con\TeX t, use:
+When using \hologo{ConTeXt}, use:
 %
 \begin{codeexample}[code only]
 %% ConTeXt file

--- a/doc/generic/pgf/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial.tex
@@ -208,9 +208,9 @@ file |pgf.cfg| or can write |\def\pgfsysdriver{pgfsys-dvipdfm.def}| somewhere
 \emph{before} she inputs |tikz.tex| or |pgf.tex|.
 
 
-\subsubsection{Setting up the Environment in Con\TeX t}
+\subsubsection{Setting up the Environment in \hologo{ConTeXt}}
 
-Karl's uncle Hans uses Con\TeX t. Like Gerda, Hans can also use \tikzname.
+Karl's uncle Hans uses \hologo{ConTeXt}. Like Gerda, Hans can also use \tikzname.
 Instead of |\usepackage{tikz}| he says |\usemodule[tikz]|. Instead of
 |\begin{tikzpicture}| he writes |\starttikzpicture| and  instead of
 |\end{tikzpicture}| he writes |\stoptikzpicture|.

--- a/doc/generic/pgf/pgfmanual-en-tutorial.tex
+++ b/doc/generic/pgf/pgfmanual-en-tutorial.tex
@@ -124,7 +124,7 @@ have is something that looks like this (ideally):
 
 In \tikzname, to draw a picture, at the start of the picture you need to tell
 \TeX\ or \LaTeX\ that you want to start a picture. In \LaTeX\ this is done
-using the environment |{tikzpicture}|, in plain \TeX\ you just use
+using the environment |{tikzpicture}|, in \hologo{plainTeX} you just use
 |\tikzpicture| to start the picture and |\endtikzpicture| to end it.
 
 
@@ -177,10 +177,10 @@ Karl is quite pleased to note that the environment automatically reserves
 enough space to encompass the picture.
 
 
-\subsubsection{Setting up the Environment in Plain \TeX}
+\subsubsection{Setting up the Environment in \Hologo{plainTeX}}
 
 Karl's wife Gerda, who also happens to be a math teacher, is not a \LaTeX\
-user, but uses plain \TeX\ since she prefers to do things ``the old way''. She
+user, but uses \hologo{plainTeX} since she prefers to do things ``the old way''. She
 can also use \tikzname. Instead of |\usepackage{tikz}| she has to write
 |\input{tikz.tex}| and instead of |\begin{tikzpicture}| she writes
 |\tikzpicture| and instead of |\end{tikzpicture}| she writes |\endtikzpicture|.

--- a/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
+++ b/tex/generic/pgf/graphdrawing/lua/pgf/gd/trees/doc.lua
@@ -46,7 +46,7 @@ introduces some nice extensions of the basic algorithm:
 %
 As a historical remark, Br\"uggemann-Klein and Wood have implemented
 their version of the Reingold--Tilford algorithm directly in \TeX\
-(resulting in the Tree\TeX\ style). With the power of Lua\TeX\ at
+(resulting in the Tree\TeX\ style). With the power of \hologo{LuaTeX} at
 our disposal, the 2012 implementation in the |graphdrawing.tree|
 library is somewhat more powerful and cleaner, but it really was an
 impressive achievement to implement this algorithm back in 1989

--- a/tex/latex/pgf/doc/pgfmanual-en-macros.tex
+++ b/tex/latex/pgf/doc/pgfmanual-en-macros.tex
@@ -152,7 +152,7 @@
     \index{Libraries!#1@\protect\texttt{#1}}%
     \index{Graph drawing libraries!#1@\protect\texttt{#1}}%
     \vskip.25em
-    {\ttfamily\char`\\usegdlibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and plain \TeX}\\
+    {\ttfamily\char`\\usegdlibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and \hologo{plainTeX}}\\
     {\ttfamily\char`\\usegdlibrary[\declare{#1}]\space \char`\%\space\space \hologo{ConTeXt}}\smallskip\par
     \pgfmanualbody
 }{\endpgfmanualentry}
@@ -1041,7 +1041,7 @@
       {\ttfamily\char`\\usepackage\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX}}
     \index{#1@\protect\texttt{#1} package}%
     \index{Packages and files!#1@\protect\texttt{#1}}%
-    \pgfmanualentryheadline{{\ttfamily\char`\\input{\declare{#1}.tex}\space\space\space \char`\%\space\space  plain \TeX}}
+    \pgfmanualentryheadline{{\ttfamily\char`\\input{\declare{#1}.tex}\space\space\space \char`\%\space\space \hologo{plainTeX}}}
     \pgfmanualentryheadline{{\ttfamily\char`\\usemodule[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt}}}
     \pgfmanualbody
 }
@@ -1055,7 +1055,7 @@
     \pgfmanualentryheadline{%
       \pgfmanualpdflabel{#1}{}%
       {\ttfamily\char`\\usepgfmodule\char`\{\declare{#1}\char`\}\space\space\space
-        \char`\%\space\space  \LaTeX\space and plain \TeX\space and pure pgf}}
+        \char`\%\space\space  \LaTeX\space and \hologo{plainTeX} and pure pgf}}
     \index{#1@\protect\texttt{#1} module}%
     \index{Modules!#1@\protect\texttt{#1}}%
     \pgfmanualentryheadline{{\ttfamily\char`\\usepgfmodule[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt} and pure pgf}}
@@ -1074,10 +1074,10 @@
     \index{Libraries!#1@\protect\texttt{#1}}%
     \vskip.25em%
     {{\ttfamily\char`\\usepgflibrary\char`\{\declare{#1}\char`\}\space\space\space
-        \char`\%\space\space  \LaTeX\space and plain \TeX\space and pure pgf}}\\
+        \char`\%\space\space  \LaTeX\space and \hologo{plainTeX} and pure pgf}}\\
     {{\ttfamily\char`\\usepgflibrary[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt} and pure pgf}}\\
     {{\ttfamily\char`\\usetikzlibrary\char`\{\declare{#1}\char`\}\space\space
-        \char`\%\space\space  \LaTeX\space and plain \TeX\space when using \tikzname}}\\
+        \char`\%\space\space  \LaTeX\space and \hologo{plainTeX} when using \tikzname}}\\
     {{\ttfamily\char`\\usetikzlibrary[\declare{#1}]\space
         \char`\%\space\space \hologo{ConTeXt} when using \tikzname}}\\[.5em]
     \pgfmanualbody
@@ -1095,7 +1095,7 @@
     \index{Libraries!#1@\protect\texttt{#1}}%
     \vskip.25em%
     {{\ttfamily\char`\\usepgflibrary\char`\{\declare{#1}\char`\}\space\space\space
-        \char`\%\space\space  \LaTeX\space and plain \TeX}}\\
+        \char`\%\space\space  \LaTeX\space and \hologo{plainTeX}}}\\
     {{\ttfamily\char`\\usepgflibrary[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt}}}\\[.5em]
     \pgfmanualbody
 }
@@ -1111,7 +1111,7 @@
     \index{#1@\protect\texttt{#1} library}%
     \index{Libraries!#1@\protect\texttt{#1}}%
     \vskip.25em%
-    {{\ttfamily\char`\\usetikzlibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and plain \TeX}}\\
+    {{\ttfamily\char`\\usetikzlibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and \hologo{plainTeX}}}\\
     {{\ttfamily\char`\\usetikzlibrary[\declare{#1}]\space \char`\%\space\space \hologo{ConTeXt}}}\\[.5em]
     \pgfmanualbody
 }
@@ -1127,7 +1127,7 @@
     \index{#1@\protect\texttt{#1} pgfkeys library}%
     \index{pgfkeys Libraries!#1@\protect\texttt{#1}}%
     \vskip.25em
-    {{\ttfamily\char`\\usepgfkeyslibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and plain \TeX}}\\
+    {{\ttfamily\char`\\usepgfkeyslibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and \hologo{plainTeX}}}\\
     {{\ttfamily\char`\\usepgfkeyslibrary[\declare{#1}]\space \char`\%\space\space \hologo{ConTeXt}}}\\[.5em]%
     \pgfmanualbody
 }%

--- a/tex/latex/pgf/doc/pgfmanual-en-macros.tex
+++ b/tex/latex/pgf/doc/pgfmanual-en-macros.tex
@@ -153,7 +153,7 @@
     \index{Graph drawing libraries!#1@\protect\texttt{#1}}%
     \vskip.25em
     {\ttfamily\char`\\usegdlibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and plain \TeX}\\
-    {\ttfamily\char`\\usegdlibrary[\declare{#1}]\space \char`\%\space\space Con\TeX t}\smallskip\par
+    {\ttfamily\char`\\usegdlibrary[\declare{#1}]\space \char`\%\space\space \hologo{ConTeXt}}\smallskip\par
     \pgfmanualbody
 }{\endpgfmanualentry}
 
@@ -1042,7 +1042,7 @@
     \index{#1@\protect\texttt{#1} package}%
     \index{Packages and files!#1@\protect\texttt{#1}}%
     \pgfmanualentryheadline{{\ttfamily\char`\\input{\declare{#1}.tex}\space\space\space \char`\%\space\space  plain \TeX}}
-    \pgfmanualentryheadline{{\ttfamily\char`\\usemodule[\declare{#1}]\space\space \char`\%\space\space  Con\TeX t}}
+    \pgfmanualentryheadline{{\ttfamily\char`\\usemodule[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt}}}
     \pgfmanualbody
 }
 {
@@ -1058,7 +1058,7 @@
         \char`\%\space\space  \LaTeX\space and plain \TeX\space and pure pgf}}
     \index{#1@\protect\texttt{#1} module}%
     \index{Modules!#1@\protect\texttt{#1}}%
-    \pgfmanualentryheadline{{\ttfamily\char`\\usepgfmodule[\declare{#1}]\space\space \char`\%\space\space  Con\TeX t\space and pure pgf}}
+    \pgfmanualentryheadline{{\ttfamily\char`\\usepgfmodule[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt} and pure pgf}}
     \pgfmanualbody
 }
 {
@@ -1075,11 +1075,11 @@
     \vskip.25em%
     {{\ttfamily\char`\\usepgflibrary\char`\{\declare{#1}\char`\}\space\space\space
         \char`\%\space\space  \LaTeX\space and plain \TeX\space and pure pgf}}\\
-    {{\ttfamily\char`\\usepgflibrary[\declare{#1}]\space\space \char`\%\space\space  Con\TeX t\space and pure pgf}}\\
+    {{\ttfamily\char`\\usepgflibrary[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt} and pure pgf}}\\
     {{\ttfamily\char`\\usetikzlibrary\char`\{\declare{#1}\char`\}\space\space
         \char`\%\space\space  \LaTeX\space and plain \TeX\space when using \tikzname}}\\
     {{\ttfamily\char`\\usetikzlibrary[\declare{#1}]\space
-        \char`\%\space\space  Con\TeX t\space when using \tikzname}}\\[.5em]
+        \char`\%\space\space \hologo{ConTeXt} when using \tikzname}}\\[.5em]
     \pgfmanualbody
 }
 {
@@ -1096,7 +1096,7 @@
     \vskip.25em%
     {{\ttfamily\char`\\usepgflibrary\char`\{\declare{#1}\char`\}\space\space\space
         \char`\%\space\space  \LaTeX\space and plain \TeX}}\\
-    {{\ttfamily\char`\\usepgflibrary[\declare{#1}]\space\space \char`\%\space\space  Con\TeX t}}\\[.5em]
+    {{\ttfamily\char`\\usepgflibrary[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt}}}\\[.5em]
     \pgfmanualbody
 }
 {
@@ -1112,7 +1112,7 @@
     \index{Libraries!#1@\protect\texttt{#1}}%
     \vskip.25em%
     {{\ttfamily\char`\\usetikzlibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and plain \TeX}}\\
-    {{\ttfamily\char`\\usetikzlibrary[\declare{#1}]\space \char`\%\space\space Con\TeX t}}\\[.5em]
+    {{\ttfamily\char`\\usetikzlibrary[\declare{#1}]\space \char`\%\space\space \hologo{ConTeXt}}}\\[.5em]
     \pgfmanualbody
 }
 {
@@ -1128,7 +1128,7 @@
     \index{pgfkeys Libraries!#1@\protect\texttt{#1}}%
     \vskip.25em
     {{\ttfamily\char`\\usepgfkeyslibrary\char`\{\declare{#1}\char`\}\space\space \char`\%\space\space  \LaTeX\space and plain \TeX}}\\
-    {{\ttfamily\char`\\usepgfkeyslibrary[\declare{#1}]\space \char`\%\space\space Con\TeX t}}\\[.5em]%
+    {{\ttfamily\char`\\usepgfkeyslibrary[\declare{#1}]\space \char`\%\space\space \hologo{ConTeXt}}}\\[.5em]%
     \pgfmanualbody
 }%
 {%

--- a/tex/latex/pgf/doc/pgfmanual-en-macros.tex
+++ b/tex/latex/pgf/doc/pgfmanual-en-macros.tex
@@ -1055,10 +1055,10 @@
     \pgfmanualentryheadline{%
       \pgfmanualpdflabel{#1}{}%
       {\ttfamily\char`\\usepgfmodule\char`\{\declare{#1}\char`\}\space\space\space
-        \char`\%\space\space  \LaTeX\space and \hologo{plainTeX} and pure pgf}}
+        \char`\%\space\space  \LaTeX\space and \hologo{plainTeX} when using pure \pgfname}}
     \index{#1@\protect\texttt{#1} module}%
     \index{Modules!#1@\protect\texttt{#1}}%
-    \pgfmanualentryheadline{{\ttfamily\char`\\usepgfmodule[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt} and pure pgf}}
+    \pgfmanualentryheadline{{\ttfamily\char`\\usepgfmodule[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt} when using pure \pgfname}}
     \pgfmanualbody
 }
 {
@@ -1074,8 +1074,8 @@
     \index{Libraries!#1@\protect\texttt{#1}}%
     \vskip.25em%
     {{\ttfamily\char`\\usepgflibrary\char`\{\declare{#1}\char`\}\space\space\space
-        \char`\%\space\space  \LaTeX\space and \hologo{plainTeX} and pure pgf}}\\
-    {{\ttfamily\char`\\usepgflibrary[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt} and pure pgf}}\\
+        \char`\%\space\space  \LaTeX\space and \hologo{plainTeX} when using pure \pgfname}}\\
+    {{\ttfamily\char`\\usepgflibrary[\declare{#1}]\space\space \char`\%\space\space \hologo{ConTeXt} when using pure \pgfname}}\\
     {{\ttfamily\char`\\usetikzlibrary\char`\{\declare{#1}\char`\}\space\space
         \char`\%\space\space  \LaTeX\space and \hologo{plainTeX} when using \tikzname}}\\
     {{\ttfamily\char`\\usetikzlibrary[\declare{#1}]\space


### PR DESCRIPTION
**Motivation for this change**

Correct unformatted TeX logos in manual. For logos not built-in to LaTeX2e, use `\hologo{<logo>}` from `hologo` package.

Addresses https://github.com/pgf-tikz/pgf/pull/1466#discussion_r3704879808 by @Mo-Gul.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
