### PR TITLE
test(examples): speed up `codeexample` extraction

### DIFF
--- a/doc/generic/pgf/extract-gd.lua
+++ b/doc/generic/pgf/extract-gd.lua
@@ -136,8 +136,8 @@ if #arg < 2 then
 end
 local manualdir = arg[1]
 local targetdir = arg[2]
-assert(lfs.attributes(manualdir, "mode") == "directory", manualdir .. " is not a directory")
-assert(lfs.attributes(targetdir, "mode") == "directory", targetdir .. " is not a directory")
+assert(lfs.isdir(manualdir), manualdir .. " is not a directory")
+assert(lfs.isdir(targetdir), targetdir .. " is not a directory")
 
 local all = {}
 for _, module in ipairs(module_list(manualdir)) do

--- a/doc/generic/pgf/extract.lua
+++ b/doc/generic/pgf/extract.lua
@@ -55,13 +55,18 @@ local function walk(sourcedir, targetdir)
             lfs.mkdir(targetdir .. file)
             walk(sourcedir .. file .. pathsep, targetdir .. file .. pathsep)
         elseif lfs.attributes(sourcedir .. file, "mode") == "file" then
+            local name, ext = basename(file)
+            -- Ignore non-TeX files
+            if ext ~= "tex" then
+                goto continue
+            end
+
             print("Processing " .. sourcedir .. file)
 
             -- Read file into memory
             local f = io.open(sourcedir .. file)
             local text = f:read("*all")
             f:close()
-            local name, ext = basename(file)
 
             -- Chapters the manual restricts to LuaTeX (\ifluatex \else ...
             -- \endinput \fi), e.g. the graph-drawing usage sections, are only
@@ -97,6 +102,8 @@ local function walk(sourcedir, targetdir)
                 })
             end
         end
+
+        ::continue::
     end
 end
 

--- a/doc/generic/pgf/extract.lua
+++ b/doc/generic/pgf/extract.lua
@@ -55,8 +55,8 @@ local function walk(sourcedir, targetdir)
             walk(sourcedir .. file .. pathsep, targetdir .. file .. pathsep)
         elseif lfs.isfile(sourcedir .. file) then
             local name, ext = basename(file)
-            -- Ignore non-TeX files
-            if ext ~= "tex" then
+            -- Ignore non-TeX files and "pgfmanual-test.*"
+            if ext ~= "tex" or name == "pgfmanual-test" then
                 goto continue
             end
 

--- a/doc/generic/pgf/extract.lua
+++ b/doc/generic/pgf/extract.lua
@@ -35,8 +35,8 @@ local uncompress_pdf =
 -- Walk the file tree
 local function walk(sourcedir, targetdir)
     -- Make sure the arguments are directories
-    assert(lfs.attributes(sourcedir, "mode") == "directory", sourcedir .. " is not a directory")
-    assert(lfs.attributes(targetdir, "mode") == "directory", targetdir .. " is not a directory")
+    assert(lfs.isdir(sourcedir), sourcedir .. " is not a directory")
+    assert(lfs.isdir(targetdir), targetdir .. " is not a directory")
 
     -- Append the path separator if necessary
     if sourcedir:sub(-1, -1) ~= pathsep then
@@ -50,11 +50,11 @@ local function walk(sourcedir, targetdir)
     for file in lfs.dir(sourcedir) do
         if file == "." or file == ".." then
             -- Ignore these two special ones
-        elseif lfs.attributes(sourcedir .. file, "mode") == "directory" then
+        elseif lfs.isdir(sourcedir .. file) then
             -- Recurse into subdirectories
             lfs.mkdir(targetdir .. file)
             walk(sourcedir .. file .. pathsep, targetdir .. file .. pathsep)
-        elseif lfs.attributes(sourcedir .. file, "mode") == "file" then
+        elseif lfs.isfile(sourcedir .. file) then
             local name, ext = basename(file)
             -- Ignore non-TeX files
             if ext ~= "tex" then

--- a/doc/generic/pgf/extract.lua
+++ b/doc/generic/pgf/extract.lua
@@ -6,7 +6,6 @@ local scriptdir = arg[0]:match("^(.*[/\\])") or "./"
 package.path = scriptdir .. "?.lua;" .. package.path
 local common = require("extract-common")
 
-local strip = common.strip
 local basename = common.basename
 local pathsep = common.pathsep
 


### PR DESCRIPTION
**Motivation for this change**

Skip non-tex files when extracting non-gd `codeexample`s from manual sources.

<details><summary>Comparison of <code>l3build examples</code> outputs, run locally</summary>
<p>

```diff
--- a/before.stdout
+++ b/after.stdout
@@ -2,7 +2,6 @@ Processing doc/generic/pgf/pgfmanual-en-dv-axes.tex
 Processing doc/generic/pgf/pgfmanual-en-dv-introduction.tex
 Processing doc/generic/pgf/pgfmanual-en-library-mindmaps.tex
 Processing doc/generic/pgf/pgfmanual-en-base-arrows.tex
-Processing doc/generic/pgf/pgfmanual-xetex.cfg
 Processing doc/generic/pgf/pgfmanual-en-library-trees.tex
 Processing doc/generic/pgf/pgfmanual-en-main-preamble.tex
 Processing doc/generic/pgf/pgfmanual-en-math-design.tex
@@ -11,63 +10,32 @@ Processing doc/generic/pgf/pgfmanual-en-tutorial-map.tex
 Processing doc/generic/pgf/pgfmanual-en-library-plot-marks.tex
 Processing doc/generic/pgf/pgfmanual-en-tutorial-nodes.tex
 Processing doc/generic/pgf/pgfmanual-en-gd-display-layer.tex
-Processing doc/generic/pgf/pgfmanual-pdftex.cfg
 Processing doc/generic/pgf/pgfmanual-en-gd-trees.tex
 Processing doc/generic/pgf/pgfmanual-en-library-spy.tex
 Processing doc/generic/pgf/pgfmanual-en-base-paths.tex
 Processing doc/generic/pgf/pgfmanual-en-library-fit.tex
-Processing doc/generic/pgf/INSTALL
-Processing doc/generic/pgf/extract-gd.lua
-Processing doc/generic/pgf/extract-common.lua
 Processing doc/generic/pgf/pgfmanual-en-base-scopes.tex
 Processing doc/generic/pgf/pgfmanual-en-library-arrows.tex
-Processing doc/generic/pgf/pgfmanual-dvips.cfg
-Processing doc/generic/pgf/missfont.log
-Processing doc/generic/pgf/extract.lua
 Processing doc/generic/pgf/pgfmanual-en-library-babel.tex
 Processing doc/generic/pgf/pgfmanual-en-tutorial-chains.tex
-Processing doc/generic/pgf/pgfmanual.cfg
 Processing doc/generic/pgf/pgfmanual-en-library-matrices.tex
 Processing doc/generic/pgf/pgfmanual-en-tikz-matrices.tex
 Processing doc/generic/pgf/pgfmanual-en-gd-phylogenetics.tex
-Processing doc/generic/pgf/licenses/manifest-documentation.txt
-Processing doc/generic/pgf/licenses/LICENSE
-Processing doc/generic/pgf/licenses/gnu-free-documentation-license-1.2.txt
-Processing doc/generic/pgf/licenses/latex-project-public-license-1.3c.txt
-Processing doc/generic/pgf/licenses/manifest-code.txt
-Processing doc/generic/pgf/licenses/gnu-public-license-2.txt
-Processing doc/generic/pgf/CHANGELOG.md
 Processing doc/generic/pgf/pgfmanual-en-pgfsys-protocol.tex
 Processing doc/generic/pgf/pgfmanual-en-base-animations.tex
 Processing doc/generic/pgf/pgfmanual-en-library-automata.tex
 Processing doc/generic/pgf/pgfmanual-en-tikz-graphs.tex
 Processing doc/generic/pgf/pgfmanual-en-base-patterns.tex
 Processing doc/generic/pgf/pgfmanual-en-base-plots.tex
-Processing doc/generic/pgf/images/pgfmanual-mindmap-2.pdf
-Processing doc/generic/pgf/images/brave-gnu-world-logo.jpg
-Processing doc/generic/pgf/images/pgfmanual-mindmap-1.pdf
-Processing doc/generic/pgf/images/brave-gnu-world-logo-mask.jpg
-Processing doc/generic/pgf/images/brave-gnu-world-logo.25.eps
-Processing doc/generic/pgf/images/brave-gnu-world-logo-mask.bb
-Processing doc/generic/pgf/images/brave-gnu-world-logo.bb
-Processing doc/generic/pgf/images/brave-gnu-world-logo-mask.eps
-Processing doc/generic/pgf/images/brave-gnu-world-logo.25.jpg
-Processing doc/generic/pgf/images/brave-gnu-world-logo.xbb
-Processing doc/generic/pgf/images/brave-gnu-world-logo.25.bb
-Processing doc/generic/pgf/images/brave-gnu-world-logo.eps
 Processing doc/generic/pgf/pgfmanual-en-tikz-trees.tex
 Processing doc/generic/pgf/pgfmanual-en-library-turtle.tex
-Processing doc/generic/pgf/pgfmanual.toc
 Processing doc/generic/pgf/pgfmanual-en-library-shapes.tex
-Processing doc/generic/pgf/pgfmanual-en-introduction.aux
 Processing doc/generic/pgf/pgfmanual-en-gd-usage-pgf.tex
 Processing doc/generic/pgf/pgfmanual-en-tikz-animations.tex
 Processing doc/generic/pgf/pgfmanual-en-math-commands.tex
 Processing doc/generic/pgf/pgfmanual-en-math-algorithms.tex
-Processing doc/generic/pgf/pgfmanual-tex4ht.cfg
 Processing doc/generic/pgf/pgfmanual-en-library-calc.tex
 Processing doc/generic/pgf/pgfmanual.tex
-Processing doc/generic/pgf/pgfmanual-en-tutorial.aux
 Processing doc/generic/pgf/pgfmanual-en-library-perspective.tex
 Processing doc/generic/pgf/pgfmanual-en-pgfcalendar.tex
 Processing doc/generic/pgf/pgfmanual-en-gd-layered.tex
@@ -75,9 +43,6 @@ Processing doc/generic/pgf/pgfmanual-en-tutorial-Euclid.tex
 Processing doc/generic/pgf/pgfmanual-en-base-internalregisters.tex
 Processing doc/generic/pgf/pgfmanual-en-library-folding.tex
 Processing doc/generic/pgf/pgfmanual-en-base-layers.tex
-Processing doc/generic/pgf/pgfmanual.out
-Processing doc/generic/pgf/pgfmanual-test.log
-Processing doc/generic/pgf/pgfmanual.ist
 Processing doc/generic/pgf/pgfmanual-en-gd-circular.tex
 Processing doc/generic/pgf/pgfmanual-en-module-parser.tex
 Processing doc/generic/pgf/pgfmanual-en-pgfsys-overview.tex
@@ -86,15 +51,11 @@ Processing doc/generic/pgf/pgfmanual-en-base-design.tex
 Processing doc/generic/pgf/pgfmanual-en-math-numberprinting.tex
 Processing doc/generic/pgf/pgfmanual-en-library-external.tex
 Processing doc/generic/pgf/pgfmanual-en-guidelines.tex
-Processing doc/generic/pgf/description.html
-Processing doc/generic/pgf/pgfmanual-dvipdfmx.cfg
 Processing doc/generic/pgf/pgfmanual-en-tikz-shapes.tex
 Processing doc/generic/pgf/pgfmanual-en-library-angles.tex
 Processing doc/generic/pgf/pgfmanual-en-license.tex
 Processing doc/generic/pgf/pgfmanual-en-library-math.tex
 Processing doc/generic/pgf/pgfmanual-en-library-petri.tex
-Processing doc/generic/pgf/pgfmanual-dvipdfm.cfg
-Processing doc/generic/pgf/pgfmanual-dvisvgm.cfg
 Processing doc/generic/pgf/pgfmanual-en-gd-overview.tex
 Processing doc/generic/pgf/pgfmanual-en-base-images.tex
 Processing doc/generic/pgf/pgfmanual-en-gd-misc.tex
@@ -113,7 +74,6 @@ Processing doc/generic/pgf/pgfmanual-en-gd-algorithms-in-c.tex
 Processing doc/generic/pgf/pgfmanual-en-base-quick.tex
 Processing doc/generic/pgf/pgfmanual-en-gd-examples.tex
 Processing doc/generic/pgf/pgfmanual-en-dv-polar.tex
-Processing doc/generic/pgf/color.cfg
 Processing doc/generic/pgf/pgfmanual-en-pages.tex
 Processing doc/generic/pgf/pgfmanual-en-main.tex
 Processing doc/generic/pgf/pgfmanual-en-gd-ogdf.tex
@@ -127,7 +87,6 @@ Processing doc/generic/pgf/pgfmanual-en-library-svg-path.tex
 Processing doc/generic/pgf/pgfmanual-en-pgfkeysfiltered.tex
 Processing doc/generic/pgf/pgfmanual-en-dv-stylesheets.tex
 Processing doc/generic/pgf/pgfmanual-en-tikz-paths.tex
-Processing doc/generic/pgf/pgfmanual-test.pdf
 Processing doc/generic/pgf/pgfmanual-en-tikz-transparency.tex
 Processing doc/generic/pgf/pgfmanual-en-main-body.tex
 Processing doc/generic/pgf/pgfmanual-en-library-rdf.tex
@@ -161,33 +120,12 @@ Processing doc/generic/pgf/pgfmanual-en-gd-binding-layer.tex
 Processing doc/generic/pgf/pgfmanual-en-pgfsys-animations.tex
 Processing doc/generic/pgf/pgfmanual-en-library-edges.tex
 Processing doc/generic/pgf/pgfmanual-en-library-lsystems.tex
-Processing doc/generic/pgf/pgfmanual-test.out
-Processing doc/generic/pgf/pgfmanual.aux
 Processing doc/generic/pgf/pgfmanual-en-library-er.tex
-Processing doc/generic/pgf/pgfmanual.log
 Processing doc/generic/pgf/pgfmanual-en-introduction.tex
 Processing doc/generic/pgf/pgfmanual-en-library-backgrounds.tex
 Processing doc/generic/pgf/pgfmanual-en-library-through.tex
 Processing doc/generic/pgf/pgfmanual-en-tutorial.tex
 Processing doc/generic/pgf/pgfmanual-en-pgfkeys.tex
-Processing doc/generic/pgf/plots/pgf-exp.table
-Processing doc/generic/pgf/plots/pgf-tan-example.table
-Processing doc/generic/pgf/plots/pgf-tan-example.gnuplot
-Processing doc/generic/pgf/plots/pgf-parametric-example-cut.gnuplot
-Processing doc/generic/pgf/plots/pgf-sin.gnuplot
-Processing doc/generic/pgf/plots/pgf-x.gnuplot
-Processing doc/generic/pgf/plots/pgf-parametric-example.table
-Processing doc/generic/pgf/plots/pgf-asymptotic-example.table
-Processing doc/generic/pgf/plots/pgf-parametric-example-cut.table
-Processing doc/generic/pgf/plots/pgfplotgnuplot-example.table
-Processing doc/generic/pgf/plots/pgf-exp.gnuplot
-Processing doc/generic/pgf/plots/pgf-parametric-example.gnuplot
-Processing doc/generic/pgf/plots/pgf-x.table
-Processing doc/generic/pgf/plots/pgfmanual-sine.table
-Processing doc/generic/pgf/plots/pgf-sin.table
-Processing doc/generic/pgf/plots/pgfmanual-sine.gnuplot
-Processing doc/generic/pgf/plots/pgf-asymptotic-example.gnuplot
-Processing doc/generic/pgf/plots/pgfplotgnuplot-example.gnuplot
 Processing doc/generic/pgf/pgfmanual-en-dv-formats.tex
 Processing doc/generic/pgf/pgfmanual-en-base-nodes.tex
 Processing doc/generic/pgf/pgfmanual-en-base-actions.tex
```

</p>
</details> 

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
