### PR TITLE
test: add test for tikz circle, old syntax

### DIFF
--- a/testfiles-regression/tikz-circle-old-syntax.lvt
+++ b/testfiles-regression/tikz-circle-old-syntax.lvt
@@ -1,0 +1,35 @@
+% -*- mode: latex -*-
+% vim: ft=tex
+\documentclass{minimal}
+\input{regression-test}
+
+\RequirePackage{tikz}
+
+\begin{document}
+
+\START
+
+\BEGINBOXTEST{circle, old syntax}
+\tikzpicture
+  \draw (0,0) circle (1);
+  \draw (3,0) circle (10pt) circle (20pt);
+  \draw (6,0) circle (1cm) +(3,0) circle (2cm);
+\endtikzpicture
+\ENDBOXTEST
+
+\BEGINBOXTEST{ellipse, old syntax}
+\tikzpicture
+  \draw (0,0) ellipse (2 and 1);
+  \draw (3,0) ellipse (20pt and 10pt) ellipse (25pt and 15pt);
+  \draw (6,0) ellipse (1cm and 2cm) +(3,0) ellipse (2cm and 4cm);
+\endtikzpicture
+\ENDBOXTEST
+
+\BEGINTEST{errors, cannot mix dimensions and dimensions values in ellipse}
+\tikzpicture
+  \draw (0,1) ellipse (1cm and 2);
+  \draw (1,1) ellipse (1 and 2cm);
+\endtikzpicture
+\ENDTEST
+
+\END

--- a/testfiles-regression/tikz-circle-old-syntax.tlg
+++ b/testfiles-regression/tikz-circle-old-syntax.tlg
@@ -1,0 +1,166 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: circle, old syntax
+============================================================
+> \box...=
+\hbox(114.211+0.0)x341.83293, direction TLT
+.\hbox(114.211+0.0)x341.83293, direction TLT
+..\glue 28.65274
+..\hbox(0.0+0.0)x0.0, shifted -57.1055, direction TLT
+...\pdfliteral origin{q }
+...\pdfliteral origin{0 G }
+...\pdfliteral origin{0 g }
+...\pdfliteral origin{0.39851 w }
+...\hbox(0.0+0.0)x0.0, direction TLT
+....\pdfliteral origin{q }
+....\pdfliteral origin{0.0 0.0 m }
+....\pdfliteral origin{28.34645 0.0 m }
+....\pdfliteral origin{28.34645 15.65552 15.65552 28.34645 0.0 28.34645 c }
+....\pdfliteral origin{-15.65552 28.34645 -28.34645 15.65552 -28.34645 0.0 c }
+....\pdfliteral origin{-28.34645 -15.65552 -15.65552 -28.34645 0.0 -28.34645 c }
+....\pdfliteral origin{15.65552 -28.34645 28.34645 -15.65552 28.34645 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{0.0 0.0 m }
+....\pdfliteral origin{S }
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{85.03934 0.0 m }
+....\pdfliteral origin{95.00198 0.0 m }
+....\pdfliteral origin{95.00198 5.50229 90.54163 9.96265 85.03934 9.96265 c }
+....\pdfliteral origin{79.53705 9.96265 75.0767 5.50229 75.0767 0.0 c }
+....\pdfliteral origin{75.0767 -5.50229 79.53705 -9.96265 85.03934 -9.96265 c }
+....\pdfliteral origin{90.54163 -9.96265 95.00198 -5.50229 95.00198 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{85.03934 0.0 m }
+....\pdfliteral origin{104.96461 0.0 m }
+....\pdfliteral origin{104.96461 11.00458 96.04391 19.9253 85.03934 19.9253 c }
+....\pdfliteral origin{74.03477 19.9253 65.11406 11.00458 65.11406 0.0 c }
+....\pdfliteral origin{65.11406 -11.00458 74.03477 -19.9253 85.03934 -19.9253 c }
+....\pdfliteral origin{96.04391 -19.9253 104.96461 -11.00458 104.96461 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{85.03934 0.0 m }
+....\pdfliteral origin{S }
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{170.07867 0.0 m }
+....\pdfliteral origin{198.42513 0.0 m }
+....\pdfliteral origin{198.42513 15.65552 185.73418 28.34645 170.07867 28.34645 c }
+....\pdfliteral origin{154.42316 28.34645 141.73222 15.65552 141.73222 0.0 c }
+....\pdfliteral origin{141.73222 -15.65552 154.42316 -28.34645 170.07867 -28.34645 c }
+....\pdfliteral origin{185.73418 -28.34645 198.42513 -15.65552 198.42513 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{170.07867 0.0 m }
+....\pdfliteral origin{255.11801 0.0 m }
+....\pdfliteral origin{311.81091 0.0 m }
+....\pdfliteral origin{311.81091 31.31104 286.42903 56.69292 255.11801 56.69292 c }
+....\pdfliteral origin{223.80699 56.69292 198.42511 31.31104 198.42511 0.0 c }
+....\pdfliteral origin{198.42511 -31.31104 223.80699 -56.69292 255.11801 -56.69292 c }
+....\pdfliteral origin{286.42903 -56.69292 311.81091 -31.31104 311.81091 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{255.11801 0.0 m }
+....\pdfliteral origin{S }
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{Q }
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\pdfliteral origin{n }
+...\pdfliteral origin{Q }
+...\glue 0.0 plus 1.0fil minus 1.0fil
+! OK.
+<argument> \TESTBOX 
+l. ...\ENDBOXTEST
+============================================================
+============================================================
+TEST 2: ellipse, old syntax
+============================================================
+> \box...=
+\hbox(228.02203+0.0)x370.28568, direction TLT
+.\hbox(228.02203+0.0)x370.28568, direction TLT
+..\glue 57.10548
+..\hbox(0.0+0.0)x0.0, shifted -114.01102, direction TLT
+...\pdfliteral origin{q }
+...\pdfliteral origin{0 G }
+...\pdfliteral origin{0 g }
+...\pdfliteral origin{0.39851 w }
+...\hbox(0.0+0.0)x0.0, direction TLT
+....\pdfliteral origin{q }
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{0.0 0.0 m }
+....\pdfliteral origin{56.6929 0.0 m }
+....\pdfliteral origin{56.6929 15.65552 31.31104 28.34645 0.0 28.34645 c }
+....\pdfliteral origin{-31.31104 28.34645 -56.6929 15.65552 -56.6929 0.0 c }
+....\pdfliteral origin{-56.6929 -15.65552 -31.31104 -28.34645 0.0 -28.34645 c }
+....\pdfliteral origin{31.31104 -28.34645 56.6929 -15.65552 56.6929 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{0.0 0.0 m }
+....\pdfliteral origin{S }
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{85.03934 0.0 m }
+....\pdfliteral origin{104.96461 0.0 m }
+....\pdfliteral origin{104.96461 5.50229 96.04391 9.96265 85.03934 9.96265 c }
+....\pdfliteral origin{74.03477 9.96265 65.11406 5.50229 65.11406 0.0 c }
+....\pdfliteral origin{65.11406 -5.50229 74.03477 -9.96265 85.03934 -9.96265 c }
+....\pdfliteral origin{96.04391 -9.96265 104.96461 -5.50229 104.96461 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{85.03934 0.0 m }
+....\pdfliteral origin{109.94594 0.0 m }
+....\pdfliteral origin{109.94594 8.25343 98.79506 14.94397 85.03934 14.94397 c }
+....\pdfliteral origin{71.28363 14.94397 60.13274 8.25343 60.13274 0.0 c }
+....\pdfliteral origin{60.13274 -8.25343 71.28363 -14.94397 85.03934 -14.94397 c }
+....\pdfliteral origin{98.79506 -14.94397 109.94594 -8.25343 109.94594 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{85.03934 0.0 m }
+....\pdfliteral origin{S }
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{170.07867 0.0 m }
+....\pdfliteral origin{198.42513 0.0 m }
+....\pdfliteral origin{198.42513 31.31104 185.73418 56.69292 170.07867 56.69292 c }
+....\pdfliteral origin{154.42316 56.69292 141.73222 31.31104 141.73222 0.0 c }
+....\pdfliteral origin{141.73222 -31.31104 154.42316 -56.69292 170.07867 -56.69292 c }
+....\pdfliteral origin{185.73418 -56.69292 198.42513 -31.31104 198.42513 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{170.07867 0.0 m }
+....\pdfliteral origin{255.11801 0.0 m }
+....\pdfliteral origin{311.81091 0.0 m }
+....\pdfliteral origin{311.81091 62.62207 286.42903 113.38583 255.11801 113.38583 c }
+....\pdfliteral origin{223.80699 113.38583 198.42511 62.62207 198.42511 0.0 c }
+....\pdfliteral origin{198.42511 -62.62207 223.80699 -113.38583 255.11801 -113.38583 c }
+....\pdfliteral origin{286.42903 -113.38583 311.81091 -62.62207 311.81091 0.0 c }
+....\pdfliteral origin{h }
+....\pdfliteral origin{255.11801 0.0 m }
+....\pdfliteral origin{S }
+....\glue(\spaceskip) 0.0
+....\glue(\spaceskip) 0.0
+....\pdfliteral origin{Q }
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\pdfliteral origin{n }
+...\pdfliteral origin{Q }
+...\glue 0.0 plus 1.0fil minus 1.0fil
+! OK.
+<argument> \TESTBOX 
+l. ...\ENDBOXTEST
+============================================================
+============================================================
+TEST 3: errors, cannot mix dimensions and dimensions values in ellipse
+============================================================
+! Package tikz Error: You cannot mix dimensions and dimensionless values in an ellipse.
+See the tikz package documentation for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+l. ...  \draw (0,1) ellipse (1cm and 2)
+                                      ;
+This error message was generated by an \errmessage
+command, so I can't give any explicit help.
+Pretend that you're Hercule Poirot: Examine all clues,
+and deduce the truth by order and method.
+! Package tikz Error: You cannot mix dimensions and dimensionless values in an ellipse.
+See the tikz package documentation for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+l. ...  \draw (1,1) ellipse (1 and 2cm)
+                                      ;
+(That was another \errmessage.)
+============================================================


### PR DESCRIPTION
**Motivation for this change**

- Add test for old `circle` syntax, as I mentioned in #1467
  > As now the manual examples use the new syntax only, maybe we can have a new test for old circle syntax.
- <s>Add a new driver `pgfsys-test.def` dedicated for log-based testing, as mentioned in [matrix chat](https://matrix.to/#/!NuxCISwYQJuyWwNsEI:matrix.org/$DMrUPfrnPIwW7Co3QaxhieVjglo19Vjf9XW9-JuD9eQ?via=matrix.org&via=t2bot.io&via=freiburg.social).\
  Coverage of `\pgfsys@xxx` commands can be increased when needed.</s>\
  Superseded by #1472, see also the [comment](https://github.com/pgf-tikz/pgf/pull/1471#issuecomment-5352465311) below.

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
