### PR TITLE
fix(pgfutil): correct prefix and suffix behavior for \pgfutil@in@

### DIFF
--- a/testfiles-regression/gh-1474.lvt
+++ b/testfiles-regression/gh-1474.lvt
@@ -1,0 +1,48 @@
+% -*- mode: latex -*-
+% vim: ft=tex
+\documentclass{minimal}
+\input{regression-test}
+
+\usepackage{pgfrcs}
+
+\begin{document}
+
+\START
+
+\BEGINTEST{Correct prefix and suffix behavior for pgfutil@in@}
+
+\makeatletter
+
+\pgfutil@in@{a}{xax}% expected true
+\ifpgfutil@in@
+  \TYPE{PASSED}%
+\else
+  \TYPE{FAILED}%
+\fi
+
+\pgfutil@in@{xx}{xax}% expected false
+\unless\ifpgfutil@in@
+  \TYPE{PASSED}%
+\else
+  \TYPE{FAILED}%
+\fi
+
+\pgfutil@in@{xyx}{zxy}% expected false
+\unless\ifpgfutil@in@
+  \TYPE{PASSED}%
+\else
+  \TYPE{FAILED}%
+\fi
+
+\pgfutil@in@{,,}{,x,}% expected false
+\unless\ifpgfutil@in@
+  \TYPE{PASSED}%
+\else
+  \TYPE{FAILED}%
+\fi
+
+\makeatother
+
+\ENDTEST
+
+\END

--- a/testfiles-regression/gh-1474.tlg
+++ b/testfiles-regression/gh-1474.tlg
@@ -1,0 +1,10 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Correct prefix and suffix behavior for pgfutil@in@
+============================================================
+PASSED
+PASSED
+PASSED
+PASSED
+============================================================

--- a/tex/generic/pgf/utilities/pgfutil-common.tex
+++ b/tex/generic/pgf/utilities/pgfutil-common.tex
@@ -209,9 +209,9 @@
 % \else
 % \fi
 \def\pgfutil@in@#1#2{%
- \def\pgfutil@in@@##1#1##2##3\pgfutil@in@@{%
+ \def\pgfutil@in@@##1#1##2\pgfutil@in@@{%
   \ifx\pgfutil@in@##2\pgfutil@in@false\else\pgfutil@in@true\fi}%
- \pgfutil@in@@#2#1\pgfutil@in@\pgfutil@in@@}
+ \pgfutil@in@@#2\pgfutil@nil#1\pgfutil@in@\pgfutil@in@@}
 
 
 % pgfutil@for


### PR DESCRIPTION
<!-- Thank you for contributing to PGF/TikZ!  Now that you are becoming a
    contributor, please also subscribe to the mailing list at
    https://tug.org/mailman/listinfo/pgf-tikz and our chat on the
    Matrix network https://matrix.to/#/#pgf-tikz:matrix.org -->

**Motivation for this change**

<!-- If this fixes an issue, add “Fixes #<issue number>” here. -->

Fixes #1474

**Checklist**

<!-- If your contribution does more than fixing a typo, please add an entry to doc/generic/pgf/CHANGELOG.md -->

Please [signoff your commits][git-s] to explicitly state your agreement to the [Developer Certificate of Origin][DCO]. If that is not possible you may check the boxes below instead:

- [x] Code changes are licensed under [GPLv2][GPL] + [LPPLv1.3c][LPPL]
- [x] Documentation changes are licensed under [FDLv1.2][FDL]

[git-s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
[DCO]: https://developercertificate.org
[GPL]: https://www.gnu.org/licenses/gpl-2.0.html
[LPPL]: https://www.latex-project.org/lppl/lppl-1-3c.txt
[FDL]: https://www.gnu.org/licenses/fdl-1.2.html
